### PR TITLE
Simplify ConnectorStatisticsImpl: use plain read instead of AtomicXXXFieldUpdater.get

### DIFF
--- a/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
+++ b/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
@@ -56,7 +56,7 @@ public class ConnectorStatisticsImpl implements ConnectorStatistics {
                     processingTimeUpdater.addAndGet(ConnectorStatisticsImpl.this, elapsed);
                     long oldMax;
                     do {
-                        oldMax = maxProcessingTimeUpdater.get(ConnectorStatisticsImpl.this);
+                        oldMax = maxProcessingTime;
                         if (oldMax >= elapsed) {
                             break;
                         }
@@ -71,32 +71,32 @@ public class ConnectorStatisticsImpl implements ConnectorStatistics {
 
     @Override
     public long getRequestCount() {
-        return requestCountUpdater.get(this);
+        return requestCount;
     }
 
     @Override
     public long getBytesSent() {
-        return bytesSentUpdater.get(this);
+        return bytesSent;
     }
 
     @Override
     public long getBytesReceived() {
-        return bytesReceivedUpdater.get(this);
+        return bytesReceived;
     }
 
     @Override
     public long getErrorCount() {
-        return errorCountUpdater.get(this);
+        return errorCount;
     }
 
     @Override
     public long getProcessingTime() {
-        return processingTimeUpdater.get(this);
+        return processingTime;
     }
 
     @Override
     public long getMaxProcessingTime() {
-        return maxProcessingTimeUpdater.get(this);
+        return maxProcessingTime;
     }
 
     @Override


### PR DESCRIPTION
I wonder if there was an intention of using `bytesSentUpdater.get(this)`. I happened to run into `ConnectorStatisticsImpl` and those `get(this)` were awkward.