### PR TITLE
[UNDERTOW-38] Update EmptyRoleSemantic handle to handle a middle ground of authenticate only.

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/SecurityInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/SecurityInfo.java
@@ -1,3 +1,20 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.undertow.servlet.api;
 
 import java.util.Arrays;
@@ -5,22 +22,43 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.servlet.annotation.ServletSecurity;
-
 /**
  * @author Stuart Douglas
  */
 public class SecurityInfo<T extends SecurityInfo> implements Cloneable {
 
-    private volatile ServletSecurity.EmptyRoleSemantic emptyRoleSemantic = ServletSecurity.EmptyRoleSemantic.DENY;
+    /**
+     * Equivalent to {@see ServletSecurity.EmptyRoleSemantic} but with an additional mode to require authentication but no role
+     * check.
+     */
+    public enum EmptyRoleSemantic {
+
+        /**
+         * Permit access to the resource without requiring authentication or role membership.
+         */
+        PERMIT,
+
+        /**
+         * Deny access to the resource regardless of the authentication state.
+         */
+        DENY,
+
+        /**
+         * Mandate authentication but authorize access as no roles to check against.
+         */
+        AUTHENTICATE;
+
+    }
+
+    private volatile EmptyRoleSemantic emptyRoleSemantic = EmptyRoleSemantic.DENY;
     private final Set<String> rolesAllowed = new HashSet<String>();
     private volatile TransportGuaranteeType transportGuaranteeType = TransportGuaranteeType.NONE;
 
-    public ServletSecurity.EmptyRoleSemantic getEmptyRoleSemantic() {
+    public EmptyRoleSemantic getEmptyRoleSemantic() {
         return emptyRoleSemantic;
     }
 
-    public T setEmptyRoleSemantic(final ServletSecurity.EmptyRoleSemantic emptyRoleSemantic) {
+    public T setEmptyRoleSemantic(final EmptyRoleSemantic emptyRoleSemantic) {
         this.emptyRoleSemantic = emptyRoleSemantic;
         return (T)this;
     }

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -50,6 +50,7 @@ import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.api.LoginConfig;
 import io.undertow.servlet.api.MimeMapping;
 import io.undertow.servlet.api.SecurityConstraint;
+import io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletContainerInitializerInfo;
 import io.undertow.servlet.api.ServletInfo;
@@ -93,7 +94,6 @@ import javax.servlet.Servlet;
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
-import javax.servlet.annotation.ServletSecurity;
 
 /**
  * The deployment manager. This manager is responsible for controlling the lifecycle of a servlet deployment.
@@ -257,7 +257,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
                     for (HttpMethodSecurityInfo method : securityInfo.getHttpMethodSecurityInfo()) {
                         methods.add(method.getMethod());
-                        if (method.getRolesAllowed().isEmpty() && method.getEmptyRoleSemantic() == ServletSecurity.EmptyRoleSemantic.PERMIT) {
+                        if (method.getRolesAllowed().isEmpty() && method.getEmptyRoleSemantic() == EmptyRoleSemantic.PERMIT) {
                             //this is an implict allow
                             continue;
                         }

--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletAttachments.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletAttachments.java
@@ -1,9 +1,9 @@
 package io.undertow.servlet.handlers;
 
 import java.util.List;
-import java.util.Set;
 
 import io.undertow.servlet.api.TransportGuaranteeType;
+import io.undertow.servlet.handlers.security.SingleConstraintMatch;
 import io.undertow.util.AttachmentKey;
 
 /**
@@ -14,6 +14,6 @@ public class ServletAttachments {
     public static final AttachmentKey<ServletChain> CURRENT_SERVLET = AttachmentKey.create(ServletChain.class);
     public static final AttachmentKey<ServletPathMatch> SERVLET_PATH_MATCH = AttachmentKey.create(ServletPathMatch.class);
 
-    public static final AttachmentKey<List<Set<String>>> REQUIRED_ROLES = AttachmentKey.create(List.class);
+    public static final AttachmentKey<List<SingleConstraintMatch>> REQUIRED_CONSTRAINTS = AttachmentKey.create(List.class);
     public static final AttachmentKey<TransportGuaranteeType> TRANSPORT_GUARANTEE_TYPE = AttachmentKey.create(TransportGuaranteeType.class);
 }

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/SecurityPathMatch.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/SecurityPathMatch.java
@@ -1,28 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.undertow.servlet.handlers.security;
 
-import java.util.List;
-import java.util.Set;
-
 import io.undertow.servlet.api.TransportGuaranteeType;
+
+import java.util.List;
 
 /**
  * @author Stuart Douglas
  */
-public class SecurityPathMatch {
+class SecurityPathMatch {
 
     private final TransportGuaranteeType transportGuaranteeType;
-    private final List<Set<String>> requiredRoles;
+    private final List<SingleConstraintMatch> requiredConstraints;
 
-    public SecurityPathMatch(final TransportGuaranteeType transportGuaranteeType, final List<Set<String>> requiredRoles) {
+    SecurityPathMatch(final TransportGuaranteeType transportGuaranteeType, final List<SingleConstraintMatch> requiredConstraints) {
         this.transportGuaranteeType = transportGuaranteeType;
-        this.requiredRoles = requiredRoles;
+        this.requiredConstraints = requiredConstraints;
     }
 
-    public TransportGuaranteeType getTransportGuaranteeType() {
+    TransportGuaranteeType getTransportGuaranteeType() {
         return transportGuaranteeType;
     }
 
-    public List<Set<String>> getRequiredRoles() {
-        return requiredRoles;
+    List<SingleConstraintMatch> getRequiredConstraints() {
+        return requiredConstraints;
     }
 }

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletAuthenticationConstraintHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletAuthenticationConstraintHandler.java
@@ -1,18 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.undertow.servlet.handlers.security;
 
 import java.util.List;
-import java.util.Set;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.security.handlers.AuthenticationConstraintHandler;
+import io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic;
 import io.undertow.servlet.handlers.ServletAttachments;
 
 /**
- * A simple handler that just sets the auth type to REQUIRED if required roles exists and is non-empty,
- * and does not contain any precluded elements (i.e. empty sets)
+ * A simple handler that just sets the auth type to REQUIRED after iterating each of the {@link SingleConstraintMatch} instances
+ * and identifying if any require authentication.
  *
  * @author Stuart Douglas
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class ServletAuthenticationConstraintHandler extends AuthenticationConstraintHandler {
 
@@ -22,18 +40,29 @@ public class ServletAuthenticationConstraintHandler extends AuthenticationConstr
 
     @Override
     protected boolean isAuthenticationRequired(final HttpServerExchange exchange) {
-        List<Set<String>> roles = exchange.getAttachmentList(ServletAttachments.REQUIRED_ROLES);
-        if (roles.isEmpty()) {
-            return false;
-        }
-        for(Set<String> role : roles) {
-            if(role.isEmpty()) {
-                //this is an empty required role set, so this means this request has been denied
-                //so there is no point authenticating as it will not help matters
-                return false;
+        List<SingleConstraintMatch> constraints = exchange.getAttachmentList(ServletAttachments.REQUIRED_CONSTRAINTS);
+
+        /*
+         * Even once this is set to true the reason we allow the loop to continue is in case an empty role with a semantic of
+         * deny is found as that will override everything.
+         */
+        boolean authenticationRequired = false;
+        for (SingleConstraintMatch constraint : constraints) {
+            if (constraint.getRequiredRoles().isEmpty()) {
+                if (constraint.getEmptyRoleSemantic() == EmptyRoleSemantic.DENY) {
+                    /*
+                     * For this case we return false as we know it can never be satisfied.
+                     */
+                    return false;
+                } else if (constraint.getEmptyRoleSemantic() == EmptyRoleSemantic.AUTHENTICATE) {
+                    authenticationRequired = true;
+                }
+            } else {
+                authenticationRequired = true;
             }
         }
-        return true;
+
+        return authenticationRequired;
     }
 
 }

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletSecurityConstraintHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletSecurityConstraintHandler.java
@@ -1,14 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.undertow.servlet.handlers.security;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpHandlers;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.api.TransportGuaranteeType;
+import io.undertow.servlet.handlers.ServletAttachments;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-
-import io.undertow.server.HttpHandler;
-import io.undertow.server.HttpServerExchange;
-import io.undertow.server.HttpHandlers;
-import io.undertow.servlet.api.TransportGuaranteeType;
-import io.undertow.servlet.handlers.ServletAttachments;
 
 /**
  * @author Stuart Douglas
@@ -27,11 +43,11 @@ public class ServletSecurityConstraintHandler implements HttpHandler {
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
         final String path = exchange.getRelativePath();
         SecurityPathMatch securityMatch = securityPathMatches.getSecurityInfo(path, exchange.getRequestMethod().toString());
-        List<Set<String>> list = exchange.getAttachment(ServletAttachments.REQUIRED_ROLES);
+        List<SingleConstraintMatch> list = exchange.getAttachment(ServletAttachments.REQUIRED_CONSTRAINTS);
         if(list == null) {
-            exchange.putAttachment(ServletAttachments.REQUIRED_ROLES, list = new ArrayList<Set<String>>());
+            exchange.putAttachment(ServletAttachments.REQUIRED_CONSTRAINTS, list = new ArrayList<SingleConstraintMatch>());
         }
-        list.addAll(securityMatch.getRequiredRoles());
+        list.addAll(securityMatch.getRequiredConstraints());
         TransportGuaranteeType type = exchange.getAttachment(ServletAttachments.TRANSPORT_GUARANTEE_TYPE);
         if(type == null || type.ordinal() < securityMatch.getTransportGuaranteeType().ordinal()) {
             exchange.putAttachment(ServletAttachments.TRANSPORT_GUARANTEE_TYPE, securityMatch.getTransportGuaranteeType());

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletSecurityRoleHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletSecurityRoleHandler.java
@@ -1,9 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.undertow.servlet.handlers.security;
 
 import io.undertow.security.api.SecurityContext;
 import io.undertow.security.idm.Account;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.api.SecurityInfo;
 import io.undertow.servlet.handlers.ServletAttachments;
 import io.undertow.servlet.spec.HttpServletRequestImpl;
 import io.undertow.servlet.spec.HttpServletResponseImpl;
@@ -30,21 +48,30 @@ public class ServletSecurityRoleHandler implements HttpHandler {
 
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
-        List<Set<String>> roles = exchange.getAttachmentList(ServletAttachments.REQUIRED_ROLES);
+        List<SingleConstraintMatch> constraints = exchange.getAttachmentList(ServletAttachments.REQUIRED_CONSTRAINTS);
         SecurityContext sc = exchange.getAttachment(SecurityContext.ATTACHMENT_KEY);
         HttpServletRequest request = HttpServletRequestImpl.getRequestImpl(exchange.getAttachment(HttpServletRequestImpl.ATTACHMENT_KEY));
         if (request.getDispatcherType() != DispatcherType.REQUEST) {
             next.handleRequest(exchange);
-        } else if (roles == null || roles.isEmpty()) {
+        } else if (constraints == null || constraints.isEmpty()) {
             next.handleRequest(exchange);
         } else {
-            for (final Set<String> roleSet : roles) {
+            Account account = sc.getAuthenticatedAccount();
+            for (final SingleConstraintMatch constraint : constraints) {
                 boolean found = false;
-                Account account = sc.getAuthenticatedAccount();
-                for (String role : roleSet) {
-                    if (account.isUserInRole(role)) {
-                        found = true;
-                        break;
+
+                Set<String> roleSet = constraint.getRequiredRoles();
+                if (roleSet.isEmpty() && constraint.getEmptyRoleSemantic() != SecurityInfo.EmptyRoleSemantic.DENY) {
+                    /*
+                     * The EmptyRoleSemantic was either PERMIT or AUTHENTICATE, either way a roles check is not needed.
+                     */
+                    found = true;
+                } else {
+                    for (String role : roleSet) {
+                        if (account.isUserInRole(role)) {
+                            found = true;
+                            break;
+                        }
                     }
                 }
                 if (!found) {

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/SingleConstraintMatch.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/SingleConstraintMatch.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.servlet.handlers.security;
+
+import io.undertow.servlet.api.SecurityInfo;
+
+import java.util.Set;
+
+/**
+ * Representation of a single security constrain matched for a single request.
+ *
+ * When performing any authentication/authorization check every constraint MUST be satisfied for the request to be allowed to
+ * proceed.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class SingleConstraintMatch {
+
+    private final SecurityInfo.EmptyRoleSemantic emptyRoleSemantic;
+    private final Set<String> requiredRoles;
+
+    SingleConstraintMatch(SecurityInfo.EmptyRoleSemantic emptyRoleSemantic, Set<String> requiredRoles) {
+        this.emptyRoleSemantic = emptyRoleSemantic;
+        this.requiredRoles = requiredRoles;
+    }
+
+    SecurityInfo.EmptyRoleSemantic getEmptyRoleSemantic() {
+        return emptyRoleSemantic;
+    }
+
+    Set<String> getRequiredRoles() {
+        return requiredRoles;
+    }
+
+}

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletRegistrationImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletRegistrationImpl.java
@@ -27,11 +27,14 @@ import javax.servlet.HttpMethodConstraintElement;
 import javax.servlet.MultipartConfigElement;
 import javax.servlet.ServletRegistration;
 import javax.servlet.ServletSecurityElement;
+import javax.servlet.annotation.ServletSecurity;
 
 import io.undertow.UndertowMessages;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.HttpMethodSecurityInfo;
 import io.undertow.servlet.api.SecurityConstraint;
+import io.undertow.servlet.api.SecurityInfo;
+import io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic;
 import io.undertow.servlet.api.ServletInfo;
 import io.undertow.servlet.api.ServletSecurityInfo;
 import io.undertow.servlet.api.TransportGuaranteeType;
@@ -79,17 +82,28 @@ public class ServletRegistrationImpl implements ServletRegistration, ServletRegi
         ServletSecurityInfo info = new ServletSecurityInfo();
         servletInfo.setServletSecurityInfo(info);
         info.setTransportGuaranteeType(constraint.getTransportGuarantee() == CONFIDENTIAL ? TransportGuaranteeType.CONFIDENTIAL : TransportGuaranteeType.NONE)
-                .setEmptyRoleSemantic(constraint.getEmptyRoleSemantic())
+                .setEmptyRoleSemantic(emptyRoleSemantic(constraint.getEmptyRoleSemantic()))
                 .addRolesAllowed(constraint.getRolesAllowed());
 
         for (final HttpMethodConstraintElement methodConstraint : constraint.getHttpMethodConstraints()) {
             info.addHttpMethodSecurityInfo(new HttpMethodSecurityInfo()
                     .setTransportGuaranteeType(methodConstraint.getTransportGuarantee() == CONFIDENTIAL ? TransportGuaranteeType.CONFIDENTIAL : TransportGuaranteeType.NONE)
                     .setMethod(methodConstraint.getMethodName())
-                    .setEmptyRoleSemantic(methodConstraint.getEmptyRoleSemantic())
+                    .setEmptyRoleSemantic(emptyRoleSemantic(methodConstraint.getEmptyRoleSemantic()))
                     .addRolesAllowed(methodConstraint.getRolesAllowed()));
         }
         return ret;
+    }
+
+    private SecurityInfo.EmptyRoleSemantic emptyRoleSemantic(final ServletSecurity.EmptyRoleSemantic emptyRoleSemantic) {
+        switch (emptyRoleSemantic) {
+            case PERMIT:
+                return EmptyRoleSemantic.PERMIT;
+            case DENY:
+                return EmptyRoleSemantic.DENY;
+            default:
+                return null;
+        }
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/security/constraint/EmptyRoleSemanticTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/security/constraint/EmptyRoleSemanticTestCase.java
@@ -1,0 +1,168 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.servlet.test.security.constraint;
+
+import static io.undertow.util.Headers.AUTHORIZATION;
+import static io.undertow.util.Headers.BASIC;
+import static io.undertow.util.Headers.WWW_AUTHENTICATE;
+import static org.junit.Assert.assertEquals;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.LoginConfig;
+import io.undertow.servlet.api.SecurityConstraint;
+import io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.api.WebResourceCollection;
+import io.undertow.servlet.test.SimpleServletTestCase;
+import io.undertow.servlet.test.util.MessageServlet;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.servlet.test.util.TestResourceLoader;
+import io.undertow.test.utils.DefaultServer;
+import io.undertow.test.utils.HttpClientUtils;
+import io.undertow.util.FlexBase64;
+import io.undertow.util.TestHttpClient;
+
+import javax.servlet.ServletException;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A test case for the three supported {@link EmptyRoleSemantic} values.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+@RunWith(DefaultServer.class)
+public class EmptyRoleSemanticTestCase {
+
+    public static final String HELLO_WORLD = "Hello World";
+
+    @BeforeClass
+    public static void setup() throws ServletException {
+
+        final PathHandler root = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        ServletInfo s = new ServletInfo("servlet", AuthenticationMessageServlet.class)
+                .addInitParam(MessageServlet.MESSAGE, HELLO_WORLD)
+                .addMapping("/permit")
+                .addMapping("/deny")
+                .addMapping("/authenticate");
+
+        ServletIdentityManager identityManager = new ServletIdentityManager();
+        identityManager.addUser("user1", "password1"); // Just one role less user.
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(SimpleServletTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName("servletContext.war")
+                .setResourceLoader(TestResourceLoader.NOOP_RESOURCE_LOADER)
+                .setIdentityManager(identityManager)
+                .setLoginConfig(new LoginConfig("BASIC", "Test Realm"))
+                .addServlet(s);
+
+        builder.addSecurityConstraint(new SecurityConstraint()
+                .addWebResourceCollection(new WebResourceCollection().addUrlPattern("/permit"))
+                .setEmptyRoleSemantic(EmptyRoleSemantic.PERMIT));
+
+        builder.addSecurityConstraint(new SecurityConstraint()
+                .addWebResourceCollection(new WebResourceCollection().addUrlPattern("/deny"))
+                .setEmptyRoleSemantic(EmptyRoleSemantic.DENY));
+
+        builder.addSecurityConstraint(new SecurityConstraint()
+                .addWebResourceCollection(new WebResourceCollection().addUrlPattern("/authenticate"))
+                .setEmptyRoleSemantic(EmptyRoleSemantic.AUTHENTICATE));
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        root.addPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(root);
+    }
+
+    @Test
+    public void testPermit() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        final String url = DefaultServer.getDefaultServerURL() + "/servletContext/permit";
+        try {
+            HttpGet initialGet = new HttpGet(url);
+            initialGet.addHeader("ExpectedMechanism", "None");
+            initialGet.addHeader("ExpectedUser", "None");
+            HttpResponse result = client.execute(initialGet);
+            assertEquals(200, result.getStatusLine().getStatusCode());
+
+            final String response = HttpClientUtils.readResponse(result);
+            Assert.assertEquals(HELLO_WORLD, response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testDeny() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        final String url = DefaultServer.getDefaultServerURL() + "/servletContext/deny";
+        try {
+            HttpGet initialGet = new HttpGet(url);
+            initialGet.addHeader("ExpectedMechanism", "None");
+            initialGet.addHeader("ExpectedUser", "None");
+            HttpResponse result = client.execute(initialGet);
+            assertEquals(403, result.getStatusLine().getStatusCode());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testAuthenticate() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        final String url = DefaultServer.getDefaultServerURL() + "/servletContext/authenticate";
+        try {
+            HttpGet get = new HttpGet(url);
+            HttpResponse result = client.execute(get);
+            assertEquals(401, result.getStatusLine().getStatusCode());
+            Header[] values = result.getHeaders(WWW_AUTHENTICATE.toString());
+            assertEquals(1, values.length);
+            assertEquals(BASIC + " realm=\"Test Realm\"", values[0].getValue());
+            HttpClientUtils.readResponse(result);
+
+            get = new HttpGet(url);
+            get.addHeader("ExpectedMechanism", "BASIC");
+            get.addHeader("ExpectedUser", "user1");
+            get.addHeader(AUTHORIZATION.toString(), BASIC + " " + FlexBase64.encodeString("user1:password1".getBytes(), false));
+            get.addHeader("ExpectedMechanism", "BASIC");
+            get.addHeader("ExpectedUser", "user1");
+            result = client.execute(get);
+            assertEquals(200, result.getStatusLine().getStatusCode());
+
+            final String response = HttpClientUtils.readResponse(result);
+            Assert.assertEquals(HELLO_WORLD, response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/security/constraint/ServletIdentityManager.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/security/constraint/ServletIdentityManager.java
@@ -48,7 +48,7 @@ public class ServletIdentityManager implements IdentityManager {
 
     @Override
     public Account verify(Account account) {
-        // Just re-use the exising account.
+        // Just re-use the existing account.
         return account;
     }
 

--- a/servlet/src/test/java/io/undertow/servlet/test/security/ssl/ConfidentialityConstraintUrlMappingTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/security/ssl/ConfidentialityConstraintUrlMappingTestCase.java
@@ -22,6 +22,7 @@ import io.undertow.server.handlers.PathHandler;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.SecurityConstraint;
+import io.undertow.servlet.api.SecurityInfo.EmptyRoleSemantic;
 import io.undertow.servlet.api.ServletContainer;
 import io.undertow.servlet.api.ServletInfo;
 import io.undertow.servlet.api.TransportGuaranteeType;
@@ -37,8 +38,6 @@ import io.undertow.test.utils.HttpClientUtils;
 import io.undertow.util.TestHttpClient;
 
 import java.io.IOException;
-
-import javax.servlet.annotation.ServletSecurity.EmptyRoleSemantic;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;


### PR DESCRIPTION
This change introduces a new EmptyRoleSemantic enumeration that includes a middle ground of still requiring authentication where no roles are defined.

This is needed for integration scenarios such as JBossWS where it is desirable to mandate authentication but where authorization checking will be handled in a different container, using pure servlet spec configuration authentication and authorization are enabled as a pair.

JBoss AS will also require the following change when this pull request is merged before AS can be updated to an Undertow version containing this change: -

https://github.com/darranl/jboss-as/commit/2da13e650cb53d6e55b0e892c569102c8b89662b
