### PR TITLE
UNDERTOW-265 Added Parse Timeout

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -176,4 +176,8 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = Logger.Level.ERROR)
     @Message(id = 5034, value = "Remote endpoint failed to send initial settings frame in HTTP2 connection")
     void remoteEndpointFailedToSendInitialSettings();
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 5035, value = "Closing channel because of parse timeout for remote address %s")
+    void parseRequestTimedOut(java.net.SocketAddress remoteAddress);
 }

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -59,6 +59,13 @@ public class UndertowOptions {
     public static final Option<Integer> IDLE_TIMEOUT = Option.simple(UndertowOptions.class, "IDLE_TIMEOUT", Integer.class);
 
     /**
+     * The maximum allowed time of reading HTTP request in milliseconds.
+     *
+     * <code>-1</code> or missing value disables this functionality.
+     */
+    public static final Option<Integer> REQUEST_PARSE_TIMEOUT = Option.simple(UndertowOptions.class, "REQUEST_PARSE_TIMEOUT", Integer.class);
+
+    /**
      * The maximum number of parameters that will be parsed. This is used to protect against hash vulnerabilities.
      * <p/>
      * This applies to both query parameters, and to POST data, but is not cumulative (i.e. you can potentially have

--- a/core/src/main/java/io/undertow/server/protocol/http/ParseTimeoutUpdater.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ParseTimeoutUpdater.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.protocol.http;
+
+import io.undertow.UndertowLogger;
+import org.xnio.IoUtils;
+import org.xnio.XnioExecutor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wrapper for parse timeout.
+ *
+ * @author Sebastian Laskawiec
+ * @see io.undertow.UndertowOptions#REQUEST_PARSE_TIMEOUT
+ */
+final class ParseTimeoutUpdater {
+
+    private final HttpServerConnection connection;
+    private final int requestParseTimeout;
+    private volatile XnioExecutor.Key handle;
+    private volatile long expireTime = -1;
+
+    //we add 50ms to the timeout to make sure the underlying channel has actually timed out
+    private static final int FUZZ_FACTOR = 50;
+
+    private final Runnable timeoutCommand = new Runnable() {
+        @Override
+        public void run() {
+            handle = null;
+            if (shouldPerformClose()) {
+                UndertowLogger.REQUEST_LOGGER.parseRequestTimedOut(connection.getChannel().getPeerAddress());
+                IoUtils.safeClose(connection);
+            }
+        }
+    };
+
+    /**
+     * Creates new instance of ParseTimeoutSourceConduit.
+     *
+     * @param channel             Channel which will be closed in case of timeout.
+     * @param requestParseTimeout Timeout value. Negative value will indicate that this updated is disabled.
+     */
+    public ParseTimeoutUpdater(HttpServerConnection channel, int requestParseTimeout) {
+        this.connection = channel;
+        this.requestParseTimeout = requestParseTimeout;
+    }
+
+    /**
+     * Needs to be called at least once to start working.
+     * <p>
+     * This method should be called inside parsing loop. This way Parse Timeout will be kicked off at the first
+     * time.
+     * </p>
+     */
+    public void update() {
+        if(isEnabled() && hasOpenConnection() && !hasScheduledTimeout()) {
+            expireTime = System.currentTimeMillis() + requestParseTimeout + FUZZ_FACTOR;
+            handle = connection.getIoThread().executeAfter(timeoutCommand, requestParseTimeout, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * Cancels timeout countdown.
+     * <p>
+     * Should be called after parsing is complete (to avoid closing connection during other activities).
+     * </p>
+     */
+    public void cancel() {
+        if (isEnabled() && hasScheduledTimeout()) {
+            // boundary condition - when the other thread is scheduled to execute timeout,
+            // the last thing to do is to check if parsing hadn't had finish. We might do this with expireTime
+            // (which is volatile).
+            expireTime = -1;
+            handle.remove();
+        }
+    }
+
+    private boolean hasScheduledTimeout() {
+        return handle != null;
+    }
+
+    private boolean isEnabled() {
+        return requestParseTimeout > 0;
+    }
+
+    /*
+     * This is the last check before closing connection. If the parsing completes (even if timeout is already
+     * executing) expiryTime set to negative value might cancel it.
+     */
+    private boolean shouldPerformClose() {
+        return expireTime > 0;
+    }
+
+    private boolean hasOpenConnection() {
+        return connection.isOpen();
+    }
+}

--- a/core/src/test/java/io/undertow/server/ParseTimeoutTestCase.java
+++ b/core/src/test/java/io/undertow/server/ParseTimeoutTestCase.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server;
+
+import io.undertow.UndertowOptions;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.ProxyIgnore;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
+import org.xnio.OptionMap;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+@RunWith(DefaultServer.class)
+@ProxyIgnore
+@HttpOneOnly
+public class ParseTimeoutTestCase {
+
+    private Socket client;
+    private OutputStream clientOutputStream;
+    private InputStream clientInputStream;
+
+    @Before
+    public void before() throws Exception {
+        client = new Socket();
+        client.connect(DefaultServer.getDefaultServerAddress());
+        clientOutputStream = client.getOutputStream();
+        clientInputStream = client.getInputStream();
+    }
+
+    public void after() throws Exception {
+        IoUtils.safeClose(client);
+        DefaultServer.setUndertowOptions(OptionMap.EMPTY);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        DefaultServer.setUndertowOptions(OptionMap.create(UndertowOptions.REQUEST_PARSE_TIMEOUT, 10));
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        DefaultServer.setUndertowOptions(OptionMap.EMPTY);
+    }
+
+    @Test(timeout = 10000)
+    public void testClosingConnectionWhenParsingHeadersForTooLong() throws Exception {
+        //given
+        DefaultServer.setRootHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) {
+                fail("Parser should never end its job, since we are streaming headers.");
+            }
+        });
+
+        String request = "GET / HTTP/1.1\r\nHost:localhost";
+
+        //when
+        clientOutputStream.write(request.getBytes());
+        clientOutputStream.flush();
+
+        Thread.sleep(100);
+
+        //then
+        assertEquals(-1, clientInputStream.read());
+    }
+}


### PR DESCRIPTION
Hi!

Please take a look at implementation of: https://issues.jboss.org/browse/UNDERTOW-265

Changes included:
- Added REQUEST_PARSE_TIMEOUT which is disabled by default
- Min value of REQUEST_PARSE_TIMEOUT is set to 51 (1 + MIN_PARSE_TIMEOUT)
- Added proper logger message
- Removed final from HttpServerConnection - needed for mocking

Best regards
Sebastian
