### PR TITLE
Use HttpString#appendTo instead of HttpString#toString() and a loop.

### DIFF
--- a/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
+++ b/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
@@ -128,11 +128,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                     log.trace("Starting request");
                     // we assume that our buffer has enough space for the initial request line plus one more CR+LF
                     assert buffer.remaining() >= 0x100;
-                    string = request.getMethod().toString();
-                    length = string.length();
-                    for (charIndex = 0; charIndex < length; charIndex ++) {
-                        buffer.put((byte) string.charAt(charIndex));
-                    }
+                    request.getMethod().appendTo(buffer);
                     buffer.put((byte) ' ');
                     string = request.getPath();
                     length = string.length();
@@ -140,11 +136,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         buffer.put((byte) string.charAt(charIndex));
                     }
                     buffer.put((byte) ' ');
-                    string = request.getProtocol().toString();
-                    length = string.length();
-                    for (charIndex = 0; charIndex < length; charIndex ++) {
-                        buffer.put((byte) string.charAt(charIndex));
-                    }
+                    request.getProtocol().appendTo(buffer);
                     buffer.put((byte) '\r').put((byte) '\n');
                     HeaderMap headers = request.getRequestHeaders();
                     nameIterator = headers.getHeaderNames().iterator();

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerResponseConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerResponseConduit.java
@@ -127,17 +127,24 @@ final class AjpServerResponseConduit extends AbstractFramedStreamSinkConduit {
         state = FLAG_START;
     }
 
-    private void putInt(final ByteBuffer buf, int value) {
+    private static void putInt(final ByteBuffer buf, int value) {
         buf.put((byte) ((value >> 8) & 0xFF));
         buf.put((byte) (value & 0xFF));
     }
 
-    private void putString(final ByteBuffer buf, String value) {
+    private static void putString(final ByteBuffer buf, String value) {
         final int length = value.length();
         putInt(buf, length);
         for (int i = 0; i < length; ++i) {
             buf.put((byte) value.charAt(i));
         }
+        buf.put((byte) 0);
+    }
+
+    private void putHttpString(final ByteBuffer buf, HttpString value) {
+        final int length = value.length();
+        putInt(buf, length);
+        value.appendTo(buf);
         buf.put((byte) 0);
     }
 
@@ -197,7 +204,7 @@ final class AjpServerResponseConduit extends AbstractFramedStreamSinkConduit {
                     if (headerCode != null) {
                         putInt(buffer, headerCode);
                     } else {
-                        putString(buffer, header.toString());
+                        putHttpString(buffer, header);
                     }
                     putString(buffer, headerValue);
                 }


### PR DESCRIPTION
Use HttpString#appendTo instead of HttpString#toString() and a loop to put a HttpString into a ByteBuffer.
