### PR TITLE
Make sure .destroy() is called for all servlets on undeploy

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
@@ -266,7 +266,7 @@ public class ManagedServlet implements Lifecycle {
 
                 @Override
                 public void release() {
-
+                    instance.destroy();
                 }
             };
         }


### PR DESCRIPTION
- fixes "memory leak" when testing with arquillian servlet protocol.

see https://github.com/wildfly/wildfly/issues/8263