### PR TITLE
Fixes small bug in the AllowedContentEncodings#isIdentity()-method.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/encoding/AllowedContentEncodings.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/AllowedContentEncodings.java
@@ -50,7 +50,7 @@ public class AllowedContentEncodings implements ConduitWrapper<StreamSinkConduit
     }
 
     public boolean isIdentity() {
-        return getCurrentContentEncoding().equals(Headers.IDENTITY);
+        return getCurrentContentEncoding().equals(Headers.IDENTITY.toString());
     }
 
     /**


### PR DESCRIPTION
Fixes small bug in #isIdentity()-method (String.equals(HttpString) returns always false; replaced by String.equals(HttpString.toString()))
