### PR TITLE
Two minor fixes.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/PathResource.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/PathResource.java
@@ -8,12 +8,10 @@ import io.undertow.util.DateUtils;
 import io.undertow.util.ETag;
 import io.undertow.util.MimeMappings;
 import io.undertow.util.StatusCodes;
-import org.xnio.FileAccess;
 import org.xnio.IoUtils;
 import org.xnio.Pooled;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -21,7 +19,9 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -117,11 +117,11 @@ public class PathResource implements RangeAwareResource {
 
             protected boolean openFile() {
                 try {
-                    fileChannel = exchange.getConnection().getWorker().getXnio().openFile(file.toFile(), FileAccess.READ_ONLY);
+                    fileChannel = FileChannel.open(file, StandardOpenOption.READ);
                     if(range) {
                         fileChannel.position(start);
                     }
-                } catch (FileNotFoundException e) {
+                } catch (NoSuchFileException e) {
                     exchange.setResponseCode(StatusCodes.NOT_FOUND);
                     callback.onException(exchange, sender, e);
                     return false;

--- a/core/src/test/java/io/undertow/server/handlers/file/FileHandlerSymlinksTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/file/FileHandlerSymlinksTestCase.java
@@ -100,12 +100,12 @@ public class FileHandlerSymlinksTestCase {
         Path innerSymlink = newDir.resolve("innerSymlink");
         Path innerPage = innerDir.resolve("page.html");
 
-        Files.delete(innerSymlink);
-        Files.delete(newSymlink);
-        Files.delete(innerPage);
-        Files.delete(page);
-        Files.delete(innerDir);
-        Files.delete(newDir);
+        Files.deleteIfExists(innerSymlink);
+        Files.deleteIfExists(newSymlink);
+        Files.deleteIfExists(innerPage);
+        Files.deleteIfExists(page);
+        Files.deleteIfExists(innerDir);
+        Files.deleteIfExists(newDir);
     }
 
     @Test


### PR DESCRIPTION
Two minor fixes, related to my previous pull request.

The first simplifies the file channel opening in the PathResource class. In my previous pull request I changed the Xnio channel opener to the standard 1.7+ method FileChannel.open() everywhere, except here. This will make it consistent across the project.

The second fix changes the symlink unit test @After method to not fail on Windows systems.