### PR TITLE
Adding redirection support to enforce confidentiality in core.

### DIFF
--- a/core/src/main/java/io/undertow/security/handlers/AbstractConfidentialityHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/AbstractConfidentialityHandler.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.security.handlers;
+
+import io.undertow.UndertowLogger;
+import io.undertow.server.HttpCompletionHandler;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.HttpHandlers;
+import io.undertow.util.Headers;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Handler responsible for checking of confidentiality is required for the requested resource and if so rejecting the request
+ * and redirecting to a secure address.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class AbstractConfidentialityHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    protected AbstractConfidentialityHandler(final HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange, HttpCompletionHandler completionHandler) {
+        if (isConfidential(exchange) || (confidentialityRequired(exchange) == false)) {
+            HttpHandlers.executeHandler(next, exchange, completionHandler);
+        } else {
+            try {
+                URI redirectUri = getRedirectURI(exchange);
+
+                exchange.setResponseCode(302);
+                exchange.getResponseHeaders().put(Headers.LOCATION, redirectUri.toString());
+            } catch (URISyntaxException e) {
+                UndertowLogger.REQUEST_LOGGER.exceptionProcessingRequest(e);
+                exchange.setResponseCode(500);
+            }
+            completionHandler.handleComplete();
+        }
+    }
+
+    /**
+     * Use the HttpServerExchange supplied to check if this request is already 'sufficiently' confidential.
+     *
+     * Here we say 'sufficiently' as sub-classes can override this and maybe even go so far as querying the actual SSLSession.
+     *
+     * @param exchange - The {@see HttpServerExchange} for the request being processed.
+     * @return true if the request is 'sufficiently' confidential, false otherwise.
+     */
+    protected boolean isConfidential(final HttpServerExchange exchange) {
+        return exchange.getRequestScheme().equals("https");
+    }
+
+    /**
+     * Use the HttpServerExchange to identify if confidentiality is required.
+     *
+     * This method currently returns true for all requests, sub-classes can override this to provide a custom check.
+     *
+     * @param exchange - The {@see HttpServerExchange} for the request being processed.
+     * @return true if the request requires confidentiality, false otherwise.
+     */
+    protected boolean confidentialityRequired(final HttpServerExchange exchange) {
+        return true;
+    }
+
+    /**
+     * All sub-classes are required to provide an implementation of this method, using the HttpServerExchange for the current
+     * request return the address to use for a redirect should confidentiality be required and the request not be confidential.
+     *
+     * @param exchange - The {@see HttpServerExchange} for the request being processed.
+     * @return The {@see URI} to redirect to.
+     */
+    protected abstract URI getRedirectURI(final HttpServerExchange exchange) throws URISyntaxException;
+
+}

--- a/core/src/main/java/io/undertow/security/handlers/AuthenticationConstraintHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/AuthenticationConstraintHandler.java
@@ -27,7 +27,7 @@ import io.undertow.server.HttpServerExchange;
  * applicable.
  *
  * Sub classes can override isAuthenticationRequired to provide a constraint check, by default this handler will set
- * authentication as always requried, authentication will be optional if this handler is omitted.
+ * authentication as always required, authentication will be optional if this handler is omitted.
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */

--- a/core/src/main/java/io/undertow/security/handlers/SinglePortConfidentialityHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/SinglePortConfidentialityHandler.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.security.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * An extension to {@see AbstractConfidentialityHandler} that uses the Host header from the incomming message and specifies the
+ * confidential address by just switching the port.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SinglePortConfidentialityHandler extends AbstractConfidentialityHandler {
+
+    private final int redirectPort;
+
+    public SinglePortConfidentialityHandler(final HttpHandler next, final int redirectPort) {
+        super(next);
+        this.redirectPort = redirectPort == 443 ? -1 : redirectPort;
+    }
+
+    @Override
+    protected URI getRedirectURI(HttpServerExchange exchange) throws URISyntaxException {
+        String host = exchange.getRequestHeaders().getFirst(Headers.HOST);
+        if (host == null) {
+            host = exchange.getDestinationAddress().getAddress().getHostAddress();
+        } else {
+            if (host.startsWith("[")) {
+                host = host.substring(1, host.indexOf(']'));
+            } else {
+                host = host.substring(0, host.indexOf(':'));
+            }
+        }
+
+        return new URI("https", null, host, redirectPort, exchange.getCanonicalPath(), exchange.getQueryString(), null);
+
+    }
+
+}

--- a/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
@@ -146,6 +146,7 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
         if (host == null) {
             host = exchange.getDestinationAddress().getAddress().getHostAddress();
         }
+        // TODO - String concatenation to construct URLS is extremely error prone - switch to a URI which will better handle this.
         String loc = exchange.getRequestScheme() + "://" + host + location;
         exchange.getResponseHeaders().put(Headers.LOCATION, loc);
     }

--- a/core/src/test/java/io/undertow/test/security/SimpleConfidentialRedirectTestCase.java
+++ b/core/src/test/java/io/undertow/test/security/SimpleConfidentialRedirectTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.test.security;
+
+import io.undertow.security.handlers.SinglePortConfidentialityHandler;
+import io.undertow.server.HttpCompletionHandler;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.test.utils.AjpIgnore;
+import io.undertow.test.utils.DefaultServer;
+import io.undertow.util.HttpString;
+import io.undertow.util.TestHttpClient;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A simple test case to verify a redirect works.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@AjpIgnore
+@RunWith(DefaultServer.class)
+public class SimpleConfidentialRedirectTestCase {
+
+    @Test
+    public void simpleRedirectTestCase() throws IOException, GeneralSecurityException {
+        DefaultServer.startSSLServer();
+
+        HttpHandler current = new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange, final HttpCompletionHandler completionHandler) {
+                exchange.getResponseHeaders().put(HttpString.tryFromString("scheme"), exchange.getRequestScheme());
+                completionHandler.handleComplete();
+            }
+        };
+
+        current = new SinglePortConfidentialityHandler(current, DefaultServer.getHostSSLPort("default"));
+
+        DefaultServer.setRootHandler(current);
+        TestHttpClient client = new TestHttpClient();
+        client.setSSLContext(DefaultServer.getClientSSLContext());
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerAddress());
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(200, result.getStatusLine().getStatusCode());
+            Header[] header = result.getHeaders("scheme");
+            Assert.assertEquals("https", header[0].getValue());
+        } finally {
+            client.getConnectionManager().shutdown();
+            DefaultServer.stopSSLServer();
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request adds redirect support within the core module where confidentiality is required.

The servlet changes are almost complete and will be sent tomorrow - I just need to complete some AS integration to verify the approach there before that part is sent.
