### PR TITLE
Match behavior of PathTemplateHandler to the one of PathHandler

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/PathHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/PathHandler.java
@@ -47,7 +47,7 @@ public class PathHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         final PathMatcher.PathMatch<HttpHandler> match = pathMatcher.match(exchange.getRelativePath());
-        if(match.getValue() == null) {
+        if (match.getValue() == null) {
             ResponseCodeHandler.HANDLE_404.handleRequest(exchange);
             return;
         }

--- a/core/src/main/java/io/undertow/server/handlers/PathTemplateHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/PathTemplateHandler.java
@@ -55,9 +55,8 @@ public class PathTemplateHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         PathTemplateMatcher.PathMatchResult<HttpHandler> match = pathTemplateMatcher.match(exchange.getRelativePath());
-        if (match == null) {
-            exchange.setResponseCode(404);
-            exchange.endExchange();
+        if (match.getValue() == null) {
+            ResponseCodeHandler.HANDLE_404.handleRequest(exchange);
             return;
         }
         exchange.putAttachment(PATH_TEMPLATE_MATCH, new PathTemplateMatch(match.getMatchedTemplate(), match.getParameters()));


### PR DESCRIPTION
PathHandler currently uses the ResponseCodeHandler if there was no match, PathTemplateHandler instead ends the exchange which makes chaining multiple Path(Template)Handlers harder. This PR changes the behavior of the PathTemplateHandler to match the one of the PathHandler.
