### PR TITLE
Make LocaleUtils return default locale if no value is specified for Accept-Language

### DIFF
--- a/core/src/main/java/io/undertow/util/LocaleUtils.java
+++ b/core/src/main/java/io/undertow/util/LocaleUtils.java
@@ -60,6 +60,9 @@ public class LocaleUtils {
                 }
             }
         }
+        if (ret.isEmpty()) {
+            ret.add(Locale.getDefault());
+        }
         return ret;
     }
 }


### PR DESCRIPTION
If a client includes the Accept-Language header in request, but has no value
for the header, then currently LocaleUtils.getLocalesFromHeader will return an
empty list. That will cause an exception in io.undertow.servlet.spec.HttpServletRequestImpl.getLocale.
Currently, if LocaleUtils.getLocalesFromHeader does not see any Accept-Language
header, it will return the Locale.getDefault().

So we should also return Locale.getDefault() if the Accept-Language has no value
