### PR TITLE
Do not swallow NotSerializableException

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -82,7 +82,7 @@ public interface UndertowServletLogger extends BasicLogger {
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 15009, value = "Failed to persist session attribute %s with value %s for session %s")
-    void failedToPersistSessionAttribute(String attributeName, Object value, String sessionID);
+    void failedToPersistSessionAttribute(String attributeName, Object value, String sessionID, @Cause Exception e);
 
     @LogMessage(level = Logger.Level.WARN)
     @Message(id = 15010, value = "Failed to persist sessions")

--- a/servlet/src/main/java/io/undertow/servlet/util/InMemorySessionPersistence.java
+++ b/servlet/src/main/java/io/undertow/servlet/util/InMemorySessionPersistence.java
@@ -35,7 +35,7 @@ public class InMemorySessionPersistence implements SessionPersistenceManager {
                         objectOutputStream.close();
                         data.put(sessionAttribute.getKey(), out.toByteArray());
                     } catch (Exception e) {
-                        UndertowServletLogger.ROOT_LOGGER.failedToPersistSessionAttribute(sessionAttribute.getKey(), sessionAttribute.getValue(), sessionEntry.getKey());
+                        UndertowServletLogger.ROOT_LOGGER.failedToPersistSessionAttribute(sessionAttribute.getKey(), sessionAttribute.getValue(), sessionEntry.getKey(), e);
                     }
                 }
                 serializedData.put(sessionEntry.getKey(), new SessionEntry(sessionEntry.getValue().getExpiration(), data));


### PR DESCRIPTION
Alternatively, the stack trace may be logged on DEBUG level not to pollute the log.
