### PR TITLE
[UNDERTOW-487] Bugfix: session would expire in a half time of actual session-timeout…

### DIFF
--- a/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
+++ b/core/src/main/java/io/undertow/server/session/InMemorySessionManager.java
@@ -361,7 +361,7 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
 
             final int maxInactiveInterval = getMaxInactiveInterval();
             if (maxInactiveInterval > 0) {
-                long newExpireTime = System.currentTimeMillis() + (maxInactiveInterval * 500L);
+                long newExpireTime = System.currentTimeMillis() + (maxInactiveInterval * 1000L);
                 if(timerCancelKey != null && (newExpireTime < expireTime)) {
                     // We have to re-schedule as the new maxInactiveInterval is lower than the old one
                     if (!timerCancelKey.remove()) {
@@ -374,7 +374,7 @@ public class InMemorySessionManager implements SessionManager, SessionManagerSta
                     //+500ms, to make sure that the time has actually expired
                     //we don't re-schedule every time, as it is expensive
                     //instead when it expires we check if the timeout has been bumped, and if so we re-schedule
-                    timerCancelKey = executor.executeAfter(cancelTask, (maxInactiveInterval * 500L) + 1, TimeUnit.MILLISECONDS);
+                    timerCancelKey = executor.executeAfter(cancelTask, (maxInactiveInterval * 1000L) + 500L, TimeUnit.MILLISECONDS);
                 }
             }
             if (evictionToken != null) {


### PR DESCRIPTION
… set

With current implementation session timeouts in a half time of the real session timeout value that is set in the undertow configuration.