### PR TITLE
WFLY-5687 max-active-sessions doesn't work with enabled statistics

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/InMemorySessionManagerFactory.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/InMemorySessionManagerFactory.java
@@ -41,6 +41,6 @@ public class InMemorySessionManagerFactory implements SessionManagerFactory {
 
     @Override
     public SessionManager createSessionManager(Deployment deployment) {
-        return new InMemorySessionManager(deployment.getDeploymentInfo().getSessionIdGenerator(), deployment.getDeploymentInfo().getDeploymentName(), maxSessions, deployment.getDeploymentInfo().getMetricsCollector() != null);
+        return new InMemorySessionManager(deployment.getDeploymentInfo().getSessionIdGenerator(), deployment.getDeploymentInfo().getDeploymentName(), maxSessions, false, deployment.getDeploymentInfo().getMetricsCollector() != null);
     }
 }


### PR DESCRIPTION
It would probably be wise to expose expireOldestUnusedSessionOnMax as configuration option. 
For now just make work again properly.