### PR TITLE
Update core/src/main/java/io/undertow/ajp/AjpResponseChannel.java

### DIFF
--- a/core/src/main/java/io/undertow/ajp/AjpResponseChannel.java
+++ b/core/src/main/java/io/undertow/ajp/AjpResponseChannel.java
@@ -238,8 +238,8 @@ final class AjpResponseChannel implements StreamSinkChannel {
             final ByteBuffer buffer = currentDataBuffer.getResource();
             packetHeaderAndDataBuffer = new ByteBuffer[1];
             packetHeaderAndDataBuffer[0] = buffer;
-            buffer.put((byte) 0x12);
-            buffer.put((byte) 0x34);
+            buffer.put((byte) 'A');
+            buffer.put((byte) 'B');
             buffer.put((byte) 0);
             buffer.put((byte) 2);
             buffer.put((byte) 5);


### PR DESCRIPTION
The header on the response end appears to be incorrect. With the header as is, Wireshark is unable to decode the exchange.

I do not expect that this would cause issues in most real-world scenarios at the moment, as the reuse flag is set to false. However, in reuse scenarios, I believe that some httpd daemons (including Apache HTTPD) may reject the end of the exchange, and close the connection.
