### PR TITLE
Fixes the initialization of state and remaining fields in case size is zero in the AjpServerRequestConduit constructor.

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerRequestConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerRequestConduit.java
@@ -96,7 +96,7 @@ public class AjpServerRequestConduit extends AbstractStreamSourceConduit<StreamS
         if (size == null) {
             state = STATE_SEND_REQUIRED;
             remaining = -1;
-        } else if (size.equals(0)) {
+        } else if (size.longValue() == 0L) {
             state = STATE_FINISHED;
             remaining = 0;
         } else {


### PR DESCRIPTION
Fixes the initialization of state and remaining fields in case size is zero (Long.equals(Integer) results always in false; replaced by simpler and faster code).
