### PR TITLE
Use the correct SSLSession during handshake.

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
@@ -124,7 +124,7 @@ public class AlpnOpenListener implements ChannelListener<StreamConnection> {
                 }
 
                 if (match != null) {
-                    sslEngine.getSession().putValue(PROTOCOL_KEY, match);
+                    sslEngine.getHandshakeSession().putValue(PROTOCOL_KEY, match);
                     return potentialConnection.selected = match;
                 }
 


### PR DESCRIPTION
During a handshake, SSLEngine returns a global shared dummy instance
for calls to getSession(). Setting a value on this results in all
future connections using the value of the first.
