### PR TITLE
Make JASPI work without loginConfig

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -290,7 +290,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
             FormParserFactory parser = FormParserFactory.builder(false)
                     .addParser(new FormEncodedDataDefinition().setDefaultEncoding(deploymentInfo.getDefaultEncoding()))
                     .build();
-                    
+
             List<AuthMethodConfig> authMethods = Collections.<AuthMethodConfig>emptyList();
             if(loginConfig != null) {
                 authMethods = loginConfig.getAuthMethods();


### PR DESCRIPTION
If I understand correctly JASPI doesn't need <login-config> entry in web.xml.

We can register SAM module always using AuthConfigFactory without any xml configuration.

I'm not sure if this patch is correct but it works on my system.
