### PR TITLE
UNDERTOW-387 Fixed parsing of boundary from Content-Type header to ignore semicolon

### DIFF
--- a/core/src/main/java/io/undertow/util/Headers.java
+++ b/core/src/main/java/io/undertow/util/Headers.java
@@ -251,7 +251,7 @@ public final class Headers {
         int start = pos + key.length() + 1;
         for (end = start; end < header.length(); ++end) {
             char c = header.charAt(end);
-            if (c == ' ' || c == '\t') {
+            if (c == ' ' || c == '\t' || c == ';') {
                 break;
             }
         }

--- a/core/src/test/java/io/undertow/util/HeadersUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeadersUtilsTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests param extraction of a header
+ *
+ * @author Tim Terlegård
+ */
+public class HeadersUtilsTestCase {
+
+    @Test
+    public void testTokenExtraction() {
+
+        Assert.assertEquals("--xyz", Headers.extractTokenFromHeader("multipart/form-data; boundary=--xyz; param=abc", "boundary"));
+    }
+
+}


### PR DESCRIPTION
Merging this fix to 1.1 branch