### PR TITLE
UNDERTOW-269 SSO not destroyed when the last associated session times out

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
@@ -169,7 +169,11 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
                         if (reason == SessionDestroyedReason.INVALIDATED) {
                             for (Session associatedSession : sso) {
                                 associatedSession.invalidate(null);
+                                sso.remove(associatedSession);
                             }
+                        }
+                        // If there are no more associated sessions, remove the SSO altogether
+                        if (!sso.iterator().hasNext()) {
                             manager.removeSingleSignOn(ssoId);
                         }
                     } finally {


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-269
