### PR TITLE
Allow timeouts to be set dynamically.

### DIFF
--- a/core/src/main/java/io/undertow/conduits/ReadTimeoutStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/ReadTimeoutStreamSourceConduit.java
@@ -19,6 +19,9 @@
 package io.undertow.conduits;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowOptions;
+import io.undertow.server.OpenListener;
+
 import org.xnio.ChannelListeners;
 import org.xnio.IoUtils;
 import org.xnio.Options;
@@ -45,6 +48,7 @@ public final class ReadTimeoutStreamSourceConduit extends AbstractStreamSourceCo
     private XnioExecutor.Key handle;
     private final StreamConnection connection;
     private volatile long expireTime = -1;
+    private final OpenListener openListener;
 
     private static final int FUZZ_FACTOR = 50; //we add 50ms to the timeout to make sure the underlying channel has actually timed out
 
@@ -52,11 +56,11 @@ public final class ReadTimeoutStreamSourceConduit extends AbstractStreamSourceCo
         @Override
         public void run() {
             handle = null;
-            if(expireTime == -1) {
+            if (expireTime == -1) {
                 return;
             }
             long current = System.currentTimeMillis();
-            if(current  < expireTime) {
+            if (current  < expireTime) {
                 //timeout has been bumped, re-schedule
                 handle = connection.getIoThread().executeAfter(timeoutCommand, (expireTime - current) + FUZZ_FACTOR, TimeUnit.MILLISECONDS);
                 return;
@@ -66,38 +70,39 @@ public final class ReadTimeoutStreamSourceConduit extends AbstractStreamSourceCo
             if (connection.getSourceChannel().isReadResumed()) {
                 ChannelListeners.invokeChannelListener(connection.getSourceChannel(), connection.getSourceChannel().getReadListener());
             }
-            if(connection.getSinkChannel().isWriteResumed()) {
+            if (connection.getSinkChannel().isWriteResumed()) {
                 ChannelListeners.invokeChannelListener(connection.getSinkChannel(), connection.getSinkChannel().getWriteListener());
             }
         }
     };
 
-    public ReadTimeoutStreamSourceConduit(final StreamSourceConduit delegate, StreamConnection connection) {
+    public ReadTimeoutStreamSourceConduit(final StreamSourceConduit delegate, StreamConnection connection, OpenListener openListener) {
         super(delegate);
         this.connection = connection;
+        this.openListener = openListener;
     }
 
     private void handleReadTimeout(final long ret) throws IOException {
-        if(!connection.isOpen()) {
+        if (!connection.isOpen()) {
             return;
         }
-        if(ret == 0 && handle != null) {
+        if (ret == 0 && handle != null) {
             return;
         }
-        long idleTimeout = connection.getSourceChannel().getOption(Options.READ_TIMEOUT);
-        if(idleTimeout <= 0) {
+        Integer timeout = getTimeout();
+        if (timeout == null || timeout <= 0) {
             return;
         }
         long currentTime = System.currentTimeMillis();
         long expireTimeVar = expireTime;
-        if(expireTimeVar != -1 && currentTime > expireTimeVar) {
+        if (expireTimeVar != -1 && currentTime > expireTimeVar) {
             IoUtils.safeClose(connection);
             throw new ClosedChannelException();
         }
-        expireTime = currentTime + idleTimeout;
+        expireTime = currentTime + timeout;
         XnioExecutor.Key key = handle;
         if (key == null) {
-            handle = connection.getIoThread().executeAfter(timeoutCommand, idleTimeout, TimeUnit.MILLISECONDS);
+            handle = connection.getIoThread().executeAfter(timeoutCommand, timeout, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -131,7 +136,7 @@ public final class ReadTimeoutStreamSourceConduit extends AbstractStreamSourceCo
 
     @Override
     public void awaitReadable() throws IOException {
-        Integer timeout = connection.getOption(Options.READ_TIMEOUT);
+        Integer timeout = getTimeout();
         if (timeout != null && timeout > 0) {
             super.awaitReadable(timeout + FUZZ_FACTOR, TimeUnit.MILLISECONDS);
         } else {
@@ -141,12 +146,23 @@ public final class ReadTimeoutStreamSourceConduit extends AbstractStreamSourceCo
 
     @Override
     public void awaitReadable(long time, TimeUnit timeUnit) throws IOException {
-        Integer timeout = connection.getOption(Options.READ_TIMEOUT);
+        Integer timeout = getTimeout();
         if (timeout != null && timeout > 0) {
             long millis = timeUnit.toMillis(time);
             super.awaitReadable(Math.min(millis, timeout + FUZZ_FACTOR), TimeUnit.MILLISECONDS);
         } else {
             super.awaitReadable(time, timeUnit);
         }
+    }
+
+    private Integer getTimeout() throws IOException {
+        Integer timeout = connection.getSourceChannel().getOption(Options.READ_TIMEOUT);
+        Integer idleTimeout = openListener.getUndertowOptions().get(UndertowOptions.IDLE_TIMEOUT);
+        if ((timeout == null || timeout <= 0) && idleTimeout != null) {
+            timeout = idleTimeout;
+        } else if (timeout != null && idleTimeout != null && idleTimeout > 0) {
+            timeout = Math.min(timeout, idleTimeout);
+        }
+        return timeout;
     }
 }

--- a/core/src/main/java/io/undertow/conduits/WriteTimeoutStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/WriteTimeoutStreamSinkConduit.java
@@ -19,6 +19,9 @@
 package io.undertow.conduits;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowOptions;
+import io.undertow.server.OpenListener;
+
 import org.xnio.ChannelListeners;
 import org.xnio.IoUtils;
 import org.xnio.Options;
@@ -35,7 +38,7 @@ import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Wrapper for read timeout. This should always be the first wrapper applied to the underlying channel.
+ * Wrapper for write timeout. This should always be the first wrapper applied to the underlying channel.
  *
  * @author Stuart Douglas
  * @see org.xnio.Options#READ_TIMEOUT
@@ -45,6 +48,7 @@ public final class WriteTimeoutStreamSinkConduit extends AbstractStreamSinkCondu
     private XnioExecutor.Key handle;
     private final StreamConnection connection;
     private volatile long expireTime = -1;
+    private final OpenListener openListener;
 
     private static final int FUZZ_FACTOR = 50; //we add 50ms to the timeout to make sure the underlying channel has actually timed out
 
@@ -52,11 +56,11 @@ public final class WriteTimeoutStreamSinkConduit extends AbstractStreamSinkCondu
         @Override
         public void run() {
             handle = null;
-            if(expireTime == -1) {
+            if (expireTime == -1) {
                 return;
             }
             long current = System.currentTimeMillis();
-            if(current  < expireTime) {
+            if (current  < expireTime) {
                 //timeout has been bumped, re-schedule
                 handle = connection.getIoThread().executeAfter(timeoutCommand, (expireTime - current) + FUZZ_FACTOR, TimeUnit.MILLISECONDS);
                 return;
@@ -66,38 +70,39 @@ public final class WriteTimeoutStreamSinkConduit extends AbstractStreamSinkCondu
             if (connection.getSourceChannel().isReadResumed()) {
                 ChannelListeners.invokeChannelListener(connection.getSourceChannel(), connection.getSourceChannel().getReadListener());
             }
-            if(connection.getSinkChannel().isWriteResumed()) {
+            if (connection.getSinkChannel().isWriteResumed()) {
                 ChannelListeners.invokeChannelListener(connection.getSinkChannel(), connection.getSinkChannel().getWriteListener());
             }
         }
     };
 
-    public WriteTimeoutStreamSinkConduit(final StreamSinkConduit delegate, StreamConnection connection) {
+    public WriteTimeoutStreamSinkConduit(final StreamSinkConduit delegate, StreamConnection connection, OpenListener openListener) {
         super(delegate);
         this.connection = connection;
+        this.openListener = openListener;
     }
 
     private void handleWriteTimeout(final long ret) throws IOException {
-        if(!connection.isOpen()) {
+        if (!connection.isOpen()) {
             return;
         }
-        if(ret == 0 && handle != null) {
+        if (ret == 0 && handle != null) {
             return;
         }
-        long idleTimeout = connection.getSourceChannel().getOption(Options.READ_TIMEOUT);
-        if(idleTimeout <= 0) {
+        Integer timeout = getTimeout();
+        if (timeout == null || timeout <= 0) {
             return;
         }
         long currentTime = System.currentTimeMillis();
         long expireTimeVar = expireTime;
-        if(expireTimeVar != -1 && currentTime > expireTimeVar) {
+        if (expireTimeVar != -1 && currentTime > expireTimeVar) {
             IoUtils.safeClose(connection);
             throw new ClosedChannelException();
         }
-        expireTime = currentTime + idleTimeout;
+        expireTime = currentTime + timeout;
         XnioExecutor.Key key = handle;
         if (key == null) {
-            handle = connection.getIoThread().executeAfter(timeoutCommand, idleTimeout, TimeUnit.MILLISECONDS);
+            handle = connection.getIoThread().executeAfter(timeoutCommand, timeout, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -145,7 +150,7 @@ public final class WriteTimeoutStreamSinkConduit extends AbstractStreamSinkCondu
 
     @Override
     public void awaitWritable() throws IOException {
-        Integer timeout = connection.getOption(Options.WRITE_TIMEOUT);
+        Integer timeout = getTimeout();
         if (timeout != null && timeout > 0) {
             super.awaitWritable(timeout + FUZZ_FACTOR, TimeUnit.MILLISECONDS);
         } else {
@@ -155,12 +160,23 @@ public final class WriteTimeoutStreamSinkConduit extends AbstractStreamSinkCondu
 
     @Override
     public void awaitWritable(long time, TimeUnit timeUnit) throws IOException {
-        Integer timeout = connection.getOption(Options.WRITE_TIMEOUT);
+        Integer timeout = getTimeout();
         if (timeout != null && timeout > 0) {
             long millis = timeUnit.toMillis(time);
             super.awaitWritable(Math.min(millis, timeout + FUZZ_FACTOR), TimeUnit.MILLISECONDS);
         } else {
             super.awaitWritable(time, timeUnit);
         }
+    }
+
+    private Integer getTimeout() throws IOException {
+        Integer timeout = connection.getSourceChannel().getOption(Options.WRITE_TIMEOUT);
+        Integer idleTimeout = openListener.getUndertowOptions().get(UndertowOptions.IDLE_TIMEOUT);
+        if ((timeout == null || timeout <= 0) && idleTimeout != null) {
+            timeout = idleTimeout;
+        } else if (timeout != null && idleTimeout != null && idleTimeout > 0) {
+            timeout = Math.min(timeout, idleTimeout);
+        }
+        return timeout;
     }
 }

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
@@ -65,6 +65,7 @@ public class AjpOpenListener implements OpenListener {
         parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, UTF_8), undertowOptions.get(DECODE_URL, true));
     }
 
+    @Override
     public void handleEvent(final StreamConnection channel) {
         if (UndertowLogger.REQUEST_LOGGER.isTraceEnabled()) {
             UndertowLogger.REQUEST_LOGGER.tracef("Opened connection with %s", channel.getPeerAddress());
@@ -74,22 +75,22 @@ public class AjpOpenListener implements OpenListener {
         try {
             Integer readTimeout = channel.getOption(Options.READ_TIMEOUT);
             Integer idleTimeout = undertowOptions.get(UndertowOptions.IDLE_TIMEOUT);
-            if((readTimeout == null || readTimeout <= 0) && idleTimeout != null) {
+            if ((readTimeout == null || readTimeout <= 0) && idleTimeout != null) {
                 readTimeout = idleTimeout;
-            } else if(readTimeout != null && idleTimeout != null && idleTimeout > 0) {
+            } else if (readTimeout != null && idleTimeout != null && idleTimeout > 0) {
                 readTimeout = Math.min(readTimeout, idleTimeout);
             }
             if (readTimeout != null && readTimeout > 0) {
-                channel.getSourceChannel().setConduit(new ReadTimeoutStreamSourceConduit(channel.getSourceChannel().getConduit(), channel));
+                channel.getSourceChannel().setConduit(new ReadTimeoutStreamSourceConduit(channel.getSourceChannel().getConduit(), channel, this));
             }
             Integer writeTimeout = channel.getOption(Options.WRITE_TIMEOUT);
-            if((writeTimeout == null || writeTimeout <= 0) && idleTimeout != null) {
+            if ((writeTimeout == null || writeTimeout <= 0) && idleTimeout != null) {
                 writeTimeout = idleTimeout;
-            } else if(writeTimeout != null && idleTimeout != null && idleTimeout > 0) {
+            } else if (writeTimeout != null && idleTimeout != null && idleTimeout > 0) {
                 writeTimeout = Math.min(writeTimeout, idleTimeout);
             }
             if (writeTimeout != null && writeTimeout > 0) {
-                channel.getSinkChannel().setConduit(new WriteTimeoutStreamSinkConduit(channel.getSinkChannel().getConduit(), channel));
+                channel.getSinkChannel().setConduit(new WriteTimeoutStreamSinkConduit(channel.getSinkChannel().getConduit(), channel, this));
             }
         } catch (IOException e) {
             IoUtils.safeClose(channel);
@@ -104,18 +105,22 @@ public class AjpOpenListener implements OpenListener {
         readListener.handleEvent(channel.getSourceChannel());
     }
 
+    @Override
     public HttpHandler getRootHandler() {
         return rootHandler;
     }
 
+    @Override
     public void setRootHandler(final HttpHandler rootHandler) {
         this.rootHandler = rootHandler;
     }
 
+    @Override
     public OptionMap getUndertowOptions() {
         return undertowOptions;
     }
 
+    @Override
     public void setUndertowOptions(final OptionMap undertowOptions) {
         if (undertowOptions == null) {
             throw UndertowMessages.MESSAGES.argumentCannotBeNull("undertowOptions");

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
@@ -63,6 +63,7 @@ public final class HttpOpenListener implements ChannelListener<StreamConnection>
         parser = HttpRequestParser.instance(undertowOptions);
     }
 
+    @Override
     public void handleEvent(final StreamConnection channel) {
         if (UndertowLogger.REQUEST_LOGGER.isTraceEnabled()) {
             UndertowLogger.REQUEST_LOGGER.tracef("Opened connection with %s", channel.getPeerAddress());
@@ -72,22 +73,22 @@ public final class HttpOpenListener implements ChannelListener<StreamConnection>
         try {
             Integer readTimeout = channel.getOption(Options.READ_TIMEOUT);
             Integer idleTimeout = undertowOptions.get(UndertowOptions.IDLE_TIMEOUT);
-            if((readTimeout == null || readTimeout <= 0) && idleTimeout != null) {
+            if ((readTimeout == null || readTimeout <= 0) && idleTimeout != null) {
                 readTimeout = idleTimeout;
-            } else if(readTimeout != null && idleTimeout != null && idleTimeout > 0) {
+            } else if (readTimeout != null && idleTimeout != null && idleTimeout > 0) {
                 readTimeout = Math.min(readTimeout, idleTimeout);
             }
             if (readTimeout != null && readTimeout > 0) {
-                channel.getSourceChannel().setConduit(new ReadTimeoutStreamSourceConduit(channel.getSourceChannel().getConduit(), channel));
+                channel.getSourceChannel().setConduit(new ReadTimeoutStreamSourceConduit(channel.getSourceChannel().getConduit(), channel, this));
             }
             Integer writeTimeout = channel.getOption(Options.WRITE_TIMEOUT);
-            if((writeTimeout == null || writeTimeout <= 0) && idleTimeout != null) {
+            if ((writeTimeout == null || writeTimeout <= 0) && idleTimeout != null) {
                 writeTimeout = idleTimeout;
-            } else if(writeTimeout != null && idleTimeout != null && idleTimeout > 0) {
+            } else if (writeTimeout != null && idleTimeout != null && idleTimeout > 0) {
                 writeTimeout = Math.min(writeTimeout, idleTimeout);
             }
             if (writeTimeout != null && writeTimeout > 0) {
-                channel.getSinkChannel().setConduit(new WriteTimeoutStreamSinkConduit(channel.getSinkChannel().getConduit(), channel));
+                channel.getSinkChannel().setConduit(new WriteTimeoutStreamSinkConduit(channel.getSinkChannel().getConduit(), channel, this));
             }
         } catch (IOException e) {
             IoUtils.safeClose(channel);


### PR DESCRIPTION
I'm not sure which is correct to use here.

```
connection.getSourceChannel().getOption(Options.READ_TIMEOUT);
```

or

```
connection.getOption(Options.READ_TIMEOUT);
```
