### PR TITLE
avoid querying resource for content type if not needed

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
@@ -277,9 +277,9 @@ public class ResourceHandler implements HttpHandler {
                     }
                 }
                 //we are going to proceed. Set the appropriate headers
-                final String contentType = resource.getContentType(mimeMappings);
 
                 if (!exchange.getResponseHeaders().contains(Headers.CONTENT_TYPE)) {
+                    final String contentType = resource.getContentType(mimeMappings);
                     if (contentType != null) {
                         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, contentType);
                     } else {


### PR DESCRIPTION
The resource can specify its mime type, but only if the exchange does not have one already. Therefore move the inquiry inside the conditional block.