### PR TITLE
UNDERTOW-80

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/SessionListenerBridge.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/SessionListenerBridge.java
@@ -42,10 +42,10 @@ public class SessionListenerBridge implements SessionListener {
             if (reason == SessionDestroyedReason.TIMEOUT) {
                 handle = threadSetup.setup(exchange);
             }
+            applicationListeners.sessionDestroyed(httpSession);
             for(String attribute : session.getAttributeNames()) {
                 session.removeAttribute(attribute);
             }
-            applicationListeners.sessionDestroyed(httpSession);
         } finally {
             if (handle != null) {
                 handle.tearDown();

--- a/servlet/src/test/java/io/undertow/servlet/test/listener/session/ServletSessionInvalidateWithListenerTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/listener/session/ServletSessionInvalidateWithListenerTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.servlet.test.listener.session;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ListenerInfo;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.test.SimpleServletTestCase;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @see UNDERTOW-80
+ *
+ * @author Jozef Hartinger
+ */
+@RunWith(DefaultServer.class)
+public class ServletSessionInvalidateWithListenerTestCase {
+
+    @BeforeClass
+    public static void setup() throws ServletException {
+        final PathHandler path = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(SimpleServletTestCase.class.getClassLoader())
+                .setContextPath("/listener")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName("listener.war")
+                .addListener(new ListenerInfo(SimpleSessionListener.class))
+                .addServlet(new ServletInfo("servlet", SessionServlet.class)
+                    .addMapping("/test"));
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        path.addPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(path);
+    }
+
+
+    @Test
+    public void testSimpleSessionUsage() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/listener/test");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(200, result.getStatusLine().getStatusCode());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/listener/session/SessionServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/listener/session/SessionServlet.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.servlet.test.listener.session;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+public class SessionServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession(true);
+        session.setAttribute("FOO", "BAR");
+        session.invalidate();
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/listener/session/SimpleSessionListener.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/listener/session/SimpleSessionListener.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.servlet.test.listener.session;
+
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+import org.junit.Assert;
+
+
+public class SimpleSessionListener implements HttpSessionListener {
+
+    @Override
+    public void sessionCreated(HttpSessionEvent arg0) {
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent event) {
+        Assert.assertEquals("BAR", event.getSession().getAttribute("FOO"));
+    }
+}


### PR DESCRIPTION
 Do not remove session attributes before HttpSessionListener.sessionDestroyed() is invoked on all listeners
