### PR TITLE
RoutingHandler updates

### DIFF
--- a/core/src/main/java/io/undertow/server/RoutingHandler.java
+++ b/core/src/main/java/io/undertow/server/RoutingHandler.java
@@ -27,6 +27,7 @@ import io.undertow.util.PathTemplateMatcher;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -119,6 +120,22 @@ public class RoutingHandler implements HttpHandler {
         }
         res.predicatedHandlers.add(new HandlerHolder(predicate, handler));
         return this;
+    }
+
+    public synchronized RoutingHandler addAll(RoutingHandler routingHandler) {
+        for (Entry<HttpString, PathTemplateMatcher<RoutingMatch>> entry : routingHandler.getMatches().entrySet()) {
+            HttpString method = entry.getKey();
+            PathTemplateMatcher<RoutingMatch> matcher = matches.get(method);
+            if (matcher == null) {
+                matches.put(method, matcher = new PathTemplateMatcher<>());
+            }
+            matcher.addAll(entry.getValue());
+        }
+        return this;
+    }
+
+    Map<HttpString, PathTemplateMatcher<RoutingMatch>> getMatches() {
+        return matches;
     }
 
     public HttpHandler getFallbackHandler() {

--- a/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
+++ b/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -144,6 +145,19 @@ public class PathTemplateMatcher<T> {
     public synchronized PathTemplateMatcher<T> add(final String pathTemplate, final T value) {
         final PathTemplate template = PathTemplate.create(pathTemplate);
         return add(template, value);
+    }
+
+    public synchronized PathTemplateMatcher<T> addAll(PathTemplateMatcher<T> pathTemplateMatcher) {
+        for (Entry<String, Set<PathTemplateHolder>> entry : pathTemplateMatcher.getPathTemplateMap().entrySet()) {
+            for (PathTemplateHolder pathTemplateHolder : entry.getValue()) {
+                add(pathTemplateHolder.template, pathTemplateHolder.value);
+            }
+        }
+        return this;
+    }
+
+    Map<String, Set<PathTemplateHolder>> getPathTemplateMap() {
+        return pathTemplateMap;
     }
 
     public synchronized PathTemplateMatcher<T> remove(final String pathTemplate) {


### PR DESCRIPTION
Allow setting the fallbackHandler and invalidMethodHandler so they are easier to customize.  I switched from void to using the builder pattern so it is a little more fluent.

Added the ability to combine multiple different RoutingHandlers into one Routing handler.  I am not sure if this was the best way to approach it.  The goal is to have common modules of routes that get shared across web services (ex. /version /info /metrics) and be able to easily plug them into a new service.  I originally wrote my own wrapper to do this but figured it might be useful.
