### PR TITLE
Minor performance improvement to Connectors.flattenCookies(HttpServerExchange)

### DIFF
--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -31,9 +31,7 @@ public class Connectors {
         Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
         if (cookies != null) {
             for (Map.Entry<String, Cookie> entry : cookies.entrySet()) {
-                StringBuilder builder = new StringBuilder();
-                builder.append(getCookieString(entry.getValue()));
-                exchange.getResponseHeaders().add(Headers.SET_COOKIE, builder.toString());
+                exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(entry.getValue()));
             }
         }
     }


### PR DESCRIPTION
Removed useless creation of StringBuilder.
