### PR TITLE
Treat trailing '/' as a wildcard match for security constraints.

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/SecurityPathMatches.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/SecurityPathMatches.java
@@ -146,8 +146,8 @@ public class SecurityPathMatches {
                     setupPathSecurityInformation(defaultPathSecurityInformation, securityInformation, webResources);
                 }
                 for (String pattern : webResources.getUrlPatterns()) {
-                    if (pattern.endsWith("/*")) {
-                        String part = pattern.substring(0, pattern.length() - 2);
+                    if (pattern.endsWith("/*") || pattern.endsWith("/")) {
+                        String part = pattern.substring(0, pattern.lastIndexOf('/'));
                         PathSecurityInformation info = prefixPathRoleInformation.get(part);
                         if (info == null) {
                             prefixPathRoleInformation.put(part, info = new PathSecurityInformation());


### PR DESCRIPTION
This beings the behaviour in-line with JBoss Web which treats the security constraints with a trailing '/' as a wildcard as though it had been specified with '/*'.

Although the current matching does appear to match the spec definition this difference in behaviour is very likely to be problematic for web applications migrating to Undertow and if unchecked could lead to portions of web applications being unsecured where they were previously secured.
