### PR TITLE
HttpServletRequestImpl.toString()

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -1078,4 +1078,10 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
         }
         return sessionCookieSource;
     }
+
+    @Override
+    public String toString() {
+        return "HttpServletRequestImpl [ " + getMethod() + ' ' + getRequestURI() + " ]";
+    }
+
 }


### PR DESCRIPTION
HttpServletRequest is used as an event payload for @Initialzied(RequestScoped) CDI events. Having a nice toString() makes inspecting events easier plus the object looks better in a debugger