### PR TITLE
Proposed correction to UNDERTOW-479

### DIFF
--- a/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
+++ b/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
@@ -319,6 +319,7 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
         private final SessionConfig sessionCookieConfig;
         private volatile long expireTime = -1;
         private volatile boolean invalid = false;
+        private volatile boolean invalidationStarted = false;
 
         final XnioExecutor executor;
         final XnioWorker worker;
@@ -354,6 +355,10 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
         }
 
         synchronized void bumpTimeout() {
+            if(invalidationStarted) {
+                return;
+            }
+
             final int maxInactiveInterval = getMaxInactiveInterval();
             if (maxInactiveInterval > 0) {
                 long newExpireTime = System.currentTimeMillis() + (maxInactiveInterval * 500L);
@@ -476,17 +481,21 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
             invalidate(exchange, SessionListener.SessionDestroyedReason.INVALIDATED);
         }
 
-        synchronized void invalidate(final HttpServerExchange exchange, SessionListener.SessionDestroyedReason reason) {
-            if (timerCancelKey != null) {
-                timerCancelKey.remove();
-            }
-            SessionImpl sess = sessionManager.sessions.remove(sessionId);
-            if (sess == null) {
-                if (reason == SessionListener.SessionDestroyedReason.INVALIDATED) {
-                    throw UndertowMessages.MESSAGES.sessionAlreadyInvalidated();
+        void invalidate(final HttpServerExchange exchange, SessionListener.SessionDestroyedReason reason) {
+            synchronized(SessionImpl.this) {
+                if (timerCancelKey != null) {
+                    timerCancelKey.remove();
                 }
-                return;
+                SessionImpl sess = sessionManager.sessions.remove(sessionId);
+                if (sess == null) {
+                    if (reason == SessionListener.SessionDestroyedReason.INVALIDATED) {
+                        throw UndertowMessages.MESSAGES.sessionAlreadyInvalidated();
+                    }
+                    return;
+                }
+                invalidationStarted = true;
             }
+
             sessionManager.sessionListeners.sessionDestroyed(this, exchange, reason);
             invalid = true;
 


### PR DESCRIPTION
Notify listeners of an invalidated session from outside the synchronized
block.