### PR TITLE
Fix path specific cookies being overridden

### DIFF
--- a/core/src/main/java/io/undertow/util/Cookies.java
+++ b/core/src/main/java/io/undertow/util/Cookies.java
@@ -293,11 +293,17 @@ public class Cookies {
     private static int createCookie(final String name, final String value, int maxCookies, int cookieCount,
             final Map<String, String> cookies, final Map<String, String> additional) {
         if (name.charAt(0) == '$') {
+            if(additional.containsKey(name)) {
+                return cookieCount;
+            }
             additional.put(name, value);
             return cookieCount;
         } else {
             if (cookieCount == maxCookies) {
                 throw UndertowMessages.MESSAGES.tooManyCookies(maxCookies);
+            }
+            if(cookies.containsKey(name)) {
+                return cookieCount;
             }
             cookies.put(name, value);
             return ++cookieCount;


### PR DESCRIPTION
Path specific JSESSIONID cookie gets overridden by parent path cookie.
If a more specific cookie already exists, then don’t override it.
