### PR TITLE
UNDERTOW-488 Allow setting the same cookie more than once

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
@@ -121,7 +121,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
     }
 
     private void clearSsoCookie(HttpServerExchange exchange) {
-        exchange.getResponseCookies().put(cookieName, new CookieImpl(cookieName).setMaxAge(0).setHttpOnly(httpOnly).setSecure(secure).setDomain(domain));
+        exchange.setResponseCookie(new CookieImpl(cookieName).setMaxAge(0).setHttpOnly(httpOnly).setSecure(secure).setDomain(domain));
     }
 
     @Override
@@ -143,7 +143,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
                 try (SingleSignOn sso = singleSignOnManager.createSingleSignOn(account, sc.getMechanismName())) {
                     Session session = getSession(exchange);
                     registerSessionIfRequired(sso, session);
-                    exchange.getResponseCookies().put(cookieName, new CookieImpl(cookieName, sso.getId()).setHttpOnly(httpOnly).setSecure(secure).setDomain(domain).setPath(path));
+                    exchange.setResponseCookie(new CookieImpl(cookieName, sso.getId()).setHttpOnly(httpOnly).setSecure(secure).setDomain(domain).setPath(path));
                 }
             }
             return factory.create();

--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -28,6 +28,7 @@ import io.undertow.connector.PooledByteBuffer;
 import org.xnio.channels.StreamSourceChannel;
 
 import java.util.Date;
+import java.util.Deque;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
@@ -49,10 +50,12 @@ public class Connectors {
      * @param exchange The server exchange
      */
     public static void flattenCookies(final HttpServerExchange exchange) {
-        Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
+        Map<String, Deque<Cookie>> cookies = exchange.getResponseCookiesInternal();
         if (cookies != null) {
-            for (Map.Entry<String, Cookie> entry : cookies.entrySet()) {
-                exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(entry.getValue()));
+            for (Map.Entry<String, Deque<Cookie>> entry : cookies.entrySet()) {
+                for (Cookie cookie : entry.getValue()) {
+                    exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(cookie));
+                }
             }
         }
     }

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -126,7 +126,7 @@ public final class HttpServerExchange extends AbstractAttachable {
     private Map<String, Deque<String>> pathParameters;
 
     private Map<String, Cookie> requestCookies;
-    private Map<String, Cookie> responseCookies;
+    private Map<String, Deque<Cookie>> responseCookies;
 
     /**
      * The actual response channel. May be null if it has not been created yet.
@@ -1088,14 +1088,18 @@ public final class HttpServerExchange extends AbstractAttachable {
         if (responseCookies == null) {
             responseCookies = new TreeMap<>(); //hashmap is slow to allocate in JDK7
         }
-        responseCookies.put(cookie.getName(), cookie);
+        Deque<Cookie> list = responseCookies.get(cookie.getName());
+        if (list == null) {
+            responseCookies.put(cookie.getName(), list = new ArrayDeque<>(2));
+        }
+        list.add(cookie);
         return this;
     }
 
     /**
      * @return A mutable map of response cookies
      */
-    public Map<String, Cookie> getResponseCookies() {
+    public Map<String, Deque<Cookie>> getResponseCookies() {
         if (responseCookies == null) {
             responseCookies = new TreeMap<>();
         }
@@ -1107,7 +1111,7 @@ public final class HttpServerExchange extends AbstractAttachable {
      *
      * @return The response cookies, or null if they have not been set yet
      */
-    Map<String, Cookie> getResponseCookiesInternal() {
+    Map<String, Deque<Cookie>> getResponseCookiesInternal() {
         return responseCookies;
     }
 

--- a/core/src/main/java/io/undertow/server/JvmRouteHandler.java
+++ b/core/src/main/java/io/undertow/server/JvmRouteHandler.java
@@ -19,6 +19,7 @@
 package io.undertow.server;
 
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -67,12 +68,14 @@ public class JvmRouteHandler implements HttpHandler {
         @Override
         public StreamSinkConduit wrap(ConduitFactory<StreamSinkConduit> factory, HttpServerExchange exchange) {
 
-            Cookie sessionId = exchange.getResponseCookies().get(sessionCookieName);
-            if (sessionId != null) {
-                StringBuilder sb = new StringBuilder(sessionId.getValue());
-                sb.append('.');
-                sb.append(jvmRoute);
-                sessionId.setValue(sb.toString());
+            Deque<Cookie> sessionCookies = exchange.getResponseCookies().get(sessionCookieName);
+            if (sessionCookies != null) {
+                for (Cookie sessionCookie : sessionCookies) {
+                    StringBuilder sb = new StringBuilder(sessionCookie.getValue());
+                    sb.append('.');
+                    sb.append(jvmRoute);
+                    sessionCookie.setValue(sb.toString());
+                }
             }
             return factory.create();
         }

--- a/core/src/main/java/io/undertow/server/handlers/RequestDumpingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/RequestDumpingHandler.java
@@ -125,10 +125,12 @@ public class RequestDumpingHandler implements HttpHandler {
                 }
                 sb.append("     contentLength=" + exchange.getResponseContentLength() + "\n");
                 sb.append("       contentType=" + exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE) + "\n");
-                Map<String, Cookie> cookies = exchange.getResponseCookies();
+                Map<String, Deque<Cookie>> cookies = exchange.getResponseCookies();
                 if (cookies != null) {
-                    for (Cookie cookie : cookies.values()) {
-                        sb.append("            cookie=" + cookie.getName() + "=" + cookie.getValue() + "; domain=" + cookie.getDomain() + "; path=" + cookie.getPath() + "\n");
+                    for (Deque<Cookie> cookieDeque : cookies.values()) {
+                        for (Cookie cookie : cookieDeque) {
+                            sb.append("            cookie=" + cookie.getName() + "=" + cookie.getValue() + "; domain=" + cookie.getDomain() + "; path=" + cookie.getPath() + "\n");
+                        }
                     }
                 }
                 for (HeaderValues header : exchange.getResponseHeaders()) {

--- a/core/src/test/java/io/undertow/server/handlers/CookieHandlingTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/CookieHandlingTestCase.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.server.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+@RunWith(DefaultServer.class)
+public class CookieHandlingTestCase {
+
+    @BeforeClass
+    public static void setup() {
+        DefaultServer.setRootHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                exchange.setResponseCookie(new CookieImpl("hello", "world").setDomain("a.b.c"));
+                exchange.setResponseCookie(new CookieImpl("hello", "world").setDomain("d.e.f"));
+                exchange.getResponseSender().send("");
+            }
+        });
+    }
+
+    @Test
+    public void testMultipleCookieSupport() throws IOException {
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/somepath");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            final Header[] headers = result.getHeaders("Set-Cookie");
+            Assert.assertEquals(headers.length, 2);
+            Assert.assertEquals(headers[0].getValue(), "hello=world; domain=a.b.c");
+            Assert.assertEquals(headers[1].getValue(), "hello=world; domain=d.e.f");
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}


### PR DESCRIPTION
This patch should resolve UNDERTOW-488 by ensuring that response cookies can be set multiple times with the same name=value mapping.