### PR TITLE
Minor performance improvement to FlexBase64.EncoderInputStream.copyOverflow()

### DIFF
--- a/core/src/main/java/io/undertow/util/FlexBase64.java
+++ b/core/src/main/java/io/undertow/util/FlexBase64.java
@@ -1491,9 +1491,7 @@ public class FlexBase64 {
         private int copyOverflow(byte[] b, int off, int len, byte[] overflow, int pos, int limit) {
             limit -= pos;
             len = limit <= len ? limit : len;
-            for (int i = 0; i < len; i++) {
-                b[off + i] = overflow[pos + i];
-            }
+            System.arraycopy(overflow, pos, b, off, len);
             this.overflowPos = pos + len;
             return len;
         }


### PR DESCRIPTION
Replaces manual array copy with System.arraycopy().
