### PR TITLE
Add zanata configuration and plugin for internationalization support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <version.com.twitter.hpack>0.10.1</version.com.twitter.hpack>
+
+        <!-- Non-default maven plugin versions and configuration -->
+        <version.org.zanata.plugin>3.7.4</version.org.zanata.plugin>
     </properties>
 
     <modules>
@@ -121,6 +124,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+
+            <!-- Zanata translations -->
+            <plugin>
+                <groupId>org.zanata</groupId>
+                <artifactId>zanata-maven-plugin</artifactId>
+                <version>${version.org.zanata.plugin}</version>
+                <configuration>
+                    <!-- Process sub-modules separately, sharing parent config -->
+                    <enableModules>true</enableModules>
+                    <projectConfig>${session.executionRootDirectory}/zanata.xml</projectConfig>
+                    <!-- Generated English i18n.properties are written here: -->
+                    <srcDir>target/classes</srcDir>
+                    <transDir>src/main/resources</transDir>
+                    <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2016 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<config xmlns="http://zanata.org/namespace/config/">
+    <url>https://translate.jboss.org/</url>
+    <project>undertow</project>
+    <project-version>2.0</project-version>
+    <project-type>properties</project-type>
+
+</config>


### PR DESCRIPTION
I created a project on the JBoss Zanata server as well, https://translate.jboss.org/project/view/undertow. I'm currently the only maintainer, but can add others that need to be. I've only created the 2.0 version, but it will be easy to back port if we need to.