### PR TITLE
Support running in JVM bootstrap class loader

### DIFF
--- a/core/src/main/java/io/undertow/client/http/HttpResponseParser.java
+++ b/core/src/main/java/io/undertow/client/http/HttpResponseParser.java
@@ -110,7 +110,7 @@ abstract class HttpResponseParser {
 
     static {
         try {
-            final Class<?> cls = HttpResponseParser.class.getClassLoader().loadClass(HttpResponseParser.class.getName() + "$$generated");
+            final Class<?> cls = Class.forName(HttpResponseParser.class.getName() + "$$generated", false, HttpResponseParser.class.getClassLoader());
             INSTANCE = (HttpResponseParser) cls.newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/io/undertow/client/http2/Http2ClientProvider.java
+++ b/core/src/main/java/io/undertow/client/http2/Http2ClientProvider.java
@@ -70,8 +70,8 @@ public class Http2ClientProvider implements ClientProvider {
     static {
         Method npnPutMethod;
         try {
-            Class<?> npnClass = Http2ClientProvider.class.getClassLoader().loadClass("org.eclipse.jetty.alpn.ALPN");
-            npnPutMethod = npnClass.getDeclaredMethod("put", SSLEngine.class, Http2ClientProvider.class.getClassLoader().loadClass("org.eclipse.jetty.alpn.ALPN$Provider"));
+            Class<?> npnClass = Class.forName("org.eclipse.jetty.alpn.ALPN", false, Http2ClientProvider.class.getClassLoader());
+            npnPutMethod = npnClass.getDeclaredMethod("put", SSLEngine.class, Class.forName("org.eclipse.jetty.alpn.ALPN$Provider", false, Http2ClientProvider.class.getClassLoader()));
         } catch (Exception e) {
             UndertowLogger.CLIENT_LOGGER.jettyALPNNotFound("HTTP2");
             npnPutMethod = null;

--- a/core/src/main/java/io/undertow/client/spdy/SpdyClientProvider.java
+++ b/core/src/main/java/io/undertow/client/spdy/SpdyClientProvider.java
@@ -73,8 +73,8 @@ public class SpdyClientProvider implements ClientProvider {
     static {
         Method npnPutMethod;
         try {
-            Class<?> npnClass = SpdyClientProvider.class.getClassLoader().loadClass("org.eclipse.jetty.alpn.ALPN");
-            npnPutMethod = npnClass.getDeclaredMethod("put", SSLEngine.class, SpdyClientProvider.class.getClassLoader().loadClass("org.eclipse.jetty.alpn.ALPN$Provider"));
+            Class<?> npnClass = Class.forName("org.eclipse.jetty.alpn.ALPN", false, SpdyClientProvider.class.getClassLoader());
+            npnPutMethod = npnClass.getDeclaredMethod("put", SSLEngine.class, Class.forName("org.eclipse.jetty.alpn.ALPN$Provider", false, SpdyClientProvider.class.getClassLoader()));
         } catch (Exception e) {
             UndertowLogger.CLIENT_LOGGER.jettyALPNNotFound("SPDY");
             npnPutMethod = null;

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -182,7 +182,7 @@ public abstract class HttpRequestParser {
 
     public static final HttpRequestParser instance(final OptionMap options) {
         try {
-            final Class<?> cls = HttpRequestParser.class.getClassLoader().loadClass(HttpRequestParser.class.getName() + "$$generated");
+            final Class<?> cls = Class.forName(HttpRequestParser.class.getName() + "$$generated", false, HttpRequestParser.class.getClassLoader());
 
             Constructor<?> ctor = cls.getConstructor(OptionMap.class);
             return (HttpRequestParser) ctor.newInstance(options);


### PR DESCRIPTION
Hi, I'd like to use undertow in a java agent that runs in the bootstrap class loader.  This causes NullPointerExceptions in a couple of places because getClassLoader() returns null for classes in the bootstrap class loader, e.g.

```
HttpResponseParser.class.getClassLoader().loadClass("...")
```

This pull request uses Class.forName() instead, which works equally well in the bootstrap class loader, e.g.

```
Class.forName("...", false, HttpResponseParser.class.getClassLoader())
```
