### PR TITLE
Provide statistics via a SessionManager method instead of forcing inheritance on implementations.

### DIFF
--- a/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
+++ b/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
@@ -233,7 +233,10 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
         return this.deploymentName;
     }
 
-
+    @Override
+    public SessionManagerStatistics getStatistics() {
+        return this;
+    }
 
     public long getCreatedSessionCount() {
         return createdSessionCount.get();

--- a/core/src/main/java/io/undertow/server/session/SessionManager.java
+++ b/core/src/main/java/io/undertow/server/session/SessionManager.java
@@ -122,4 +122,9 @@ public interface SessionManager {
      * passive
      */
     Set<String> getAllSessions();
+
+    /**
+     * Returns the statistics for this session manager, or null, if statistics are not supported.
+     */
+    SessionManagerStatistics getStatistics();
 }

--- a/core/src/main/java/io/undertow/server/session/SessionManagerStatistics.java
+++ b/core/src/main/java/io/undertow/server/session/SessionManagerStatistics.java
@@ -24,7 +24,7 @@ package io.undertow.server.session;
  *
  * @author Stuart Douglas
  */
-public interface SessionManagerStatistics extends SessionManager {
+public interface SessionManagerStatistics {
 
     /**
      *


### PR DESCRIPTION
The basic motivation behind this change is that the distributed session manager is not going to want to implement statistics via inheritance.
Once WF is upgraded to the next release of Undertow, we can change the logic for obtaining the SessionManagerStatistics object from the current "instanceof" with a simple call to the getStatistics() method - although the old logic will continue to work.