### PR TITLE
Fixing substring-index in ProxyPeerAddress Handler

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -50,7 +50,7 @@ public class ProxyPeerAddressHandler implements HttpHandler {
             if (index == -1) {
                 value = forwardedFor;
             } else {
-                value = forwardedFor.substring(0, index - 1);
+                value = forwardedFor.substring(0, index);
             }
             InetAddress address = InetAddress.getByName(value);
             //we have no way of knowing the port


### PR DESCRIPTION
In ProxyPeerAddressHander, the substring boundary is wrongly calculated with 0 to index -1.
As the end-index is exclusive, it must be 0 to index.

Example XFF-Header without additional proxies (was correct before fix)
X-Forwarded-For: 123.123.123.123
Handler-Value: 123.123.123.123

Example XFF with at least one additional proxy:
X-Forwarded-For: 123.123.123.123, 210.210.210.210
Handler-Value (wrong): 123.123.123.12  (note the missing last character)
Handler-Value (fixed): 123.123.123.123
