### PR TITLE
WFLY-1888 also load ServletExtension-s from parent class loader so that ...

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -204,8 +204,24 @@ public class DeploymentManagerImpl implements DeploymentManager {
     }
 
     private void handleExtensions(final DeploymentInfo deploymentInfo, final ServletContextImpl servletContext) {
+        Set<ServletExtension> loadedExtensions = new HashSet<ServletExtension>();
+
         for (ServletExtension extension : ServiceLoader.load(ServletExtension.class, deploymentInfo.getClassLoader())) {
+            loadedExtensions.add(extension);
             extension.handleDeployment(deploymentInfo, servletContext);
+        }
+
+        if (!Thread.currentThread().getContextClassLoader().equals(deploymentInfo.getClassLoader())) {
+            for (ServletExtension extension : ServiceLoader.load(ServletExtension.class)) {
+
+                // Note: If the CLs are different, but can the see the same extensions and extension might get loaded
+                // and thus instantiated twice, but the handleDeployment() is executed only once.
+
+                if (!loadedExtensions.contains(extension)) {
+                    loadedExtensions.add(extension);
+                    extension.handleDeployment(deploymentInfo, servletContext);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
...other modules can export services and add their own Handler-s

Say we want to add RequestCountHttpHandler via RequestCountHandlerExtension to support mod_cluster metrics on Undertow. Then an optional dependency can be added, e.g. `<module name="org.wildfly.mod_cluster.undertow" services="export" optional="true"/>`

WDYT? Is this a reasonable approach, or should mod_cluster be handled completely differently? Actually, this might not be enough since I need to add channel conduit to track sent/received bytes too which I am not sure yet if can be done via ServletExtension.
