### PR TITLE
[UNDERTOW-462] Deprecate the AuthenticationMechanism handling on the SecurityContext interface.

### DIFF
--- a/core/src/main/java/io/undertow/security/api/AuthenticationMechanismContext.java
+++ b/core/src/main/java/io/undertow/security/api/AuthenticationMechanismContext.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.undertow.security.api;
+
+
+/**
+ * An Undertow {@link SecurityContext} that uses Undertow {@link AuthenticationMechanism}
+ * instances for authentication.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface AuthenticationMechanismContext extends SecurityContext {
+
+    /**
+     * Adds an authentication mechanism to this context. When {@link #authenticate()} is
+     * called mechanisms will be iterated over in the order they are added, and given a chance to authenticate the user.
+     *
+     * @param mechanism The mechanism to add
+     */
+    @Override
+    void addAuthenticationMechanism(AuthenticationMechanism mechanism);
+
+}

--- a/core/src/main/java/io/undertow/security/api/SecurityContext.java
+++ b/core/src/main/java/io/undertow/security/api/SecurityContext.java
@@ -101,13 +101,17 @@ public interface SecurityContext {
      * called mechanisms will be iterated over in the order they are added, and given a chance to authenticate the user.
      *
      * @param mechanism The mechanism to add
+     * @deprecated This method is now only applicable to {@code SecurityContext} implementations that also implement the {@link AuthenticationMechanismContext} interface.
      */
+    @Deprecated
     void addAuthenticationMechanism(AuthenticationMechanism mechanism);
 
     /**
      *
      * @return A list of all authentication mechanisms in this context
+     * @deprecated Obtaining lists of mechanisms is discouraged, however there should not be a need to call this anyway.
      */
+    @Deprecated
     List<AuthenticationMechanism> getAuthenticationMechanisms();
 
     /*

--- a/core/src/main/java/io/undertow/security/handlers/AuthenticationMechanismsHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/AuthenticationMechanismsHandler.java
@@ -20,6 +20,7 @@ package io.undertow.security.handlers;
 
 import io.undertow.Handlers;
 import io.undertow.security.api.AuthenticationMechanism;
+import io.undertow.security.api.AuthenticationMechanismContext;
 import io.undertow.security.api.SecurityContext;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -50,9 +51,10 @@ public class AuthenticationMechanismsHandler implements HttpHandler {
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
         final SecurityContext sc = exchange.getSecurityContext();
-        if(sc != null) {
+        if(sc != null && sc instanceof AuthenticationMechanismContext) {
+            AuthenticationMechanismContext amc = (AuthenticationMechanismContext) sc;
             for(AuthenticationMechanism mechanism : authenticationMechanisms) {
-                sc.addAuthenticationMechanism(mechanism);
+                amc.addAuthenticationMechanism(mechanism);
             }
         }
         next.handleRequest(exchange);

--- a/core/src/main/java/io/undertow/security/impl/SecurityContextImpl.java
+++ b/core/src/main/java/io/undertow/security/impl/SecurityContextImpl.java
@@ -17,19 +17,14 @@
  */
 package io.undertow.security.impl;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
+import static io.undertow.UndertowMessages.MESSAGES;
 import io.undertow.UndertowMessages;
 import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.security.api.AuthenticationMechanism.AuthenticationMechanismOutcome;
 import io.undertow.security.api.AuthenticationMechanism.ChallengeResult;
+import io.undertow.security.api.AuthenticationMechanismContext;
 import io.undertow.security.api.AuthenticationMode;
 import io.undertow.security.api.NotificationReceiver;
-import io.undertow.security.api.SecurityContext;
 import io.undertow.security.api.SecurityNotification;
 import io.undertow.security.api.SecurityNotification.EventType;
 import io.undertow.security.idm.Account;
@@ -38,7 +33,11 @@ import io.undertow.security.idm.PasswordCredential;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.StatusCodes;
 
-import static io.undertow.UndertowMessages.MESSAGES;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * The internal SecurityContext used to hold the state of security for the current exchange.
@@ -46,7 +45,7 @@ import static io.undertow.UndertowMessages.MESSAGES;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @author Stuart Douglas
  */
-public class SecurityContextImpl implements SecurityContext {
+public class SecurityContextImpl implements AuthenticationMechanismContext {
 
     private static final RuntimePermission PERMISSION = new RuntimePermission("MODIFY_UNDERTOW_SECURITY_CONTEXT");
 
@@ -97,6 +96,7 @@ public class SecurityContextImpl implements SecurityContext {
      * CHALLENGED_SENT
      */
 
+    @Override
     public boolean authenticate() {
         if(authenticationState == AuthenticationState.ATTEMPTED) {
             //we are re-attempted, so we just reset the state


### PR DESCRIPTION
Instead add a specific interface for if Undertow AuthenticationMechanisms are supported.