### PR TITLE
Fixed classname typo: ChaninedHandlerWrapper -> Chained...

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/builder/PredicatedHandlersParser.java
+++ b/core/src/main/java/io/undertow/server/handlers/builder/PredicatedHandlersParser.java
@@ -22,7 +22,7 @@ import io.undertow.predicate.Predicate;
 import io.undertow.predicate.PredicateParser;
 import io.undertow.predicate.Predicates;
 import io.undertow.server.HandlerWrapper;
-import io.undertow.util.ChaninedHandlerWrapper;
+import io.undertow.util.ChainedHandlerWrapper;
 import io.undertow.util.FileUtils;
 
 import java.io.File;
@@ -71,7 +71,7 @@ public class PredicatedHandlersParser {
                     for(int i = 0; i < handlers.length; ++i) {
                         handlers[i] = HandlerParser.parse(parts[i + 1], classLoader);
                     }
-                    handler = new ChaninedHandlerWrapper(Arrays.asList(handlers));
+                    handler = new ChainedHandlerWrapper(Arrays.asList(handlers));
                 }
                 wrappers.add(new PredicatedHandler(predicate, handler));
             }

--- a/core/src/main/java/io/undertow/server/handlers/cache/ResponseCache.java
+++ b/core/src/main/java/io/undertow/server/handlers/cache/ResponseCache.java
@@ -200,22 +200,22 @@ public class ResponseCache {
     }
 
     private static class DereferenceCallback implements IoCallback {
-        private final DirectBufferCache.CacheEntry cache;
+        private final DirectBufferCache.CacheEntry entry;
 
-        public DereferenceCallback(DirectBufferCache.CacheEntry cache) {
-            this.cache = cache;
+        public DereferenceCallback(DirectBufferCache.CacheEntry entry) {
+            this.entry = entry;
         }
 
         @Override
         public void onComplete(final HttpServerExchange exchange, final Sender sender) {
-            cache.dereference();
+            entry.dereference();
             exchange.endExchange();
         }
 
         @Override
         public void onException(final HttpServerExchange exchange, final Sender sender, final IOException exception) {
             UndertowLogger.REQUEST_IO_LOGGER.ioException(exception);
-            cache.dereference();
+            entry.dereference();
             exchange.endExchange();
         }
     }

--- a/core/src/main/java/io/undertow/server/handlers/resource/CachedResource.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/CachedResource.java
@@ -225,18 +225,18 @@ public class CachedResource implements Resource {
 
     private static class DereferenceCallback implements IoCallback {
 
-        private final DirectBufferCache.CacheEntry cache;
+        private final DirectBufferCache.CacheEntry entry;
         private final IoCallback callback;
 
-        public DereferenceCallback(DirectBufferCache.CacheEntry cache, final IoCallback callback) {
-            this.cache = cache;
+        public DereferenceCallback(DirectBufferCache.CacheEntry entry, final IoCallback callback) {
+            this.entry = entry;
             this.callback = callback;
         }
 
         @Override
         public void onComplete(final HttpServerExchange exchange, final Sender sender) {
             try {
-                cache.dereference();
+                entry.dereference();
             } finally {
                 callback.onComplete(exchange, sender);
             }
@@ -246,7 +246,7 @@ public class CachedResource implements Resource {
         public void onException(final HttpServerExchange exchange, final Sender sender, final IOException exception) {
             UndertowLogger.REQUEST_IO_LOGGER.ioException(exception);
             try {
-                cache.dereference();
+                entry.dereference();
             } finally {
                 callback.onException(exchange, sender, exception);
             }

--- a/core/src/main/java/io/undertow/util/ChainedHandlerWrapper.java
+++ b/core/src/main/java/io/undertow/util/ChainedHandlerWrapper.java
@@ -28,11 +28,11 @@ import io.undertow.server.HttpHandler;
  *
  * @author Stuart Douglas
  */
-public class ChaninedHandlerWrapper implements HandlerWrapper {
+public class ChainedHandlerWrapper implements HandlerWrapper {
 
     private final List<HandlerWrapper> handlers;
 
-    public ChaninedHandlerWrapper(List<HandlerWrapper> handlers) {
+    public ChainedHandlerWrapper(List<HandlerWrapper> handlers) {
         this.handlers = handlers;
     }
 


### PR DESCRIPTION
I have renamed a class which contained a typo in its name. Unfortunately this will be a breaking change for any existing users of that class.

I have also refactored a misleadingly named variable `cache` which is actually an `entry`. Variables of the same type (`DirectBufferCache.CacheEntry`) are called `entry` elsewhere in the same file, while `cache` refers to a `DirectBufferCache`.