### PR TITLE
[UNDERTOW-506] GSSAPIAuthenticationMechanism doesn't parse IPv6 addre…

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/GSSAPIAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/GSSAPIAuthenticationMechanism.java
@@ -209,7 +209,9 @@ public class GSSAPIAuthenticationMechanism implements AuthenticationMechanism {
     private String getHostName(final HttpServerExchange exchange) {
         String hostName = exchange.getRequestHeaders().getFirst(HOST);
         if (hostName != null) {
-            if (hostName.contains(":")) {
+            if (hostName.startsWith("[") && hostName.contains("]")) {
+                hostName = hostName.substring(0, hostName.indexOf(']') + 1);
+            } else if (hostName.contains(":")) {
                 hostName = hostName.substring(0, hostName.indexOf(":"));
             }
             return hostName;


### PR DESCRIPTION
…ss correctly

https://issues.jboss.org/browse/UNDERTOW-506
https://bugzilla.redhat.com/show_bug.cgi?id=1172180