### PR TITLE
context.initialise should be called after all metadata is constructed

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -155,10 +155,10 @@ public class DeploymentManagerImpl implements DeploymentManager {
                 }
             }
 
-            listeners.contextInitialized();
             initializeErrorPages(deployment, deploymentInfo);
             initializeMimeMappings(deployment, deploymentInfo);
             initializeTempDir(servletContext, deploymentInfo);
+            listeners.contextInitialized();
             //run
 
             ServletPathMatches matches = setupServletChains(servletContext, threadSetupAction, listeners);


### PR DESCRIPTION
- this fixes deployment of icefaces showcase
