### PR TITLE
[master] UNDERTOW-291 Iterate over listeners in reverse for sessionDestroyed() so that SessionListenerBridge is triggered last.

### DIFF
--- a/core/src/main/java/io/undertow/server/session/SessionListeners.java
+++ b/core/src/main/java/io/undertow/server/session/SessionListeners.java
@@ -18,7 +18,10 @@
 
 package io.undertow.server.session;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.undertow.server.HttpServerExchange;
@@ -52,10 +55,12 @@ public class SessionListeners {
     }
 
     public void sessionDestroyed(final Session session, final HttpServerExchange exchange, SessionListener.SessionDestroyedReason reason) {
-        for (SessionListener listener : sessionListeners) {
-            listener.sessionDestroyed(session, exchange, reason);
+        // We need to create our own snapshot to safely iterate over a concurrent list in reverse
+        List<SessionListener> listeners = new ArrayList<>(sessionListeners);
+        ListIterator<SessionListener> iterator = listeners.listIterator(listeners.size());
+        while (iterator.hasPrevious()) {
+            iterator.previous().sessionDestroyed(session, exchange, reason);
         }
-
     }
 
     public void attributeAdded(final Session session, final String name, final Object value) {


### PR DESCRIPTION
Otherwise subsequent listeners will never see any session attributes, since SessionListenerBridge removes them.

https://issues.jboss.org/browse/UNDERTOW-291
