### PR TITLE
Replaces #toUpperCase() with #toUpperCase(Locale)

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -902,7 +903,7 @@ public class DeploymentInfo implements Cloneable {
      * @return
      */
     public DeploymentInfo addAuthenticationMechanism(final String name, final AuthenticationMechanismFactory factory) {
-        authenticationMechanisms.put(name.toUpperCase(), factory);
+        authenticationMechanisms.put(name.toUpperCase(Locale.US), factory);
         return this;
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -94,6 +94,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -321,7 +322,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
                 properties.put(AuthenticationMechanismFactory.LOGIN_PAGE, loginConfig.getLoginPage());
                 properties.putAll(method.getProperties());
 
-                String name = method.getName().toUpperCase();
+                String name = method.getName().toUpperCase(Locale.US);
                 // The mechanism name is passed in from the HttpServletRequest interface as the name reported needs to be
                 // comparable using '=='
                 name = name.equals(FORM_AUTH) ? FORM_AUTH : name;


### PR DESCRIPTION
Replaces #toUpperCase() with #toUpperCase(Locale) as String#toUpperCase() without a Locale may lead to unexpected results in JVMs with Turkish locale (s. JavaDocs of String#toUpperCase()).
