### PR TITLE
Adds port to the host header value in the HTTP client request.

### DIFF
--- a/core/src/main/java/io/undertow/client/HttpClientRequestImpl.java
+++ b/core/src/main/java/io/undertow/client/HttpClientRequestImpl.java
@@ -294,10 +294,15 @@ class HttpClientRequestImpl extends HttpClientRequest {
             String host = null;
             if(target.isAbsolute()) {
                 host = target.getHost();
+                int port = target.getPort();
+                if(port != -1) {
+                    host = host + ':' + port;
+                }
             }
             if(host == null) {
                 try {
-                    host = connection.getPeerAddress(InetSocketAddress.class).getHostName();
+                    InetSocketAddress address = connection.getPeerAddress(InetSocketAddress.class);
+                    host = address.getHostName() + ':' + address.getPort();
                 } catch (Exception ignore)  {
                     //
                 }


### PR DESCRIPTION
Adds port to the host header value. Due to http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23 the port should be added if it differs from the default port. To simplify the code we just always add the port.
