### PR TITLE
[UNDERTOW-36] Remote the getName() method from AuthenticationMechanism

### DIFF
--- a/core/src/main/java/io/undertow/security/api/AuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/api/AuthenticationMechanism.java
@@ -59,11 +59,6 @@ import io.undertow.server.HttpServerExchange;
 public interface AuthenticationMechanism {
 
     /**
-     * @return The name of the mechanism.
-     */
-    String getName();
-
-    /**
      * Perform authentication of the request. Any potentially blocking work should be performed in the handoff executor provided
      *
      * @param exchange The exchange

--- a/core/src/main/java/io/undertow/security/impl/BasicAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/BasicAuthenticationMechanism.java
@@ -62,10 +62,6 @@ public class BasicAuthenticationMechanism implements AuthenticationMechanism {
         this.name = mechanismName;
     }
 
-    public String getName() {
-        return name;
-    }
-
     /**
      * @see io.undertow.server.HttpHandler#handleRequest(io.undertow.server.HttpServerExchange)
      */
@@ -94,10 +90,10 @@ public class BasicAuthenticationMechanism implements AuthenticationMechanism {
                             final AuthenticationMechanismOutcome result;
                             Account account = idm.verify(userName, credential);
                             if (account != null) {
-                                securityContext.authenticationComplete(account, getName());
+                                securityContext.authenticationComplete(account, name);
                                 result = AuthenticationMechanismOutcome.AUTHENTICATED;
                             } else {
-                                securityContext.authenticationFailed(MESSAGES.authenticationFailed(userName), getName());
+                                securityContext.authenticationFailed(MESSAGES.authenticationFailed(userName), name);
                                 result = AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
                             }
                             return result;

--- a/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
@@ -31,14 +31,6 @@ import io.undertow.server.HttpServerExchange;
  */
 public class CachedAuthenticatedSessionMechanism implements AuthenticationMechanism {
 
-    private static final String NAME = "CACHED";
-
-    @Override
-    public String getName() {
-        // TODO - The API changes probably mean we do not need to be able to return a name anymore.
-        return NAME;
-    }
-
     @Override
     public AuthenticationMechanismOutcome authenticate(HttpServerExchange exchange, SecurityContext securityContext) {
         AuthenticatedSessionManager sessionManager = exchange.getAttachment(AuthenticatedSessionManager.ATTACHMENT_KEY);

--- a/core/src/main/java/io/undertow/security/impl/ClientCertAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/ClientCertAuthenticationMechanism.java
@@ -51,10 +51,6 @@ public class ClientCertAuthenticationMechanism implements AuthenticationMechanis
         this.name = mechanismName;
     }
 
-    public String getName() {
-        return name;
-    }
-
     public AuthenticationMechanismOutcome authenticate(final HttpServerExchange exchange, final SecurityContext securityContext) {
         SSLSession sslSession = exchange.getConnection().getSslSession();
         if (sslSession != null) {
@@ -66,7 +62,7 @@ public class ClientCertAuthenticationMechanism implements AuthenticationMechanis
                     IdentityManager idm = securityContext.getIdentityManager();
                     Account account = idm.verify(credential);
                     if (account != null) {
-                        securityContext.authenticationComplete(account, getName());
+                        securityContext.authenticationComplete(account, name);
                         return AuthenticationMechanismOutcome.AUTHENTICATED;
                     }
                 }

--- a/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
@@ -101,7 +101,7 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
                     securityContext.authenticationComplete(account, name);
                     outcome = AuthenticationMechanismOutcome.AUTHENTICATED;
                 } else {
-                    securityContext.authenticationFailed(MESSAGES.authenticationFailed(userName), getName());
+                    securityContext.authenticationFailed(MESSAGES.authenticationFailed(userName), name);
                 }
             } finally {
                 if (outcome == AuthenticationMechanismOutcome.AUTHENTICATED) {
@@ -166,10 +166,5 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
         // TODO - String concatenation to construct URLS is extremely error prone - switch to a URI which will better handle this.
         String loc = exchange.getRequestScheme() + "://" + host + location;
         exchange.getResponseHeaders().put(Headers.LOCATION, loc);
-    }
-
-    @Override
-    public String getName() {
-        return name;
     }
 }

--- a/core/src/main/java/io/undertow/security/impl/GSSAPIAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/GSSAPIAuthenticationMechanism.java
@@ -64,15 +64,12 @@ public class GSSAPIAuthenticationMechanism implements AuthenticationMechanism {
 
     private static final String NEGOTIATION_PLAIN = NEGOTIATE.toString();
     private static final String NEGOTIATE_PREFIX = NEGOTIATE + " ";
+    private final String name = "SPNEGO";
 
     private final GSSAPIServerSubjectFactory subjectFactory;
 
     public GSSAPIAuthenticationMechanism(final GSSAPIServerSubjectFactory subjectFactory) {
         this.subjectFactory = subjectFactory;
-    }
-
-    public String getName() {
-        return "SPNEGO";
     }
 
     @Override
@@ -86,7 +83,7 @@ public class GSSAPIAuthenticationMechanism implements AuthenticationMechanism {
                 IdentityManager identityManager = securityContext.getIdentityManager();
                 final Account account = identityManager.verify(new GSSContextCredential(negContext.getGssContext()));
                 if (account != null) {
-                    securityContext.authenticationComplete(account, getName());
+                    securityContext.authenticationComplete(account, name);
                     return AuthenticationMechanismOutcome.AUTHENTICATED;
                 } else {
                     return AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
@@ -206,7 +203,7 @@ public class GSSAPIAuthenticationMechanism implements AuthenticationMechanism {
                 IdentityManager identityManager = securityContext.getIdentityManager();
                 final Account account = identityManager.verify(new GSSContextCredential(negContext.getGssContext()));
                 if (account != null) {
-                    securityContext.authenticationComplete(account, getName());
+                    securityContext.authenticationComplete(account, name);
                     return AuthenticationMechanismOutcome.AUTHENTICATED;
                 } else {
                     return AuthenticationMechanismOutcome.NOT_AUTHENTICATED;


### PR DESCRIPTION
Mechanisms now pass in the name using the notification API instead.
