### PR TITLE
Add SingleSignOn.close() (analogous to Session.requestDone(HttpServerExchange)) to indicate when the SingleSignOn is no longer in use.

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/InMemorySingleSignOnManager.java
+++ b/core/src/main/java/io/undertow/security/impl/InMemorySingleSignOnManager.java
@@ -90,5 +90,10 @@ public class InMemorySingleSignOnManager implements SingleSignOnManager {
         public void remove(Session session) {
             this.sessions.remove(session.getSessionManager());
         }
+
+        @Override
+        public void close() {
+            // Do nothing
+        }
     }
 }

--- a/core/src/main/java/io/undertow/security/impl/SingleSignOn.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOn.java
@@ -1,5 +1,7 @@
 package io.undertow.security.impl;
 
+import java.io.Closeable;
+
 import io.undertow.security.idm.Account;
 import io.undertow.server.session.Session;
 import io.undertow.server.session.SessionManager;
@@ -8,7 +10,7 @@ import io.undertow.server.session.SessionManager;
  * @author Stuart Douglas
  * @author Paul Ferraro
  */
-public interface SingleSignOn extends Iterable<Session> {
+public interface SingleSignOn extends Iterable<Session>, Closeable {
 
     /**
      * Returns the unique identifier for this SSO.
@@ -53,4 +55,11 @@ public interface SingleSignOn extends Iterable<Session> {
      * @return a session
      */
     Session getSession(SessionManager manager);
+
+    /**
+     * Releases any resources acquired by this object.
+     * Must be called after this object is no longer in use.
+     */
+    @Override
+    void close();
 }


### PR DESCRIPTION
This will be leveraged by the distributable SSO implementation in WildFly.
