### PR TITLE
Link to the superseding function in addPath().

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/PathHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/PathHandler.java
@@ -68,7 +68,7 @@ public class PathHandler implements HttpHandler {
      * @param path    The path
      * @param handler The handler
      * @see #addPrefixPath(String, io.undertow.server.HttpHandler)
-     * @deprecated
+     * @deprecated Superseded by {@link #addPrefixPath()}.
      */
     @Deprecated
     public synchronized PathHandler addPath(final String path, final HttpHandler handler) {


### PR DESCRIPTION
The first line in the displayed javadoc now links the function which supersedes addPath().
