### PR TITLE
Avoid ChunkedStreamSinkConduit on 100-continue

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/HttpContinue.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpContinue.java
@@ -3,6 +3,7 @@ package io.undertow.server.protocol.http;
 import io.undertow.UndertowMessages;
 import io.undertow.io.IoCallback;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import org.xnio.ChannelExceptionHandler;
 import org.xnio.ChannelListener;
@@ -78,7 +79,11 @@ public class HttpContinue {
             throw UndertowMessages.MESSAGES.responseChannelAlreadyProvided();
         }
 
+        HeaderValues transfer_encoding = exchange.getRequestHeaders().get(Headers.TRANSFER_ENCODING);
+        exchange.getRequestHeaders().remove(Headers.TRANSFER_ENCODING);
         HttpServerExchange newExchange = exchange.getConnection().sendOutOfBandResponse(exchange);
+        if(transfer_encoding != null)
+            exchange.getRequestHeaders().putAll(Headers.TRANSFER_ENCODING, transfer_encoding);
         newExchange.setResponseCode(100);
         newExchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, 0);
         final StreamSinkChannel responseChannel = newExchange.getResponseChannel();
@@ -115,7 +120,11 @@ public class HttpContinue {
         if (!exchange.isResponseChannelAvailable()) {
             throw UndertowMessages.MESSAGES.responseChannelAlreadyProvided();
         }
+        HeaderValues transfer_encoding = exchange.getRequestHeaders().get(Headers.TRANSFER_ENCODING);
+        exchange.getRequestHeaders().remove(Headers.TRANSFER_ENCODING);
         HttpServerExchange newExchange = exchange.getConnection().sendOutOfBandResponse(exchange);
+        if(transfer_encoding != null)
+            exchange.getRequestHeaders().putAll(Headers.TRANSFER_ENCODING, transfer_encoding);
         newExchange.setResponseCode(100);
         newExchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, 0);
         newExchange.startBlocking();
@@ -136,7 +145,11 @@ public class HttpContinue {
 
 
     private static void internalSendContinueResponse(final HttpServerExchange exchange, final IoCallback callback) {
+        HeaderValues transfer_encoding = exchange.getRequestHeaders().get(Headers.TRANSFER_ENCODING);
+        exchange.getRequestHeaders().remove(Headers.TRANSFER_ENCODING);
         HttpServerExchange newExchange = exchange.getConnection().sendOutOfBandResponse(exchange);
+        if(transfer_encoding != null)
+            exchange.getRequestHeaders().putAll(Headers.TRANSFER_ENCODING, transfer_encoding);
         newExchange.setResponseCode(100);
         newExchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, 0);
         final StreamSinkChannel responseChannel = newExchange.getResponseChannel();


### PR DESCRIPTION
Ok. This is a dirty workaround for an issue when receiving a request with both "Expect: 100-continue" and "Transfer-Encoding: chunked" headers. I hope it will, at least, make more clear what is the issue but I'm sure there is a better fix.

Plese, be indulgent if the nonsense I'm going to explain now sounds like crap: I don't think I fully understand all the code yet.

Like I said, when receiving a request with those headers, the first response (out of band) is the "100 continue". Because of the presence of the "Transfer-Encoding: chunked", it will use a ChunkedStreamSinkConduit, and it will close its channel after writing the out of band response. 

For the actual response (in band) it will try to use the same ChunkedStreamSinkConduit but, closed as it is, it won't write anything.

So, I removed the "Transfer Encoding" header before sending out of band. And put it back again right after.

Does it make any sense?
