### PR TITLE
Fixes usages of String#toLowerCase() without a Locale.

### DIFF
--- a/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
@@ -64,6 +64,7 @@ import java.net.SocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.Locale;
 
 import static io.undertow.client.UndertowClientMessages.MESSAGES;
 import static io.undertow.util.Headers.CLOSE;
@@ -260,7 +261,7 @@ public class HttpClientConnection extends AbstractAttachable implements Closeabl
                 return;
             }
         } else if (transferEncodingString != null) {
-            if (!transferEncodingString.toLowerCase().contains(Headers.CHUNKED.toString())) {
+            if (!transferEncodingString.toLowerCase(Locale.ENGLISH).contains(Headers.CHUNKED.toString())) {
                 handleError(UndertowClientMessages.MESSAGES.unknownTransferEncoding(transferEncodingString));
                 return;
             }

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpContinue.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpContinue.java
@@ -46,7 +46,7 @@ public class HttpContinue {
         List<String> expect = exchange.getRequestHeaders().get(Headers.EXPECT);
         if (expect != null) {
             for (String header : expect) {
-                if (header.toLowerCase().equals(CONTINUE)) {
+                if (header.equalsIgnoreCase(CONTINUE)) {
                     return true;
                 }
             }

--- a/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
+++ b/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
@@ -3,6 +3,7 @@ package io.undertow.server.session;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Deque;
+import java.util.Locale;
 
 import io.undertow.server.HttpServerExchange;
 
@@ -20,7 +21,7 @@ public class PathParameterSessionConfig implements SessionConfig {
     }
 
     public PathParameterSessionConfig() {
-        this(SessionCookieConfig.DEFAULT_SESSION_ID.toLowerCase());
+        this(SessionCookieConfig.DEFAULT_SESSION_ID.toLowerCase(Locale.ENGLISH));
     }
 
     @Override

--- a/core/src/main/java/io/undertow/util/Cookies.java
+++ b/core/src/main/java/io/undertow/util/Cookies.java
@@ -100,23 +100,23 @@ public class Cookies {
     }
 
     private static void handleValue(CookieImpl cookie, String key, String value) {
-        if (key.toLowerCase().equals("path")) {
+        if (key.equalsIgnoreCase("path")) {
             cookie.setPath(value);
-        } else if (key.toLowerCase().equals("domain")) {
+        } else if (key.equalsIgnoreCase("domain")) {
             cookie.setDomain(value);
-        } else if (key.toLowerCase().equals("max-age")) {
+        } else if (key.equalsIgnoreCase("max-age")) {
             cookie.setMaxAge(Integer.parseInt(value));
-        } else if (key.toLowerCase().equals("expires")) {
+        } else if (key.equalsIgnoreCase("expires")) {
             cookie.setExpires(DateUtils.parseDate(value));
-        } else if (key.toLowerCase().equals("discard")) {
+        } else if (key.equalsIgnoreCase("discard")) {
             cookie.setDiscard(true);
-        } else if (key.toLowerCase().equals("secure")) {
+        } else if (key.equalsIgnoreCase("secure")) {
             cookie.setSecure(true);
-        } else if (key.toLowerCase().equals("httpOnly")) {
+        } else if (key.equalsIgnoreCase("httpOnly")) {
             cookie.setHttpOnly(true);
-        } else if (key.toLowerCase().equals("version")) {
+        } else if (key.equalsIgnoreCase("version")) {
             cookie.setVersion(Integer.parseInt(value));
-        } else if (key.toLowerCase().equals("comment")) {
+        } else if (key.equalsIgnoreCase("comment")) {
             cookie.setComment(value);
         }
         //otherwise ignore this key-value pair

--- a/core/src/main/java/io/undertow/util/MultipartParser.java
+++ b/core/src/main/java/io/undertow/util/MultipartParser.java
@@ -190,9 +190,9 @@ public class MultipartParser {
                     String encoding = headers.getFirst(Headers.CONTENT_TRANSFER_ENCODING);
                     if (encoding == null) {
                         encodingHandler = new IdentityEncoding();
-                    } else if (encoding.toLowerCase().equals("base64")) {
+                    } else if (encoding.equalsIgnoreCase("base64")) {
                         encodingHandler = new Base64Encoding(bufferPool);
-                    } else if (encoding.toLowerCase().equals("quoted-printable")) {
+                    } else if (encoding.equalsIgnoreCase("quoted-printable")) {
                         encodingHandler = new QuotedPrintableEncoding(bufferPool);
                     } else {
                         encodingHandler = new IdentityEncoding();

--- a/core/src/main/java/io/undertow/websockets/client/WebSocket13ClientHandshake.java
+++ b/core/src/main/java/io/undertow/websockets/client/WebSocket13ClientHandshake.java
@@ -19,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -68,15 +69,15 @@ public class WebSocket13ClientHandshake extends WebSocketClientHandshake {
         return new HandshakeChecker() {
             @Override
             public void checkHandshake(Map<String, String> headers) throws IOException {
-                String upgrade = headers.get(Headers.UPGRADE_STRING.toLowerCase());
-                if (upgrade == null || !upgrade.toLowerCase().trim().equals("websocket")) {
+                String upgrade = headers.get(Headers.UPGRADE_STRING.toLowerCase(Locale.ENGLISH));
+                if (upgrade == null || !upgrade.trim().equalsIgnoreCase("websocket")) {
                     throw WebSocketMessages.MESSAGES.noWebSocketUpgradeHeader();
                 }
-                String connHeader = headers.get(Headers.CONNECTION_STRING.toLowerCase());
-                if (connHeader == null || !connHeader.toLowerCase().trim().equals("upgrade")) {
+                String connHeader = headers.get(Headers.CONNECTION_STRING.toLowerCase(Locale.ENGLISH));
+                if (connHeader == null || !connHeader.trim().equalsIgnoreCase("upgrade")) {
                     throw WebSocketMessages.MESSAGES.noWebSocketConnectionHeader();
                 }
-                String acceptKey = headers.get(Headers.SEC_WEB_SOCKET_ACCEPT_STRING.toLowerCase());
+                String acceptKey = headers.get(Headers.SEC_WEB_SOCKET_ACCEPT_STRING.toLowerCase(Locale.ENGLISH));
                 final String dKey = solve(sentKey);
                 if (!dKey.equals(acceptKey)) {
                     throw WebSocketMessages.MESSAGES.webSocketAcceptKeyMismatch(dKey, acceptKey);

--- a/core/src/test/java/io/undertow/util/HeaderOrderTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderOrderTestCase.java
@@ -39,7 +39,7 @@ public class HeaderOrderTestCase {
         Collections.sort(headers, new Comparator<HttpString>() {
             @Override
             public int compare(final HttpString o1, final HttpString o2) {
-                return o1.toString().toLowerCase().compareTo(o2.toString().toLowerCase());
+                return o1.toString().compareToIgnoreCase(o2.toString());
             }
         });
         int val = 1;

--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletInitialHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletInitialHandler.java
@@ -140,8 +140,8 @@ public class ServletInitialHandler implements HttpHandler, ServletDispatcher {
     }
 
     private boolean isForbiddenPath(String path) {
-        final String lowerPath = path.toLowerCase();
-        return lowerPath.equals("/meta-inf/") || lowerPath.startsWith("/web-inf/");
+        return path.equalsIgnoreCase("/meta-inf/")
+            || path.regionMatches(true, 0, "/web-inf/", 0, "/web-inf/".length());
     }
 
     public void dispatchToPath(final HttpServerExchange exchange, final ServletPathMatch pathInfo, final DispatcherType dispatcherType) throws Exception {

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
@@ -720,7 +720,7 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
         StringBuilder sb = new StringBuilder(path);
         if (sb.length() > 0) { // jsessionid can't be first.
             sb.append(';');
-            sb.append(servletContext.getSessionCookieConfig().getName().toLowerCase());
+            sb.append(servletContext.getSessionCookieConfig().getName().toLowerCase(Locale.ENGLISH));
             sb.append('=');
             sb.append(sessionId);
         }

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -34,6 +34,7 @@ import java.util.Enumeration;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -145,11 +146,11 @@ public class ServletContextImpl implements ServletContext {
             } else {
                 if (sessionTrackingModes.contains(SessionTrackingMode.COOKIE) || sessionTrackingModes.contains(SessionTrackingMode.URL)) {
                     sessionConfig = sessionCookieConfig;
-                    sessionCookieConfig.setFallback(new PathParameterSessionConfig(sessionCookieConfig.getName().toLowerCase()));
+                    sessionCookieConfig.setFallback(new PathParameterSessionConfig(sessionCookieConfig.getName().toLowerCase(Locale.ENGLISH)));
                 } else if (sessionTrackingModes.contains(SessionTrackingMode.COOKIE)) {
                     sessionConfig = sessionCookieConfig;
                 } else if (sessionTrackingModes.contains(SessionTrackingMode.URL)) {
-                    sessionConfig = new PathParameterSessionConfig(sessionCookieConfig.getName().toLowerCase());
+                    sessionConfig = new PathParameterSessionConfig(sessionCookieConfig.getName().toLowerCase(Locale.ENGLISH));
                 }
             }
         }


### PR DESCRIPTION
Replaces #toLowerCase() with #toLowerCase(Locale), #equalsIgnoreCase(String), #compareToIgnoreCase(String), or #regionMatches(boolean, int, String, int, int). #toLowerCase() without a Locale may lead to unexpected results in JVM with Turkish locale (s. JavaDocs of String#toLowerCase()). Additionally it improves performance as #equalsIgnoreCase(), #compareToIgnoreCase() and #regionMatches() are faster in comparison to equivalent code which uses combination of #toLowerCase() and #equals(), #compareTo() or #startWith().
