### PR TITLE
Use UT instead of UNDERTOW as the project code

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -35,7 +35,7 @@ import java.net.SocketAddress;
  *
  * @author Stuart Douglas
  */
-@MessageLogger(projectCode = "UNDERTOW")
+@MessageLogger(projectCode = "UT")
 public interface UndertowLogger extends BasicLogger {
 
     UndertowLogger ROOT_LOGGER = Logger.getMessageLogger(UndertowLogger.class, UndertowLogger.class.getPackage().getName());

--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -29,7 +29,7 @@ import java.net.SocketAddress;
 /**
  * @author Stuart Douglas
  */
-@MessageBundle(projectCode = "UNDERTOW")
+@MessageBundle(projectCode = "UT")
 public interface UndertowMessages {
 
     UndertowMessages MESSAGES = Messages.getBundle(UndertowMessages.class);

--- a/core/src/main/java/io/undertow/client/UndertowClientMessages.java
+++ b/core/src/main/java/io/undertow/client/UndertowClientMessages.java
@@ -9,7 +9,7 @@ import org.jboss.logging.annotations.MessageBundle;
  *
  * @author Emanuel Muckenhuber
  */
-@MessageBundle(projectCode = "UNDERTOW")
+@MessageBundle(projectCode = "UT")
 public interface UndertowClientMessages {
 
     UndertowClientMessages MESSAGES = Messages.getBundle(UndertowClientMessages.class);

--- a/core/src/main/java/io/undertow/websockets/core/WebSocketLogger.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSocketLogger.java
@@ -30,7 +30,7 @@ import org.jboss.logging.annotations.MessageLogger;
  *
  * @author Stuart Douglas
  */
-@MessageLogger(projectCode = "UNDERTOW")
+@MessageLogger(projectCode = "UT")
 public interface WebSocketLogger extends BasicLogger {
 
     WebSocketLogger ROOT_LOGGER = Logger.getMessageLogger(WebSocketLogger.class, WebSocketLogger.class.getPackage().getName());

--- a/core/src/main/java/io/undertow/websockets/core/WebSocketMessages.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSocketMessages.java
@@ -30,7 +30,7 @@ import org.jboss.logging.annotations.MessageBundle;
  * start at 20000
  * @author Stuart Douglas
  */
-@MessageBundle(projectCode = "UNDERTOW")
+@MessageBundle(projectCode = "UT")
 public interface WebSocketMessages {
 
     WebSocketMessages MESSAGES = Messages.getBundle(WebSocketMessages.class);

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -36,7 +36,7 @@ import org.jboss.logging.annotations.MessageLogger;
  *
  * @author Stuart Douglas
  */
-@MessageLogger(projectCode = "UNDERTOW")
+@MessageLogger(projectCode = "UT")
 public interface UndertowServletLogger extends BasicLogger {
 
     UndertowServletLogger ROOT_LOGGER = Logger.getMessageLogger(UndertowServletLogger.class, UndertowServletLogger.class.getPackage().getName());

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
@@ -39,7 +39,7 @@ import org.jboss.logging.Messages;
  *
  * @author Stuart Douglas
  */
-@MessageBundle(projectCode = "UNDERTOW")
+@MessageBundle(projectCode = "UT")
 public interface UndertowServletMessages {
 
     UndertowServletMessages MESSAGES = Messages.getBundle(UndertowServletMessages.class);

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketLogger.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketLogger.java
@@ -30,7 +30,7 @@ import org.jboss.logging.annotations.MessageLogger;
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-@MessageLogger(projectCode = "UNDERTOW")
+@MessageLogger(projectCode = "UT")
 public interface JsrWebSocketLogger extends BasicLogger {
 
     JsrWebSocketLogger ROOT_LOGGER = Logger.getMessageLogger(JsrWebSocketLogger.class, JsrWebSocketLogger.class.getPackage().getName());

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketMessages.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketMessages.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * start at 3000
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
-@MessageBundle(projectCode = "UNDERTOW")
+@MessageBundle(projectCode = "UT")
 public interface JsrWebSocketMessages {
 
     JsrWebSocketMessages MESSAGES = Messages.getBundle(JsrWebSocketMessages.class);


### PR DESCRIPTION
Long project codes are cumbersome in log files and generally discouraged.  Shorten the code.
