### PR TITLE
Fixed NPE and problem in which custom AuthenticationMechanisms aren't used

### DIFF
--- a/core/src/main/java/io/undertow/util/ImmediateAuthenticationMechanismFactory.java
+++ b/core/src/main/java/io/undertow/util/ImmediateAuthenticationMechanismFactory.java
@@ -20,6 +20,6 @@ public class ImmediateAuthenticationMechanismFactory implements AuthenticationMe
 
     @Override
     public AuthenticationMechanism create(String mechanismName, FormParserFactory formParserFactory, Map<String, String> properties) {
-        return null;
+        return authenticationMechanism;
     }
 }


### PR DESCRIPTION
The DeploymentInfo wraps an AuthenticationMechanism with a
ImmediateAuthenticationMechanismFactory.  However, that factory always returns
null when create() is called.  Fix is to simply returns the AuthenticationMechanism
that was provided to it during construction.
