### PR TITLE
[undertow-core] Added a support to read the cookie value as JSON object

### DIFF
--- a/core/src/main/java/io/undertow/util/Cookies.java
+++ b/core/src/main/java/io/undertow/util/Cookies.java
@@ -205,6 +205,7 @@ public class Cookies {
         int state = 0;
         String name = null;
         int start = 0;
+        int braceBalance = 0;
         int cookieCount = parsedCookies.size();
         final Map<String, String> cookies = new HashMap<>();
         final Map<String, String> additional = new HashMap<>();
@@ -242,6 +243,10 @@ public class Cookies {
                     } else if (c == '"') {
                         state = 3;
                         start = i + 1;
+                    } else if (c == '{') {
+                        state = 5;
+                        start = i;
+                        braceBalance = 0;
                     } else if (!allowEqualInValue && c == '=') {
                         cookieCount = createCookie(name, cookie.substring(start, i), maxCookies, cookieCount, cookies, additional);
                         state = 4;
@@ -264,6 +269,20 @@ public class Cookies {
                         state = 0;
                     }
                     start = i + 1;
+                    break;
+                }
+                case 5: {
+                    //extract JSON value
+                    if (c == '{') {
+                       braceBalance += 1;
+                    }
+                    if (c == '}' && braceBalance == 0) {
+                        cookieCount = createCookie(name, cookie.substring(start, (i + 1)), maxCookies, cookieCount, cookies, additional);
+                        state = 0;
+                        start = i + 1;
+                    } else if (c == '}' && braceBalance > 0) {
+                        braceBalance -= 1;
+                    }
                     break;
                 }
             }

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -154,4 +154,54 @@ public class CookiesTestCase {
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
     }
+
+    @Test
+    public void testSimpleJSONObjectInRequestCookies() {
+        Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, false, Arrays.asList(
+                "CUSTOMER={\"v1\":1, \"id\":\"some_unique_id\", \"c\":\"http://www.google.com?q=love me\"};"
+                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"));
+
+        Cookie cookie = cookies.get("CUSTOMER");
+        Assert.assertEquals("CUSTOMER", cookie.getName());
+        Assert.assertEquals("{\"v1\":1, \"id\":\"some_unique_id\", \"c\":\"http://www.google.com?q=love me\"}",
+               cookie.getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookie.getDomain());
+        Assert.assertEquals(1, cookie.getVersion());
+        Assert.assertEquals("/", cookie.getPath());
+
+        cookie = cookies.get("SHIPPING");
+        Assert.assertEquals("SHIPPING", cookie.getName());
+        Assert.assertEquals("FEDEX", cookie.getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookie.getDomain());
+        Assert.assertEquals(1, cookie.getVersion());
+        Assert.assertEquals("/", cookie.getPath());
+    }
+
+    @Test
+    public void testComplexJSONObjectInRequestCookies() {
+        Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, false, Arrays.asList(
+                "CUSTOMER={ \"accounting\" : [ { \"firstName\" : \"John\", \"lastName\" : \"Doe\", \"age\" : 23 },"
+                + " { \"firstName\" : \"Mary\",  \"lastName\" : \"Smith\", \"age\" : 32 }], "
+                + "\"sales\" : [ { \"firstName\" : \"Sally\", \"lastName\" : \"Green\", \"age\" : 27 }, "
+                + "{ \"firstName\" : \"Jim\", \"lastName\" : \"Galley\", \"age\" : 41 } ] };"
+                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"));
+
+        Cookie cookie = cookies.get("CUSTOMER");
+        Assert.assertEquals("CUSTOMER", cookie.getName());
+        Assert.assertEquals("{ \"accounting\" : [ { \"firstName\" : \"John\", \"lastName\" : \"Doe\", \"age\" : 23 },"
+                + " { \"firstName\" : \"Mary\",  \"lastName\" : \"Smith\", \"age\" : 32 }], "
+                + "\"sales\" : [ { \"firstName\" : \"Sally\", \"lastName\" : \"Green\", \"age\" : 27 }, "
+                + "{ \"firstName\" : \"Jim\", \"lastName\" : \"Galley\", \"age\" : 41 } ] }",
+               cookie.getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookie.getDomain());
+        Assert.assertEquals(1, cookie.getVersion());
+        Assert.assertEquals("/", cookie.getPath());
+
+        cookie = cookies.get("SHIPPING");
+        Assert.assertEquals("SHIPPING", cookie.getName());
+        Assert.assertEquals("FEDEX", cookie.getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookie.getDomain());
+        Assert.assertEquals(1, cookie.getVersion());
+        Assert.assertEquals("/", cookie.getPath());
+    }
 }


### PR DESCRIPTION
This will add a support to parse cookie value as JSON string. Cookie header value was not correctly parsed when cookie value is JSON string and if JSON string has '=' sign, then code was throwing IllegalArgumentException.
