### PR TITLE
[UNDERTOW-421] Deprecate the getIdentityManager method on the SecurityContext

### DIFF
--- a/core/src/main/java/io/undertow/security/api/SecurityContext.java
+++ b/core/src/main/java/io/undertow/security/api/SecurityContext.java
@@ -17,10 +17,10 @@
  */
 package io.undertow.security.api;
 
-import java.util.List;
-
 import io.undertow.security.idm.Account;
 import io.undertow.security.idm.IdentityManager;
+
+import java.util.List;
 
 /**
  * The security context.
@@ -32,10 +32,6 @@ import io.undertow.security.idm.IdentityManager;
  * @see io.undertow.security.impl.SecurityContextImpl
  */
 public interface SecurityContext {
-
-    // TODO - Some of this is used within the core of undertow, some by the servlet integration and some by the mechanisms -
-    // once released the use by mechanisms will require the greatest level of backwards compatibility maintenance so may be
-    // better to split the rest out.
 
     /*
      * Methods Used To Run Authentication Process
@@ -84,9 +80,6 @@ public interface SecurityContext {
     /*
      * Methods Used To Control/Configure The Authentication Process.
      */
-
-    // TODO - May be better to pass a parameter to the authenticate methods to indicate that authentication is required.
-
 
     /**
      * Marks this request as requiring authentication. Authentication challenge headers will only be sent if this
@@ -150,7 +143,9 @@ public interface SecurityContext {
      * Obtain the associated {@link IdentityManager} to use to make account verification decisions.
      *
      * @return The associated {@link IdentityManager}
+     * @deprecated Authentication mechanisms that rely on the {@link IdentityManager} should instead hold their own reference to it.
      */
+    @Deprecated
     IdentityManager getIdentityManager();
 
     /**

--- a/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/CachedAuthenticatedSessionMechanism.java
@@ -22,6 +22,7 @@ import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession
 import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.security.api.SecurityContext;
 import io.undertow.security.idm.Account;
+import io.undertow.security.idm.IdentityManager;
 import io.undertow.server.HttpServerExchange;
 
 /**
@@ -30,6 +31,21 @@ import io.undertow.server.HttpServerExchange;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class CachedAuthenticatedSessionMechanism implements AuthenticationMechanism {
+
+    private final IdentityManager identityManager;
+
+    public CachedAuthenticatedSessionMechanism() {
+        this(null);
+    }
+
+    public CachedAuthenticatedSessionMechanism(final IdentityManager identityManager) {
+        this.identityManager = identityManager;
+    }
+
+    @SuppressWarnings("deprecation")
+    private IdentityManager getIdentityManager(SecurityContext securityContext) {
+        return identityManager != null ? identityManager : securityContext.getIdentityManager();
+    }
 
     @Override
     public AuthenticationMechanismOutcome authenticate(HttpServerExchange exchange, SecurityContext securityContext) {
@@ -44,7 +60,7 @@ public class CachedAuthenticatedSessionMechanism implements AuthenticationMechan
     public AuthenticationMechanismOutcome runCached(final HttpServerExchange exchange, final SecurityContext securityContext, final AuthenticatedSessionManager sessionManager) {
         AuthenticatedSession authSession = sessionManager.lookupSession(exchange);
         if (authSession != null) {
-            Account account = securityContext.getIdentityManager().verify(authSession.getAccount());
+            Account account = getIdentityManager(securityContext).verify(authSession.getAccount());
             if (account != null) {
                 securityContext.authenticationComplete(account, authSession.getMechanism(), false);
                 return AuthenticationMechanismOutcome.AUTHENTICATED;

--- a/core/src/main/java/io/undertow/security/impl/DigestAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/DigestAuthenticationMechanism.java
@@ -61,14 +61,14 @@ import java.util.Set;
 public class DigestAuthenticationMechanism implements AuthenticationMechanism {
 
     private static final String DEFAULT_NAME = "DIGEST";
-    private final String mechanismName;
     private static final String DIGEST_PREFIX = DIGEST + " ";
     private static final int PREFIX_LENGTH = DIGEST_PREFIX.length();
     private static final String OPAQUE_VALUE = "00000000000000000000000000000000";
     private static final byte COLON = ':';
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-    public static final Factory FACTORY = new Factory();
+    private final String mechanismName;
+    private final IdentityManager identityManager;
 
     private static final Set<DigestAuthorizationToken> MANDATORY_REQUEST_TOKENS;
 
@@ -106,12 +106,18 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
 
     public DigestAuthenticationMechanism(final List<DigestAlgorithm> supportedAlgorithms, final List<DigestQop> supportedQops,
             final String realmName, final String domain, final NonceManager nonceManager, final String mechanismName) {
+        this(supportedAlgorithms, supportedQops, realmName, domain, nonceManager, mechanismName, null);
+    }
+
+    public DigestAuthenticationMechanism(final List<DigestAlgorithm> supportedAlgorithms, final List<DigestQop> supportedQops,
+            final String realmName, final String domain, final NonceManager nonceManager, final String mechanismName, final IdentityManager identityManager) {
         this.supportedAlgorithms = supportedAlgorithms;
         this.supportedQops = supportedQops;
         this.realmName = realmName;
         this.domain = domain;
         this.nonceManager = nonceManager;
         this.mechanismName = mechanismName;
+        this.identityManager = identityManager;
 
         if (!supportedQops.isEmpty()) {
             StringBuilder sb = new StringBuilder();
@@ -127,8 +133,16 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
     }
 
     public DigestAuthenticationMechanism(final String realmName, final String domain, final String mechanismName) {
-        this(Collections.singletonList(DigestAlgorithm.MD5), new ArrayList<DigestQop>(0), realmName, domain,
-                new SimpleNonceManager());
+        this(realmName, domain, mechanismName, null);
+    }
+
+    public DigestAuthenticationMechanism(final String realmName, final String domain, final String mechanismName, final IdentityManager identityManager) {
+        this(Collections.singletonList(DigestAlgorithm.MD5), new ArrayList<DigestQop>(0), realmName, domain, new SimpleNonceManager(), DEFAULT_NAME, identityManager);
+    }
+
+    @SuppressWarnings("deprecation")
+    private IdentityManager getIdentityManager(SecurityContext securityContext) {
+        return identityManager != null ? identityManager : securityContext.getIdentityManager();
     }
 
     public AuthenticationMechanismOutcome authenticate(final HttpServerExchange exchange,
@@ -250,7 +264,7 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
         }
 
         final String userName = parsedHeader.get(DigestAuthorizationToken.USERNAME);
-        final IdentityManager identityManager = securityContext.getIdentityManager();
+        final IdentityManager identityManager = getIdentityManager(securityContext);
         final Account account;
 
         if (algorithm.isSession()) {
@@ -603,35 +617,17 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
 
     }
 
-    private class AuthenticationException extends Exception {
+    public static final class Factory implements AuthenticationMechanismFactory {
 
-        private static final long serialVersionUID = 4123187263595319747L;
+        private final IdentityManager identityManager;
 
-        // TODO - Remove unused constructors and maybe even move exception to higher level.
-
-        public AuthenticationException() {
-            super();
+        public Factory(IdentityManager identityManager) {
+            this.identityManager = identityManager;
         }
-
-        public AuthenticationException(String message, Throwable cause) {
-            super(message, cause);
-        }
-
-        public AuthenticationException(String message) {
-            super(message);
-        }
-
-        public AuthenticationException(Throwable cause) {
-            super(cause);
-        }
-
-    }
-
-    private static final class Factory implements AuthenticationMechanismFactory {
 
         @Override
         public AuthenticationMechanism create(String mechanismName, FormParserFactory formParserFactory, Map<String, String> properties) {
-            return new DigestAuthenticationMechanism(properties.get(REALM), properties.get(CONTEXT_PATH), mechanismName);
+            return new DigestAuthenticationMechanism(properties.get(REALM), properties.get(CONTEXT_PATH), mechanismName, identityManager);
         }
     }
 

--- a/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/FormAuthenticationMechanism.java
@@ -53,6 +53,7 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
     private final String errorPage;
     private final String postLocation;
     private final FormParserFactory formParserFactory;
+    private final IdentityManager identityManager;
 
     public FormAuthenticationMechanism(final String name, final String loginPage, final String errorPage) {
         this(FormParserFactory.builder().build(), name, loginPage, errorPage);
@@ -66,12 +67,26 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
         this(formParserFactory, name, loginPage, errorPage, DEFAULT_POST_LOCATION);
     }
 
+    public FormAuthenticationMechanism(final FormParserFactory formParserFactory, final String name, final String loginPage, final String errorPage, final IdentityManager identityManager) {
+        this(formParserFactory, name, loginPage, errorPage, DEFAULT_POST_LOCATION, identityManager);
+    }
+
     public FormAuthenticationMechanism(final FormParserFactory formParserFactory, final String name, final String loginPage, final String errorPage, final String postLocation) {
+        this(formParserFactory, name, loginPage, errorPage, postLocation, null);
+    }
+
+    public FormAuthenticationMechanism(final FormParserFactory formParserFactory, final String name, final String loginPage, final String errorPage, final String postLocation, final IdentityManager identityManager) {
         this.name = name;
         this.loginPage = loginPage;
         this.errorPage = errorPage;
         this.postLocation = postLocation;
         this.formParserFactory = formParserFactory;
+        this.identityManager = identityManager;
+    }
+
+    @SuppressWarnings("deprecation")
+    private IdentityManager getIdentityManager(SecurityContext securityContext) {
+        return identityManager != null ? identityManager : securityContext.getIdentityManager();
     }
 
     @Override
@@ -105,7 +120,7 @@ public class FormAuthenticationMechanism implements AuthenticationMechanism {
             AuthenticationMechanismOutcome outcome = null;
             PasswordCredential credential = new PasswordCredential(password.toCharArray());
             try {
-                IdentityManager identityManager = securityContext.getIdentityManager();
+                IdentityManager identityManager = getIdentityManager(securityContext);
                 Account account = identityManager.verify(userName, credential);
                 if (account != null) {
                     securityContext.authenticationComplete(account, name, true);

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
@@ -30,8 +30,9 @@ import io.undertow.servlet.spec.HttpSessionImpl;
 import io.undertow.servlet.spec.ServletContextImpl;
 import io.undertow.servlet.util.SavedRequest;
 
-import javax.servlet.http.HttpSession;
 import java.security.AccessController;
+
+import javax.servlet.http.HttpSession;
 
 /**
  * {@link HttpHandler} responsible for setting up the {@link AuthenticatedSessionManager} for cached authentications and
@@ -53,6 +54,7 @@ public class CachedAuthenticatedSessionHandler implements HttpHandler {
         this.next = next;
         this.servletContext = servletContext;
     }
+
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletFormAuthenticationMechanism.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletFormAuthenticationMechanism.java
@@ -20,6 +20,7 @@ package io.undertow.servlet.handlers.security;
 
 import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.security.api.AuthenticationMechanismFactory;
+import io.undertow.security.idm.IdentityManager;
 import io.undertow.security.impl.FormAuthenticationMechanism;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.form.FormParserFactory;
@@ -35,6 +36,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.security.AccessController;
 import java.util.Map;
@@ -48,8 +50,6 @@ import java.util.Map;
 public class ServletFormAuthenticationMechanism extends FormAuthenticationMechanism {
 
     private static final String SESSION_KEY = "io.undertow.servlet.form.auth.redirect.location";
-
-    public static final Factory FACTORY = new Factory();
 
     @Deprecated
     public ServletFormAuthenticationMechanism(final String name, final String loginPage, final String errorPage) {
@@ -67,6 +67,10 @@ public class ServletFormAuthenticationMechanism extends FormAuthenticationMechan
 
     public ServletFormAuthenticationMechanism(FormParserFactory formParserFactory, String name, String loginPage, String errorPage) {
         super(formParserFactory, name, loginPage, errorPage);
+    }
+
+    public ServletFormAuthenticationMechanism(FormParserFactory formParserFactory, String name, String loginPage, String errorPage, IdentityManager identityManager) {
+        super(formParserFactory, name, loginPage, errorPage, identityManager);
     }
 
     @Override
@@ -130,9 +134,16 @@ public class ServletFormAuthenticationMechanism extends FormAuthenticationMechan
     }
 
     public static class Factory implements AuthenticationMechanismFactory {
+
+        private final IdentityManager identityManager;
+
+        public Factory(IdentityManager identityManager) {
+            this.identityManager = identityManager;
+        }
+
         @Override
         public AuthenticationMechanism create(String mechanismName, FormParserFactory formParserFactory, Map<String, String> properties) {
-            return new ServletFormAuthenticationMechanism(formParserFactory, mechanismName, properties.get(LOGIN_PAGE), properties.get(ERROR_PAGE));
+            return new ServletFormAuthenticationMechanism(formParserFactory, mechanismName, properties.get(LOGIN_PAGE), properties.get(ERROR_PAGE), identityManager);
         }
     }
 }


### PR DESCRIPTION
Whilst all current mechanisms make use of this it should not be seen as an exclusive way to access identities and accounts.

The next step for Elytron is going to be to adjust the mechanisms to make use of the Elytron domains and realms directly.