### PR TITLE
Modify SingleSignOnManager.removeSingleSignOn(...) to accept SSO itself

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/InMemorySingleSignOnManager.java
+++ b/core/src/main/java/io/undertow/security/impl/InMemorySingleSignOnManager.java
@@ -53,8 +53,8 @@ public class InMemorySingleSignOnManager implements SingleSignOnManager {
     }
 
     @Override
-    public void removeSingleSignOn(String ssoId) {
-        this.ssoEntries.remove(ssoId);
+    public void removeSingleSignOn(SingleSignOn sso) {
+        this.ssoEntries.remove(sso.getId());
     }
 
     private static class SimpleSingleSignOnEntry implements SingleSignOn {

--- a/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
@@ -82,7 +82,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
         Cookie cookie = exchange.getRequestCookies().get(cookieName);
         if (cookie != null) {
             final String ssoId = cookie.getValue();
-            try (SingleSignOn sso = this.singleSignOnManager.findSingleSignOn(ssoId)) {
+            try (final SingleSignOn sso = this.singleSignOnManager.findSingleSignOn(ssoId)) {
                 if (sso != null) {
                     Account verified = getIdentityManager(securityContext).verify(sso.getAccount());
                     if (verified == null) {
@@ -96,7 +96,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
                         @Override
                         public void handleNotification(SecurityNotification notification) {
                             if (notification.getEventType() == SecurityNotification.EventType.LOGGED_OUT) {
-                                singleSignOnManager.removeSingleSignOn(ssoId);
+                                singleSignOnManager.removeSingleSignOn(sso);
                             }
                         }
                     });
@@ -161,7 +161,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
         public void sessionDestroyed(Session session, HttpServerExchange exchange, SessionDestroyedReason reason) {
             String ssoId = (String) session.getAttribute(SSO_SESSION_ATTRIBUTE);
             if (ssoId != null) {
-                try (SingleSignOn sso = singleSignOnManager.findSingleSignOn(ssoId)) {
+                try (final SingleSignOn sso = singleSignOnManager.findSingleSignOn(ssoId)) {
                     if (sso != null) {
                         sso.remove(session);
                         if (reason == SessionDestroyedReason.INVALIDATED) {
@@ -172,7 +172,7 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
                         }
                         // If there are no more associated sessions, remove the SSO altogether
                         if (!sso.iterator().hasNext()) {
-                            singleSignOnManager.removeSingleSignOn(ssoId);
+                            singleSignOnManager.removeSingleSignOn(sso);
                         }
                     }
                 }

--- a/core/src/main/java/io/undertow/security/impl/SingleSignOnManager.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOnManager.java
@@ -28,5 +28,5 @@ public interface SingleSignOnManager {
 
     SingleSignOn findSingleSignOn(String ssoId);
 
-    void removeSingleSignOn(String ssoId);
+    void removeSingleSignOn(SingleSignOn sso);
 }


### PR DESCRIPTION
... instead of just its identifier.

This is required for the distributable implementation to propagate the transaction context of the SSO to be removed - since the removal is performed while the SSO is locked.  This is needed to fix:
https://issues.jboss.org/browse/WFLY-5473
https://issues.jboss.org/browse/WFLY-5422