### PR TITLE
FileResourceManager not handling multiple safe paths properly

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/FileResourceManager.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/FileResourceManager.java
@@ -247,9 +247,11 @@ public class FileResourceManager implements ResourceManager {
                     /*
                      * Absolute path
                      */
-                    return safePath.length() > 0 &&
-                            canonicalPath.length() >= safePath.length() &&
-                            canonicalPath.startsWith(safePath);
+                    if (safePath.length() > 0 &&
+                        canonicalPath.length() >= safePath.length() &&
+                        canonicalPath.startsWith(safePath)) {
+                        return true;
+                    }
                 } else {
                     /*
                      * In relative path we build the path appending to base
@@ -257,9 +259,11 @@ public class FileResourceManager implements ResourceManager {
                     String absSafePath = base + '/' + safePath;
                     File absSafePathFile = new File(absSafePath);
                     String canonicalSafePath = absSafePathFile.getCanonicalPath();
-                    return canonicalSafePath.length() > 0 &&
-                            canonicalPath.length() >= canonicalSafePath.length() &&
-                            canonicalPath.startsWith(canonicalSafePath);
+                    if (canonicalSafePath.length() > 0 &&
+                        canonicalPath.length() >= canonicalSafePath.length() &&
+                        canonicalPath.startsWith(canonicalSafePath)) {
+                        return true;
+                    }
 
                 }
             }


### PR DESCRIPTION
isSymlinkSafe() fixed so that it iterates through all entries in safePaths. Previous behavior was that it would return true/false on the first iteration.

I ran into the issue when trying to configure symbolic link following in FileResourceManager. In my project there are two symlinked folders inside the main deployment folder, and it turned out that it was able to process symlinks only if there was a single string in safePaths parameter.