### PR TITLE
UNDERTOW-254 IPAddressAccessControlHandler should allow for alternative code

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
@@ -72,15 +72,22 @@ public class IPAddressAccessControlHandler implements HttpHandler {
 
     private volatile HttpHandler next;
     private volatile boolean defaultAllow = false;
+    private final int denyResponseCode;
     private final List<PeerMatch> ipv6acl = new CopyOnWriteArrayList<PeerMatch>();
     private final List<PeerMatch> ipv4acl = new CopyOnWriteArrayList<PeerMatch>();
 
     public IPAddressAccessControlHandler(final HttpHandler next) {
+        this(next, StatusCodes.FORBIDDEN);
+    }
+
+    public IPAddressAccessControlHandler(final HttpHandler next, final int denyResponseCode) {
         this.next = next;
+        this.denyResponseCode = denyResponseCode;
     }
 
     public IPAddressAccessControlHandler() {
         this.next = ResponseCodeHandler.HANDLE_404;
+        this.denyResponseCode = StatusCodes.FORBIDDEN;
     }
 
     @Override
@@ -89,7 +96,7 @@ public class IPAddressAccessControlHandler implements HttpHandler {
         if (isAllowed(peer.getAddress())) {
             next.handleRequest(exchange);
         } else {
-            exchange.setResponseCode(StatusCodes.FORBIDDEN);
+            exchange.setResponseCode(denyResponseCode);
             exchange.endExchange();
         }
     }
@@ -109,6 +116,11 @@ public class IPAddressAccessControlHandler implements HttpHandler {
             }
         }
         return defaultAllow;
+    }
+
+
+    public int getDenyResponseCode() {
+        return denyResponseCode;
     }
 
     public boolean isDefaultAllow() {

--- a/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
@@ -21,6 +21,7 @@ package io.undertow.server.handlers;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import io.undertow.util.StatusCodes;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -110,5 +111,17 @@ public class IPAddressAccessControlHandlerUnitTestCase {
         Assert.assertTrue(handler.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f4")));
         Assert.assertTrue(handler.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f5")));
         Assert.assertFalse(handler.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f6")));
+    }
+
+    @Test
+    public void testDefaultDenyResponseCode() {
+        IPAddressAccessControlHandler handler = new IPAddressAccessControlHandler();
+        Assert.assertEquals(StatusCodes.FORBIDDEN, handler.getDenyResponseCode());
+    }
+
+    @Test
+    public void testDenyResponseCode() {
+        IPAddressAccessControlHandler handler = new IPAddressAccessControlHandler(null, StatusCodes.NOT_FOUND);
+        Assert.assertEquals(StatusCodes.NOT_FOUND, handler.getDenyResponseCode());
     }
 }


### PR DESCRIPTION
Changed `IPAddressAccessControlHandler` to allow for an alternative response code when access is denied.
