### PR TITLE
Stripping the header date from the semicolon-separated extensions before parsing

### DIFF
--- a/core/src/main/java/io/undertow/util/DateUtils.java
+++ b/core/src/main/java/io/undertow/util/DateUtils.java
@@ -111,7 +111,9 @@ public class DateUtils {
             parsing.
 
          */
-        final String trimmedDate = date.replaceAll(";.*$","");
+
+        final int semicolonIndex = date.indexOf(';');
+        final String trimmedDate = semicolonIndex >=0 ? date.substring(0, semicolonIndex) : date;
 
         ParsePosition pp = new ParsePosition(0);
         SimpleDateFormat dateFormat = RFC1123_PATTERN_FORMAT.get();

--- a/core/src/test/java/io/undertow/util/DateUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/DateUtilsTestCase.java
@@ -66,4 +66,29 @@ public class DateUtilsTestCase {
 
     }
 
+    @Test
+    public void testPerformance() {
+
+        String ie9Header = "Wed, 12 Feb 2014 04:43:29 GMT; length=142951";
+
+        long timestamp = System.currentTimeMillis();
+        for (int i=0; i < 1000; i++) {
+            ie9Header.replaceAll(";.*$", "");
+        }
+        long ts1 = System.currentTimeMillis() - timestamp;
+
+        timestamp = System.currentTimeMillis();
+
+        for (int i=0; i < 1000; i++) {
+            int index = ie9Header.indexOf(';');
+            final String trimmedDate = index >=0 ? ie9Header.substring(0, index) : ie9Header;
+        }
+
+        long ts2 = System.currentTimeMillis() - timestamp;
+
+        Assert.assertTrue(ts2 < ts1);
+
+    }
+
+
 }


### PR DESCRIPTION
Having deployed an application to a Wildfly AS (powered by Undertow 1.0.0) I realized that it fails to parse _If-Modified-Since_ header passed by Internet Explorer 9. The header value contains additional "length" parameter after a semicolon, which causes the date parsing routine to fail. 

I propose a fix of removing a trailing semicolon and everything that comes after it before attempting to parse the date in _DateUtils_ class. I'm attaching a simple test suite that parses the _If-Modified-Header_ sent by three major browsers.
