### PR TITLE
Rename jvMRoute method name to jvmRoute

### DIFF
--- a/core/src/main/java/io/undertow/Handlers.java
+++ b/core/src/main/java/io/undertow/Handlers.java
@@ -331,7 +331,7 @@ public class Handlers {
         return new ProxyPeerAddressHandler(next);
     }
 
-    public static JvmRouteHandler jvMRoute(final String sessionCookieName, final String jvmRoute, HttpHandler next) {
+    public static JvmRouteHandler jvmRoute(final String sessionCookieName, final String jvmRoute, HttpHandler next) {
         return new JvmRouteHandler(next, sessionCookieName, jvmRoute);
     }
 

--- a/core/src/test/java/io/undertow/server/handlers/proxy/LoadBalancingProxyTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/proxy/LoadBalancingProxyTestCase.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static io.undertow.Handlers.jvMRoute;
+import static io.undertow.Handlers.jvmRoute;
 import static io.undertow.Handlers.path;
 
 /**
@@ -65,14 +65,14 @@ public class LoadBalancingProxyTestCase {
         int port = DefaultServer.getHostPort("default");
         server1 = Undertow.builder()
                 .addListener(port + 1, DefaultServer.getHostAddress("default"))
-                .setHandler(jvMRoute("JSESSIONID", "s1", path()
+                .setHandler(jvmRoute("JSESSIONID", "s1", path()
                         .addPrefixPath("/session", new SessionAttachmentHandler(new SessionTestHandler(sessionConfig), new InMemorySessionManager(), sessionConfig))
                         .addPrefixPath("/name", new StringSendHandler("server1"))))
                 .build();
 
         server2 = Undertow.builder()
                 .addListener(port + 2, DefaultServer.getHostAddress("default"))
-                .setHandler(jvMRoute("JSESSIONID", "s2", path()
+                .setHandler(jvmRoute("JSESSIONID", "s2", path()
                         .addPrefixPath("/session", new SessionAttachmentHandler(new SessionTestHandler(sessionConfig), new InMemorySessionManager(), sessionConfig))
                         .addPrefixPath("/name", new StringSendHandler("server2"))))
                 .build();


### PR DESCRIPTION
Fix typo, this is public API method name change but at least it's not used by wildfly.
