### PR TITLE
Fix : Can't handle CJK multibyte request in AJP parameter value

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParseState.java
@@ -18,6 +18,8 @@
 
 package io.undertow.server.protocol.ajp;
 
+import java.util.ArrayList;
+
 /**
  * Abstract AJP parse state. Stores state common to both request and response parsers
  *
@@ -35,7 +37,7 @@ public class AbstractAjpParseState {
      * The current string being read
      */
     public StringBuilder currentString;
-
+    public ArrayList<Byte> currentBytes;
     /**
      * when reading the first byte of an integer this stores the first value. It is set to -1 to signify that
      * the first byte has not been read yet.

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParser.java
@@ -48,7 +48,7 @@ public abstract class AbstractAjpParser {
         }
     }
 
-    protected StringHolder parseString(ByteBuffer buf, AbstractAjpParseState state, boolean header) {
+    protected StringHolder parseString(ByteBuffer buf, AbstractAjpParseState state, String encoding, boolean header) {
         boolean containsUrlCharacters = state.containsUrlCharacters;
         if (!buf.hasRemaining()) {
             return new StringHolder(null, false, false);
@@ -83,18 +83,28 @@ public abstract class AbstractAjpParser {
             state.currentString = builder;
         }
         int length = builder.length();
+
+        byte[] b = new byte[stringLength];
+        int count = 0;
+
         while (length < stringLength) {
             if (!buf.hasRemaining()) {
                 state.stringLength = stringLength;
                 state.containsUrlCharacters = containsUrlCharacters;
                 return new StringHolder(null, false, false);
             }
-            char c = (char) buf.get();
-            if(c == '+' || c == '%') {
+            byte c = buf.get();
+            if((char)c == '+' || (char)c == '%') {
                 containsUrlCharacters = true;
             }
-            builder.append(c);
+            b[count++] = c;
             ++length;
+        }
+
+        try {
+            builder.append(new String(b, encoding));
+        } catch (Exception e) {
+            e.printStackTrace();
         }
 
         if (buf.hasRemaining()) {

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AbstractAjpParser.java
@@ -20,7 +20,9 @@ package io.undertow.server.protocol.ajp;
 
 import io.undertow.util.HttpString;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 
 /**
  * @author Stuart Douglas
@@ -48,10 +50,10 @@ public abstract class AbstractAjpParser {
         }
     }
 
-    protected StringHolder parseString(ByteBuffer buf, AbstractAjpParseState state, String encoding, boolean header) {
+    protected StringHolder parseString(ByteBuffer buf, AbstractAjpParseState state, boolean header, boolean isAttribute) {
         boolean containsUrlCharacters = state.containsUrlCharacters;
         if (!buf.hasRemaining()) {
-            return new StringHolder(null, false, false);
+            return new StringHolder(null, null, false, false);
         }
         int stringLength = state.stringLength;
         if (stringLength == -1) {
@@ -61,7 +63,7 @@ public abstract class AbstractAjpParser {
                 stringLength = ((0xFF & number) << 8) + (b & 0xFF);
             } else {
                 state.stringLength = number | STRING_LENGTH_MASK;
-                return new StringHolder(null, false, false);
+                return new StringHolder(null, null, false, false);
             }
         } else if ((stringLength & STRING_LENGTH_MASK) != 0) {
             int number = stringLength & ~STRING_LENGTH_MASK;
@@ -74,37 +76,37 @@ public abstract class AbstractAjpParser {
         if (stringLength == 0xFFFF) {
             //OxFFFF means null
             state.stringLength = -1;
-            return new StringHolder(null, true, false);
+            return new StringHolder(null, null, true, false);
         }
         StringBuilder builder = state.currentString;
-
         if (builder == null) {
             builder = new StringBuilder();
             state.currentString = builder;
         }
+
+        ArrayList<Byte> byteArray = state.currentBytes;
+        if( byteArray == null ) {
+            byteArray = new ArrayList<Byte>();
+            state.currentBytes = byteArray;
+        }
+
         int length = builder.length();
-
-        byte[] b = new byte[stringLength];
-        int count = 0;
-
         while (length < stringLength) {
             if (!buf.hasRemaining()) {
                 state.stringLength = stringLength;
                 state.containsUrlCharacters = containsUrlCharacters;
-                return new StringHolder(null, false, false);
+                return new StringHolder(null, null, false, false);
             }
             byte c = buf.get();
             if((char)c == '+' || (char)c == '%') {
                 containsUrlCharacters = true;
             }
-            b[count++] = c;
-            ++length;
-        }
 
-        try {
-            builder.append(new String(b, encoding));
-        } catch (Exception e) {
-            e.printStackTrace();
+            if( isAttribute ) {
+                byteArray.add(c);
+            }
+            builder.append((char)c);
+            ++length;
         }
 
         if (buf.hasRemaining()) {
@@ -112,11 +114,11 @@ public abstract class AbstractAjpParser {
             state.currentString = null;
             state.stringLength = -1;
             state.containsUrlCharacters = false;
-            return new StringHolder(builder.toString(), true, containsUrlCharacters);
+            return new StringHolder(builder.toString(), byteArray, true, containsUrlCharacters);
         } else {
             state.stringLength = stringLength;
             state.containsUrlCharacters = containsUrlCharacters;
-            return new StringHolder(null, false, false);
+            return new StringHolder(null, null, false, false);
         }
     }
 
@@ -134,12 +136,14 @@ public abstract class AbstractAjpParser {
 
     protected static class StringHolder {
         public final String value;
+        public ArrayList<Byte> bytes = new ArrayList<Byte>();
         public final HttpString header;
         public final boolean readComplete;
         public final boolean containsUrlCharacters;
 
-        private StringHolder(String value, boolean readComplete, boolean containsUrlCharacters) {
+        private StringHolder(String value, ArrayList<Byte> byteValue, boolean readComplete, boolean containsUrlCharacters) {
             this.value = value;
+            this.bytes = byteValue;
             this.readComplete = readComplete;
             this.containsUrlCharacters = containsUrlCharacters;
             this.header = null;
@@ -150,6 +154,22 @@ public abstract class AbstractAjpParser {
             this.readComplete = true;
             this.header = value;
             this.containsUrlCharacters = false;
+        }
+
+        public String getByteString(String encoding) {
+            byte[] data = new byte[bytes.size()];
+            for (int i = 0; i < data.length; i++) {
+                data[i] = (byte) bytes.get(i);
+            }
+
+            String str = null;
+            try {
+                str = new String(data, encoding);
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+
+            return str;
         }
     }
 }

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -222,7 +222,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_PROTOCOL: {
-                StringHolder result = parseString(buf, state, encoding, false);
+                StringHolder result = parseString(buf, state, false, false);
                 if (result.readComplete) {
                     //TODO: more efficient way of doing this
                     exchange.setProtocol(HttpString.tryFromString(result.value));
@@ -232,7 +232,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REQUEST_URI: {
-                StringHolder result = parseString(buf, state, encoding, false);
+                StringHolder result = parseString(buf, state, false, false);
                 if (result.readComplete) {
                     int colon = result.value.indexOf(';');
                     if (colon == -1) {
@@ -254,7 +254,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REMOTE_ADDR: {
-                StringHolder result = parseString(buf, state, encoding, false);
+                StringHolder result = parseString(buf, state, false, false);
                 if (result.readComplete) {
                     state.remoteAddress = result.value;
                 } else {
@@ -263,7 +263,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REMOTE_HOST: {
-                StringHolder result = parseString(buf, state, encoding, false);
+                StringHolder result = parseString(buf, state, false, false);
                 if (result.readComplete) {
                     //exchange.setRequestURI(result.value);
                 } else {
@@ -272,7 +272,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_SERVER_NAME: {
-                StringHolder result = parseString(buf, state, encoding, false);
+                StringHolder result = parseString(buf, state, false, false);
                 if (result.readComplete) {
                     state.serverAddress = result.value;
                 } else {
@@ -315,7 +315,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 int readHeaders = state.readHeaders;
                 while (readHeaders < state.numHeaders) {
                     if (state.currentHeader == null) {
-                        StringHolder result = parseString(buf, state, encoding, true);
+                        StringHolder result = parseString(buf, state, true, false);
                         if (!result.readComplete) {
                             state.state = AjpRequestParseState.READING_HEADERS;
                             state.readHeaders = readHeaders;
@@ -327,7 +327,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                             state.currentHeader = HttpString.tryFromString(result.value);
                         }
                     }
-                    StringHolder result = parseString(buf, state, encoding, false);
+                    StringHolder result = parseString(buf, state, false, false);
                     if (!result.readComplete) {
                         state.state = AjpRequestParseState.READING_HEADERS;
                         state.readHeaders = readHeaders;
@@ -357,7 +357,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                         }
                     }
                     if (state.currentIntegerPart == 1) {
-                        StringHolder result = parseString(buf, state, encoding, false);
+                        StringHolder result = parseString(buf, state, false, true);
                         if (!result.readComplete) {
                             state.state = AjpRequestParseState.READING_ATTRIBUTES;
                             return;
@@ -374,12 +374,13 @@ public class AjpRequestParser extends AbstractAjpParser {
                         }
                         result = Integer.toString(resultHolder.value);
                     } else {
-                        StringHolder resultHolder = parseString(buf, state, encoding, false);
+                        StringHolder resultHolder = parseString(buf, state, false, true);
                         if (!resultHolder.readComplete) {
                             state.state = AjpRequestParseState.READING_ATTRIBUTES;
                             return;
                         }
-                        result = resultHolder.value;
+//                        result = resultHolder.value;
+                        result = resultHolder.getByteString(encoding);
                     }
                     //query string.
                     if (state.currentAttribute.equals(QUERY_STRING)) {

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -222,7 +222,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_PROTOCOL: {
-                StringHolder result = parseString(buf, state, false);
+                StringHolder result = parseString(buf, state, encoding, false);
                 if (result.readComplete) {
                     //TODO: more efficient way of doing this
                     exchange.setProtocol(HttpString.tryFromString(result.value));
@@ -232,7 +232,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REQUEST_URI: {
-                StringHolder result = parseString(buf, state, false);
+                StringHolder result = parseString(buf, state, encoding, false);
                 if (result.readComplete) {
                     int colon = result.value.indexOf(';');
                     if (colon == -1) {
@@ -254,7 +254,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REMOTE_ADDR: {
-                StringHolder result = parseString(buf, state, false);
+                StringHolder result = parseString(buf, state, encoding, false);
                 if (result.readComplete) {
                     state.remoteAddress = result.value;
                 } else {
@@ -263,7 +263,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_REMOTE_HOST: {
-                StringHolder result = parseString(buf, state, false);
+                StringHolder result = parseString(buf, state, encoding, false);
                 if (result.readComplete) {
                     //exchange.setRequestURI(result.value);
                 } else {
@@ -272,7 +272,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 }
             }
             case AjpRequestParseState.READING_SERVER_NAME: {
-                StringHolder result = parseString(buf, state, false);
+                StringHolder result = parseString(buf, state, encoding, false);
                 if (result.readComplete) {
                     state.serverAddress = result.value;
                 } else {
@@ -315,7 +315,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                 int readHeaders = state.readHeaders;
                 while (readHeaders < state.numHeaders) {
                     if (state.currentHeader == null) {
-                        StringHolder result = parseString(buf, state, true);
+                        StringHolder result = parseString(buf, state, encoding, true);
                         if (!result.readComplete) {
                             state.state = AjpRequestParseState.READING_HEADERS;
                             state.readHeaders = readHeaders;
@@ -327,7 +327,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                             state.currentHeader = HttpString.tryFromString(result.value);
                         }
                     }
-                    StringHolder result = parseString(buf, state, false);
+                    StringHolder result = parseString(buf, state, encoding, false);
                     if (!result.readComplete) {
                         state.state = AjpRequestParseState.READING_HEADERS;
                         state.readHeaders = readHeaders;
@@ -357,7 +357,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                         }
                     }
                     if (state.currentIntegerPart == 1) {
-                        StringHolder result = parseString(buf, state, false);
+                        StringHolder result = parseString(buf, state, encoding, false);
                         if (!result.readComplete) {
                             state.state = AjpRequestParseState.READING_ATTRIBUTES;
                             return;
@@ -374,7 +374,7 @@ public class AjpRequestParser extends AbstractAjpParser {
                         }
                         result = Integer.toString(resultHolder.value);
                     } else {
-                        StringHolder resultHolder = parseString(buf, state, false);
+                        StringHolder resultHolder = parseString(buf, state, encoding, false);
                         if (!resultHolder.readComplete) {
                             state.state = AjpRequestParseState.READING_ATTRIBUTES;
                             return;


### PR DESCRIPTION
### Problem :

In HTTP protocol hander can handle multibyte character set. My case use EUC-KR character set.  Tested in Wildfly 8.2 GA.
```xml
            <server name="default-server">
                <ajp-listener name="ajp" socket-binding="ajp" url-charset="EUC-KR"/>
                <http-listener name="default" socket-binding="http" url-charset="EUC-KR"/>
```
http://localhost:8080/test/test.jsp?param=한글

But, When I use AJP protocol can't handle EUC-KR character set.
http://localhost/test/test.jsp?param=한글

Query param's value are not '한글', it  prints '??'.
Similar cases are in https://developer.jboss.org/thread/242677?start=0&tstart=0

### Reason :

I found that it cause of handle byte as a char in AbstractAjpParser. 
Multibyte(CJK ; Chinese, Japanese, Korean) character set are use most significant bit. So, when byte are casted to char, multibytes informations are eliminated.

Thanks for your great **'undertow'**.


