### PR TITLE
Remove deprecated method from examples

### DIFF
--- a/examples/src/main/java/io/undertow/examples/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/undertow/examples/helloworld/HelloWorldServer.java
@@ -32,7 +32,7 @@ public class HelloWorldServer {
 
     public static void main(final String[] args) {
         Undertow server = Undertow.builder()
-                .addListener(8080, "localhost")
+                .addHttpListener(8080, "localhost")
                 .setHandler(new HttpHandler() {
                     @Override
                     public void handleRequest(final HttpServerExchange exchange) throws Exception {

--- a/examples/src/main/java/io/undertow/examples/reverseproxy/ReverseProxyServer.java
+++ b/examples/src/main/java/io/undertow/examples/reverseproxy/ReverseProxyServer.java
@@ -39,7 +39,7 @@ public class ReverseProxyServer {
     public static void main(final String[] args) {
         try {
             final Undertow server1 = Undertow.builder()
-                    .addListener(8081, "localhost")
+                    .addHttpListener(8081, "localhost")
                     .setHandler(new HttpHandler() {
                         @Override
                         public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -52,7 +52,7 @@ public class ReverseProxyServer {
             server1.start();
 
             final Undertow server2 = Undertow.builder()
-                    .addListener(8082, "localhost")
+                    .addHttpListener(8082, "localhost")
                     .setHandler(new HttpHandler() {
                         @Override
                         public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -64,7 +64,7 @@ public class ReverseProxyServer {
             server2.start();
 
             final Undertow server3 = Undertow.builder()
-                    .addListener(8083, "localhost")
+                    .addHttpListener(8083, "localhost")
                     .setHandler(new HttpHandler() {
                         @Override
                         public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -83,7 +83,7 @@ public class ReverseProxyServer {
                     .setConnectionsPerThread(20);
 
             Undertow reverseProxy = Undertow.builder()
-                    .addListener(8080, "localhost")
+                    .addHttpListener(8080, "localhost")
                     .setIoThreads(4)
                     .setHandler(new ProxyHandler(loadBalancer, 30000, ResponseCodeHandler.HANDLE_404))
                     .build();

--- a/examples/src/main/java/io/undertow/examples/security/basic/BasicAuthServer.java
+++ b/examples/src/main/java/io/undertow/examples/security/basic/BasicAuthServer.java
@@ -61,7 +61,7 @@ public class BasicAuthServer {
         final IdentityManager identityManager = new MapIdentityManager(users);
 
         Undertow server = Undertow.builder()
-                .addListener(8080, "localhost")
+                .addHttpListener(8080, "localhost")
                 .setHandler(addSecurity(new HttpHandler() {
                     @Override
                     public void handleRequest(final HttpServerExchange exchange) throws Exception {

--- a/examples/src/main/java/io/undertow/examples/servlet/ServletServer.java
+++ b/examples/src/main/java/io/undertow/examples/servlet/ServletServer.java
@@ -63,7 +63,7 @@ public class ServletServer {
             PathHandler path = Handlers.path(Handlers.redirect(MYAPP))
                     .addPrefixPath(MYAPP, servletHandler);
             Undertow server = Undertow.builder()
-                    .addListener(8080, "localhost")
+                    .addHttpListener(8080, "localhost")
                     .setHandler(path)
                     .build();
             server.start();


### PR DESCRIPTION
Removed the call from the deprecated addListener to addHttpListener
