### PR TITLE
Improves performance of HttpString#appendTo(ByteBuffer)

### DIFF
--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -201,9 +201,7 @@ public final class HttpString implements Comparable<HttpString>, Serializable {
      * @param buffer the buffer to append to
      */
     public void appendTo(ByteBuffer buffer) {
-        for(int i = 0; i < bytes.length; ++i) {
-            buffer.put(bytes[i]);
-        }
+        buffer.put(bytes);
     }
 
     /**


### PR DESCRIPTION
Improves performance of HttpString#appendTo(ByteBuffer) by using the bulk put method of ByteBuffer. Subclasses of ByteBuffer provide optimized implementations of the bulk put method which does not use a loop over the byte array.
