### PR TITLE
Prevent "Could not find message parameter on method" for methods with generic parameters

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/AnnotatedEndpointFactory.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/AnnotatedEndpointFactory.java
@@ -18,12 +18,6 @@
 
 package io.undertow.websockets.jsr.annotated;
 
-import io.undertow.servlet.api.InstanceHandle;
-import io.undertow.websockets.jsr.Encoding;
-import io.undertow.websockets.jsr.EncodingFactory;
-import io.undertow.websockets.jsr.JsrWebSocketLogger;
-import io.undertow.websockets.jsr.JsrWebSocketMessages;
-
 import javax.websocket.CloseReason;
 import javax.websocket.DecodeException;
 import javax.websocket.DeploymentException;
@@ -35,6 +29,7 @@ import javax.websocket.OnOpen;
 import javax.websocket.PongMessage;
 import javax.websocket.Session;
 import javax.websocket.server.PathParam;
+
 import java.io.InputStream;
 import java.io.Reader;
 import java.lang.annotation.Annotation;
@@ -44,6 +39,13 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+
+import io.undertow.servlet.api.InstanceHandle;
+import io.undertow.websockets.jsr.Encoding;
+import io.undertow.websockets.jsr.EncodingFactory;
+import io.undertow.websockets.jsr.JsrWebSocketLogger;
+import io.undertow.websockets.jsr.JsrWebSocketMessages;
 
 /**
  * Factory that creates annotated end points.
@@ -124,7 +126,7 @@ public class AnnotatedEndpointFactory {
                             new BoundSingleParameter(method, Throwable.class, false),
                             createBoundPathParameters(method, paths, endpointClass));
                 }
-                if (method.isAnnotationPresent(OnMessage.class)) {
+                if (method.isAnnotationPresent(OnMessage.class) && ! method.isBridge()) {
                     if(binaryMessage != null && binaryMessage.overrides(method)) {
                         continue;
                     }

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedGenericClientEndpoint.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedGenericClientEndpoint.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.websockets.jsr.test.annotated;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+@ClientEndpoint(subprotocols = {"foo", "bar"})
+public class AnnotatedGenericClientEndpoint implements GenericWebSocketClientEndpoint<String> {
+
+    private static final BlockingDeque<String> MESSAGES = new LinkedBlockingDeque<>();
+
+    private volatile boolean open = false;
+
+    public static String message() throws InterruptedException {
+        return MESSAGES.pollFirst(3, TimeUnit.SECONDS);
+    }
+
+    @OnOpen
+    public void onOpen(final Session session) {
+        session.getAsyncRemote().sendText("hi");
+        this.open = true;
+    }
+
+    @OnMessage
+    public void onMessage(final String message) {
+        MESSAGES.add(message);
+    }
+
+    public boolean isOpen() {
+        return open;
+    }
+
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/GenericWebSocketClientEndpoint.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/GenericWebSocketClientEndpoint.java
@@ -1,0 +1,6 @@
+package io.undertow.websockets.jsr.test.annotated;
+
+public interface GenericWebSocketClientEndpoint<M> {
+
+    void onMessage(final M message);
+}


### PR DESCRIPTION
Shadow synthetic bridge methods are generated with annotations as of JDK8. This causes the bridged method with the @OnMessage annotation to be scanned by the AnnotatedEndpointFactory. The bridged method has an Object parameter which causes the exception:

javax.websocket.DeploymentException: UT003029: Could not find message parameter on method ....... onMessage(java.lang.Object)

The fix is to not scan bridged methods. This works fine in JDK7 and JDK8. Similar problem in myBatis: https://github.com/mybatis/mybatis-3/issues/237