### PR TITLE
Fix testsuite failures on windows.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -194,6 +194,8 @@
                         <test.level>${test.level}</test.level>
                         <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
                         <alpn-boot-string>${alpn-boot-string}</alpn-boot-string>
+                        <!-- to make testsuite pass on windows -->
+                        <sun.net.useExclusiveBind>false</sun.net.useExclusiveBind>
                     </systemPropertyVariables>
                     <argLine>${alpn-boot-string} ${jacoco.agent.argLine}</argLine>
                 </configuration>


### PR DESCRIPTION
add -Dsun.net.useExclusiveBind=false as JDK7u25 on windows changed to use exclusive socket by default
