### PR TITLE
HTTP2 added missing checks on stream IDs for frame types when parsing

### DIFF
--- a/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
@@ -69,10 +69,16 @@ class Http2FrameHeaderParser implements FrameHeaderData {
             }
             switch (type) {
                 case FRAME_TYPE_DATA: {
+                    if (streamId == 0) {
+                        throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustNotBeZeroForFrameType(Http2Channel.FRAME_TYPE_DATA));
+                    }
                     parser = new Http2DataFrameParser(length);
                     break;
                 }
                 case FRAME_TYPE_HEADERS: {
+                    if (streamId == 0) {
+                        throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustNotBeZeroForFrameType(Http2Channel.FRAME_TYPE_HEADERS));
+                    }
                     parser = new Http2HeadersParser(length, http2Channel.getDecoder());
                     if(allAreClear(flags, Http2Channel.HEADERS_FLAG_END_HEADERS)) {
                         continuationParser = (Http2HeadersParser) parser;
@@ -100,6 +106,9 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                     break;
                 }
                 case FRAME_TYPE_GOAWAY: {
+                    if (streamId != 0) {
+                        throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustBeZeroForFrameType(Http2Channel.FRAME_TYPE_GOAWAY));
+                    }
                     parser = new Http2GoAwayParser(length);
                     break;
                 }
@@ -114,6 +123,9 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                     break;
                 }
                 case FRAME_TYPE_SETTINGS: {
+                    if (streamId != 0) {
+                        throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustBeZeroForFrameType(Http2Channel.FRAME_TYPE_SETTINGS));
+                    }
                     parser = new Http2SettingsParser(length);
                     break;
                 }

--- a/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
@@ -134,6 +134,9 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                     break;
                 }
                 case FRAME_TYPE_PRIORITY: {
+                    if (streamId == 0) {
+                        throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustNotBeZeroForFrameType(Http2Channel.FRAME_TYPE_PRIORITY));
+                    }
                     parser = new Http2PriorityParser(length);
                     break;
                 }


### PR DESCRIPTION
According to the [RFC7540](https://tools.ietf.org/html/rfc7540) there should be check for stream ID number of frames of types DATA, HEADERS, GOAWAY and SETTINGS and raise PROTOCOL_ERROR if invalid stream ID has been passed.

I've added that check into Http2FrameHeaderParser.java as there is already similar check for PING frame type.

Although as I browsed through the codebase I saw that similar check is made also in [Http2Channel.java](https://github.com/undertow-io/undertow/blob/90789748d3b493d7a233a4ef5ba8ae33032c1543/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java#L259) and also e.g. in [ping parser itself](https://github.com/undertow-io/undertow/blob/90789748d3b493d7a233a4ef5ba8ae33032c1543/core/src/main/java/io/undertow/protocols/http2/Http2PingParser.java#L43). As I am not much familiar with whole HTTP2 codebase here I am not quite sure, but I think that the best solution would be to put those checks into appropriate http2 frame parsers (so e.g. into Http2DataFrameParser.java, Http2PingParser.java, etc.). Any opinions?

