### PR TITLE
make next HttpHandler final

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/SetHeaderHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SetHeaderHandler.java
@@ -23,18 +23,20 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 
 /**
+ * Set a fixed response header.
+ * 
  * @author Stuart Douglas
  */
 public class SetHeaderHandler implements HttpHandler {
 
     private final HttpString header;
     private final String value;
-
-    private volatile HttpHandler next = ResponseCodeHandler.HANDLE_404;
+    private final HttpHandler next;
 
     public SetHeaderHandler(final String header, final String value) {
-        this.header = new HttpString(header);
+        this.next = ResponseCodeHandler.HANDLE_404;
         this.value = value;
+        this.header = new HttpString(header);
     }
 
     public SetHeaderHandler(final HttpHandler next, final String header, final String value) {


### PR DESCRIPTION
This handler has no setNext(), so it is safe to make it final and remove volatile. Also sort the field initialization in both constructors the same. Add JavaDoc.

 The constructor with no next handler does not look very useful, want me to provide a volatile+setNext version instead?

Signed-off-by: Bernd Eckenfels
