### PR TITLE
1.1.x

### DIFF
--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -324,7 +324,9 @@ public final class HttpString implements Comparable<HttpString>, Serializable {
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
         ois.defaultReadObject();
         try {
+            hashCodeField.setAccessible(true);
             hashCodeField.setInt(this, calcHashCode(bytes));
+            hashCodeField.setAccessible(false);
         } catch (IllegalAccessException e) {
             throw new IllegalAccessError(e.getMessage());
         }


### PR DESCRIPTION
This prevents error message java.lang.IllegalAccessError in clustered installation. See http://stackoverflow.com/questions/34304940/clustered-wildfly-throws-java-lang-illegalaccesserror