### PR TITLE
Fixes NPEs thrown when processing large binary messages.

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
@@ -383,7 +383,10 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
             S next = it.next();
             //todo: rather than adding empty buffers just store the offsets
             SendFrameHeader frameHeader = next.getFrameHeader();
-            data[j * 3] = frameHeader.getByteBuffer().getResource();
+            Pooled<ByteBuffer> frameHeaderByteBuffer = frameHeader.getByteBuffer();
+            data[j * 3] = frameHeaderByteBuffer != null
+                        ? frameHeaderByteBuffer.getResource()
+                        : Buffers.EMPTY_BYTE_BUFFER;
             data[(j * 3) + 1] = next.getBuffer();
             data[(j * 3) + 2] = next.getFrameFooter();
             ++j;
@@ -405,7 +408,8 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
 
         while (max > 0) {
             S sinkChannel = pendingFrames.get(0);
-            if (sinkChannel.getFrameHeader().getByteBuffer().getResource().hasRemaining()
+            Pooled<ByteBuffer> frameHeaderByteBuffer = sinkChannel.getFrameHeader().getByteBuffer();
+            if (frameHeaderByteBuffer != null && frameHeaderByteBuffer.getResource().hasRemaining()
                     || sinkChannel.getBuffer().hasRemaining()
                     || sinkChannel.getFrameFooter().hasRemaining()) {
                 break;

--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSinkChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSinkChannel.java
@@ -462,7 +462,9 @@ public abstract class AbstractFramedStreamSinkChannel<C extends AbstractFramedCh
             } else {
                 buffer.getResource().compact();
             }
-            header.getByteBuffer().free();
+            if (header.getByteBuffer() != null) {
+                header.getByteBuffer().free();
+            }
             trailer.free();
             header = null;
             trailer = null;

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointServlet.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointServlet.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.websockets.jsr.test;
+
+import java.io.IOException;
+import javax.servlet.Servlet;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.websocket.DeploymentException;
+import javax.websocket.server.ServerContainer;
+import javax.websocket.server.ServerEndpointConfig;
+
+/**
+ * @author Andrej Golovnin
+ * @author Stuart Douglas
+ */
+public class BinaryEndpointServlet implements Servlet {
+    @Override
+    public void init(ServletConfig c) throws ServletException {
+        String websocketPath = "/partial";
+        ServerEndpointConfig config = ServerEndpointConfig.Builder.create(BinaryPartialEndpoint.class, websocketPath).build();
+        ServerContainer serverContainer = (ServerContainer) c.getServletContext().getAttribute("javax.websocket.server.ServerContainer");
+        try {
+            serverContainer.addEndpoint(config);
+        } catch (DeploymentException ex) {
+            throw new ServletException("Error deploying websocket endpoint:", ex);
+        }
+    }
+
+    @Override
+    public ServletConfig getServletConfig() {
+        return null;
+    }
+
+    @Override
+    public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+    }
+
+    @Override
+    public String getServletInfo() {
+        return null;
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointTest.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointTest.java
@@ -1,0 +1,134 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLContext;
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.ContainerProvider;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
+
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.testutils.AjpIgnore;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.websockets.jsr.DefaultWebSocketClientSslProvider;
+import io.undertow.websockets.jsr.ServerWebSocketContainer;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.xnio.ByteBufferSlicePool;
+
+/**
+ * @author Andrej Golovnin
+ * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
+ */
+@RunWith(DefaultServer.class)
+@AjpIgnore
+public class BinaryEndpointTest {
+
+    private static ServerWebSocketContainer deployment;
+
+    private static byte[] bytes;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+
+        bytes = new byte[256 * 1024];
+        new Random().nextBytes(bytes);
+
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(BinaryEndpointTest.class.getClassLoader())
+                .setContextPath("/")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .addServlet(Servlets.servlet("bin", BinaryEndpointServlet.class).setLoadOnStartup(100))
+                .addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME,
+                        new WebSocketDeploymentInfo()
+                                .setBuffers(new ByteBufferSlicePool(16 * 1024, 16 * 1024))
+                                .setWorker(DefaultServer.getWorker())
+                                .addListener(new WebSocketDeploymentInfo.ContainerReadyListener() {
+                                    @Override
+                                    public void ready(ServerWebSocketContainer container) {
+                                        deployment = container;
+                                    }
+                                })
+                )
+                .setDeploymentName("servletContext.war");
+
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+
+
+        DefaultServer.setRootHandler(manager.start());
+        DefaultServer.startSSLServer();
+    }
+
+    @AfterClass
+    public static void after() throws IOException {
+        deployment = null;
+        DefaultServer.stopSSLServer();
+    }
+
+    @org.junit.Test
+    public void testBytesOnMessage() throws Exception {
+        SSLContext context = DefaultServer.getClientSSLContext();
+        ProgramaticClientEndpoint endpoint = new ProgramaticClientEndpoint();
+
+        ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create().build();
+        clientEndpointConfig.getUserProperties().put(DefaultWebSocketClientSslProvider.SSL_CONTEXT, context);
+        ContainerProvider.getWebSocketContainer().connectToServer(endpoint, clientEndpointConfig, new URI("wss://" + DefaultServer.getHostAddress("default") + ":" + DefaultServer.getHostSSLPort("default") + "/partial"));
+        Assert.assertArrayEquals(bytes, endpoint.getResponses().poll(15, TimeUnit.SECONDS));
+    }
+
+    public static class ProgramaticClientEndpoint extends Endpoint {
+
+        private final LinkedBlockingDeque<byte[]> responses = new LinkedBlockingDeque<byte[]>();
+
+        @Override
+        public void onOpen(Session session, EndpointConfig config) {
+            session.getAsyncRemote().sendBinary(ByteBuffer.wrap(bytes));
+            session.addMessageHandler(new MessageHandler.Whole<byte[]>() {
+
+                @Override
+                public void onMessage(byte[] message) {
+                    responses.add(message);
+                }
+            });
+        }
+
+        public LinkedBlockingDeque<byte[]> getResponses() {
+            return responses;
+        }
+    }
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryPartialEndpoint.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryPartialEndpoint.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.websockets.jsr.test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.Session;
+
+/**
+ * @author Andrej Golovnin
+ */
+public final class BinaryPartialEndpoint extends Endpoint {
+
+    @Override
+    public void onOpen(final Session session, EndpointConfig config) {
+        session.addMessageHandler(new MessageHandler.Partial<byte[]>() {
+
+            private ByteArrayOutputStream buffer;
+
+            @Override
+            public void onMessage(byte[] bytes, boolean last) {
+                if (last) {
+                    if (buffer == null) {
+                        onRequest(bytes);
+                    } else {
+                        try {
+                            buffer(bytes);
+                            byte[] tmp = buffer.toByteArray();
+                            onRequest(tmp);
+                        } finally {
+                            buffer = null;
+                        }
+                    }
+                } else {
+                    buffer(bytes);
+                }
+            }
+
+            private void onRequest(byte[] bytes) {
+                // Just return the received bytes for the test
+                try {
+                    session.getBasicRemote().sendBinary(
+                        ByteBuffer.wrap(bytes));
+                } catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            private void buffer(byte[] data) {
+                if (buffer == null) {
+                    buffer = new ByteArrayOutputStream(8096);
+                }
+                buffer.write(data, 0, data.length);
+            }
+
+        });
+
+    }
+}


### PR DESCRIPTION
Fixes NPEs thrown when processing large binary messages. Adds new test to show the problem.
I'm not sure that the patch is good. Maybe there is a better solution. But it fixes at least for me the NPEs.
