### PR TITLE
[UNDERTOW-463] Deprecate the SecurityContextFactory.

### DIFF
--- a/core/src/main/java/io/undertow/security/api/SecurityContextFactory.java
+++ b/core/src/main/java/io/undertow/security/api/SecurityContextFactory.java
@@ -26,7 +26,9 @@ import io.undertow.server.HttpServerExchange;
  * </p>
  *
  * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ * @deprecated Instead extend AbstractSecurityContextAssociationHandler to provide alternative contexts.
  */
+@Deprecated()
 public interface SecurityContextFactory {
 
     /**

--- a/core/src/main/java/io/undertow/security/handlers/AbstractSecurityContextAssociationHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/AbstractSecurityContextAssociationHandler.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.security.handlers;
+
+import io.undertow.security.api.SecurityContext;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Base class responsible for associating the {@link SecurityContext} instance with the current request.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public abstract class AbstractSecurityContextAssociationHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    protected AbstractSecurityContextAssociationHandler(final HttpHandler next) {
+        this.next = next;
+    }
+
+    /**
+     * @see io.undertow.server.HttpHandler#handleRequest(io.undertow.server.HttpServerExchange)
+     */
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        SecurityActions.setSecurityContext(exchange, createSecurityContext(exchange));
+        next.handleRequest(exchange);
+    }
+
+    public abstract SecurityContext createSecurityContext(final HttpServerExchange exchange);
+
+}

--- a/core/src/main/java/io/undertow/security/handlers/SecurityInitialHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/SecurityInitialHandler.java
@@ -38,21 +38,21 @@ import io.undertow.server.HttpServerExchange;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-public class SecurityInitialHandler implements HttpHandler {
+@SuppressWarnings("deprecation")
+public class SecurityInitialHandler extends AbstractSecurityContextAssociationHandler {
 
     private final AuthenticationMode authenticationMode;
     private final IdentityManager identityManager;
-    private final HttpHandler next;
     private final String programaticMechName;
     private final SecurityContextFactory contextFactory;
 
     public SecurityInitialHandler(final AuthenticationMode authenticationMode, final IdentityManager identityManager,
             final String programaticMechName, final SecurityContextFactory contextFactory, final HttpHandler next) {
+        super(next);
         this.authenticationMode = authenticationMode;
         this.identityManager = identityManager;
         this.programaticMechName = programaticMechName;
         this.contextFactory = contextFactory;
-        this.next = next;
     }
 
     public SecurityInitialHandler(final AuthenticationMode authenticationMode, final IdentityManager identityManager,
@@ -66,14 +66,12 @@ public class SecurityInitialHandler implements HttpHandler {
     }
 
     /**
-     * @see io.undertow.server.HttpHandler#handleRequest(io.undertow.server.HttpServerExchange)
+     * @see io.undertow.security.handlers.AbstractSecurityContextAssociationHandler#createSecurityContext()
      */
     @Override
-    public void handleRequest(HttpServerExchange exchange) throws Exception {
-        SecurityContext newContext = this.contextFactory.createSecurityContext(exchange, authenticationMode, identityManager,
-                programaticMechName);
-        SecurityActions.setSecurityContext(exchange, newContext);
-        next.handleRequest(exchange);
+    public SecurityContext createSecurityContext(final HttpServerExchange exchange) {
+        return contextFactory.createSecurityContext(exchange, authenticationMode, identityManager, programaticMechName);
     }
+
 
 }


### PR DESCRIPTION
Instead a new AbstractSecurityContextAssociationHandler can be extended to provide custom implementations.