### PR TITLE
Properly log exception

### DIFF
--- a/core/src/main/java/io/undertow/conduits/PipelingBufferingStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/PipelingBufferingStreamSinkConduit.java
@@ -331,7 +331,8 @@ public class PipelingBufferingStreamSinkConduit extends AbstractStreamSinkCondui
                     nextListener.proceed();
                 }
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+                IoUtils.safeClose(connection.getChannel());
             }
         }
     }


### PR DESCRIPTION
This (unlikely) runtime exception causes weird problems.
