### PR TITLE
Makes the template path matcher consistent with the path matcher

### DIFF
--- a/core/src/main/java/io/undertow/util/PathTemplate.java
+++ b/core/src/main/java/io/undertow/util/PathTemplate.java
@@ -56,7 +56,25 @@ public class PathTemplate implements Comparable<PathTemplate> {
         this.parameterNames = Collections.unmodifiableSet(parameterNames);
     }
 
-    public static PathTemplate create(final String path) {
+    public static PathTemplate create(final String inputPath) {
+        // a path is required
+        if(inputPath == null) {
+            throw UndertowMessages.MESSAGES.pathMustBeSpecified();
+        }
+
+        // prepend a "/" if none is present
+        if(!inputPath.startsWith("/")) {
+            return PathTemplate.create("/" + inputPath);
+        }
+
+        // otherwise normalize template
+        final StringBuilder builder = new StringBuilder(inputPath);
+        while(builder != null && builder.length() > 1 && '/' == builder.charAt(builder.length() - 1)) {
+            builder.deleteCharAt(builder.length() - 1);
+        }
+
+        // create string from modified string
+        final String path = builder.toString();
 
         int state = 0;
         String base = "";

--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -32,6 +32,7 @@ public class PathTemplateTestCase {
 
     @Test
     public void testMatches() {
+        // test normal use
         testMatch("/docs/mydoc", "/docs/mydoc");
         testMatch("/docs/{docId}", "/docs/mydoc", "docId", "mydoc");
         testMatch("/docs/{docId}/{op}", "/docs/mydoc/read", "docId", "mydoc", "op", "read");
@@ -40,9 +41,36 @@ public class PathTemplateTestCase {
         testMatch("/docs/{docId}/read", "/docs/mydoc/read", "docId", "mydoc");
         testMatch("/docs/{docId}/read", "/docs/mydoc/read?myQueryParam", "docId", "mydoc");
 
+        // test no leading slash
+        testMatch("docs/mydoc", "/docs/mydoc");
+        testMatch("docs/{docId}", "/docs/mydoc", "docId", "mydoc");
+        testMatch("docs/{docId}/{op}", "/docs/mydoc/read", "docId", "mydoc", "op", "read");
+        testMatch("docs/{docId}/{op}/{allowed}", "/docs/mydoc/read/true", "docId", "mydoc", "op", "read", "allowed", "true");
+        testMatch("docs/{docId}/operation/{op}", "/docs/mydoc/operation/read", "docId", "mydoc", "op", "read");
+        testMatch("docs/{docId}/read", "/docs/mydoc/read", "docId", "mydoc");
+        testMatch("docs/{docId}/read", "/docs/mydoc/read?myQueryParam", "docId", "mydoc");
+
+        // test trailing slashes
+        testMatch("/docs/mydoc/", "/docs/mydoc");
+        testMatch("/docs/{docId}/", "/docs/mydoc", "docId", "mydoc");
+        testMatch("/docs/{docId}/{op}/", "/docs/mydoc/read", "docId", "mydoc", "op", "read");
+        testMatch("/docs/{docId}/{op}/{allowed}/", "/docs/mydoc/read/true", "docId", "mydoc", "op", "read", "allowed", "true");
+        testMatch("/docs/{docId}/operation/{op}/", "/docs/mydoc/operation/read", "docId", "mydoc", "op", "read");
+        testMatch("/docs/{docId}/read/", "/docs/mydoc/read", "docId", "mydoc");
+
+        // test straight replacement of template
         testMatch("/{foo}", "/bob", "foo", "bob");
+        testMatch("{foo}", "/bob", "foo", "bob");
+        testMatch("/{foo}/", "/bob", "foo", "bob");
+
+        // test that brackets (and the possibility of recursive templates) don't mess up the matching
+        testMatch("/{value}", "/{value}", "value", "{value}");
     }
 
+    @Test(expected=IllegalArgumentException.class)
+    public void testNullPath() {
+        PathTemplate.create(null);
+    }
 
     @Test
     public void testDetectDuplicates() {


### PR DESCRIPTION
Especially with regards to the behavior with leading/trailing slashes (plus updated tests)
