### PR TITLE
Make visibility CachedAuthenticatedSessionHandler#ATTRIBUTE_NAME public

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/CachedAuthenticatedSessionHandler.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpSession;
  */
 public class CachedAuthenticatedSessionHandler implements HttpHandler {
 
-    private static final String ATTRIBUTE_NAME = CachedAuthenticatedSessionHandler.class.getName() + ".AuthenticatedSession";
+    public static final String ATTRIBUTE_NAME = CachedAuthenticatedSessionHandler.class.getName() + ".AuthenticatedSession";
 
     private final NotificationReceiver NOTIFICATION_RECEIVER = new SecurityNotificationReceiver();
     private final AuthenticatedSessionManager SESSION_MANAGER = new ServletAuthenticatedSessionManager();


### PR DESCRIPTION
Removes the need for duplication in org.wildfly.clustering.web.undertow.session.DistributableSession#AUTHENTICATED_SESSION_ATTRIBUTE_NAME.