### PR TITLE
Clear cached session when IdentityManager declares Account is invalid

### DIFF
--- a/core/src/main/java/io/undertow/security/api/AuthenticatedSessionManager.java
+++ b/core/src/main/java/io/undertow/security/api/AuthenticatedSessionManager.java
@@ -38,6 +38,8 @@ public interface AuthenticatedSessionManager {
 
     AuthenticatedSession lookupSession(final HttpServerExchange exchange);
 
+    void clearSession(final HttpServerExchange exchange);
+
     public static class AuthenticatedSession implements Serializable {
 
         private final Account account;

--- a/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
@@ -51,6 +51,7 @@ public class CachedAuthenticatedSessionMechanism implements AuthenticationMechan
             } else {
                 // We know we had a previously authenticated account but for some reason the IdentityManager is no longer
                 // accepting it, safer to mark as a failed authentication.
+                sessionManager.clearSession(exchange);
                 return AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
             }
         } else {

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
@@ -126,6 +126,24 @@ public class CachedAuthenticatedSessionHandler implements HttpHandler {
             return null;
         }
 
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void clearSession(HttpServerExchange exchange) {
+          HttpSessionImpl httpSession = servletContext.getSession(exchange, false);
+          if (httpSession == null) {
+            return;
+          }
+          Session session;
+          if (System.getSecurityManager() == null) {
+              session = httpSession.getSession();
+          } else {
+              session = AccessController.doPrivileged(new HttpSessionImpl.UnwrapSessionAction(httpSession));
+          }
+          session.removeAttribute(ATTRIBUTE_NAME);
+        }
+
     }
 
     private boolean isCacheable(final SecurityNotification notification) {


### PR DESCRIPTION
When an IdentityManager declares an Account is invalid, challenges are
resent. Upon the next request (which may occur based on an OAuth/CAS
redirect back), the CachedAuthenticatedSessionMechanism is invoked first
and finds a cached AuthenticatSession. It runs the Account against the
IdentityManager, which still declares it invalid and challenges are sent
again.  A forever redirect loop occurs.

This request clears the cached AuthenticatedSession from the session,
allowing subsequent requests to invoke the authenticate methods on the
registered AuthenticationMechanisms and allowing authentication to
actually occur.
