### PR TITLE
Added some convience methods to routing handler.  Handle an edge case fo...

### DIFF
--- a/core/src/main/java/io/undertow/server/RoutingHandler.java
+++ b/core/src/main/java/io/undertow/server/RoutingHandler.java
@@ -23,6 +23,7 @@ import io.undertow.server.handlers.ResponseCodeHandler;
 import io.undertow.util.CopyOnWriteMap;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
+import io.undertow.util.PathTemplate;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.PathTemplateMatcher;
 
@@ -39,6 +40,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class RoutingHandler implements HttpHandler {
 
     private final Map<HttpString, PathTemplateMatcher<RoutingMatch>> matches = new CopyOnWriteMap<>();
+    private final PathTemplateMatcher<RoutingMatch> allMethodsMatcher = new PathTemplateMatcher<>();
 
     private volatile HttpHandler fallbackHandler = ResponseCodeHandler.HANDLE_404;
     private volatile HttpHandler invalidMethodHandler = ResponseCodeHandler.HANDLE_405;
@@ -67,13 +69,9 @@ public class RoutingHandler implements HttpHandler {
         }
         PathTemplateMatcher.PathMatchResult<RoutingMatch> match = matcher.match(exchange.getRelativePath());
         if (match == null) {
-            // Check all PathTemplateMatchers to see if there is a match
-            // with a different HttpMethod
-            for (PathTemplateMatcher<RoutingMatch> value : matches.values()) {
-                if (value.match(exchange.getRelativePath()) != null) {
-                    invalidMethodHandler.handleRequest(exchange);
-                    return;
-                }
+            if (allMethodsMatcher.match(exchange.getRelativePath()) != null) {
+                invalidMethodHandler.handleRequest(exchange);
+                return;
             }
             fallbackHandler.handleRequest(exchange);
             return;
@@ -110,9 +108,14 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
+        if (allMethodsMatcher.get(template) == null) {
+            allMethodsMatcher.add(template, res);
+        }
         res.defaultHandler = handler;
         return this;
     }
+
+
 
     public synchronized RoutingHandler get(final String template, HttpHandler handler) {
         return add(Methods.GET, template, handler);
@@ -143,6 +146,9 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
+        if (allMethodsMatcher.get(template) == null) {
+            allMethodsMatcher.add(template, res);
+        }
         res.predicatedHandlers.add(new HandlerHolder(predicate, handler));
         return this;
     }
@@ -171,6 +177,13 @@ public class RoutingHandler implements HttpHandler {
                 matches.put(method, matcher = new PathTemplateMatcher<>());
             }
             matcher.addAll(entry.getValue());
+            // If we use allMethodsMatcher.addAll() we can have duplicate
+            // PathTemplates which we want to ignore here so it does not crash.
+            for (PathTemplate template : entry.getValue().getPathTemplates()) {
+                if (allMethodsMatcher.get(template.getTemplateString()) == null) {
+                    allMethodsMatcher.add(template, new RoutingMatch());
+                }
+            }
         }
         return this;
     }

--- a/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
+++ b/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
@@ -22,6 +22,7 @@ import io.undertow.UndertowMessages;
 
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -158,6 +159,16 @@ public class PathTemplateMatcher<T> {
 
     Map<String, Set<PathTemplateHolder>> getPathTemplateMap() {
         return pathTemplateMap;
+    }
+
+    public Set<PathTemplate> getPathTemplates() {
+        Set<PathTemplate> templates = new HashSet<>();
+        for (Set<PathTemplateHolder> holders : pathTemplateMap.values()) {
+            for (PathTemplateHolder holder: holders) {
+                templates.add(holder.template);
+            }
+        }
+        return templates;
     }
 
     public synchronized PathTemplateMatcher<T> remove(final String pathTemplate) {

--- a/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
@@ -28,8 +28,6 @@ import io.undertow.testutils.HttpClientUtils;
 import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.Methods;
 
-import java.io.IOException;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -39,6 +37,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.io.IOException;
 
 /**
  * @author Stuart Douglas


### PR DESCRIPTION
Tests initially failed from the following.

Given 3 routes
GET           /foo
DELETE    /foo
GET          /bar

A request to DELETE /bar will result in a 404 instead of a 405.  

```
PathTemplateMatcher<RoutingMatch> matcher = matches.get(exchange.getRequestMethod());
if (matcher == null) {
    invalidMethodHandler.handleRequest(exchange);
    return;
}
PathTemplateMatcher.PathMatchResult<RoutingMatch> match = matcher.match(exchange.getRelativePath());
if (match == null) {
    fallbackHandler.handleRequest(exchange);
    return;
} 
```

Since the routes are first mapped on the HttpMethod we will get a PathTemplateMatcher back which contains DELETE /foo.  It will then fall through to the next if and return a 404.  I think the expected behavior should be 405?  Is looping over ALL PathTemplateMatchers the only way to catch this?
