### PR TITLE
incorrect close behavior 

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/UndertowSession.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/UndertowSession.java
@@ -170,7 +170,7 @@ public final class UndertowSession implements Session {
 
     @Override
     public void close() throws IOException {
-        close(null);
+        close(new CloseReason(CloseReason.CloseCodes.NORMAL_CLOSURE, null));
     }
 
     @Override


### PR DESCRIPTION
A call of `close()` with no argument should cause a normal closure without any phrase:

http://docs.oracle.com/javaee/7/api/javax/websocket/Session.html#close()
