### PR TITLE
Trailing slashes addition to CanonicalPathUtilsTestCase

### DIFF
--- a/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
@@ -60,10 +60,11 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("/", CanonicalPathUtils.canonicalize("/a/../.."));
         Assert.assertEquals("/foo", CanonicalPathUtils.canonicalize("/a/../../foo"));
 
-        //preserve trailing /
+        //preserve (single) trailing /
         Assert.assertEquals("/a/", CanonicalPathUtils.canonicalize("/a/"));
         Assert.assertEquals("/", CanonicalPathUtils.canonicalize("/"));
         Assert.assertEquals("/bbb/a", CanonicalPathUtils.canonicalize("/cc/../bbb/a/."));
+        Assert.assertEquals("/aaa/bbb/", CanonicalPathUtils.canonicalize("/aaa/bbb//////"));
     }
 
 }


### PR DESCRIPTION
Adds a single case for multiple trailing slashes at the end of the path
