### PR TITLE
Make sure that getOutputStream() has not been called when using getWriter()

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletDebugPageHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletDebugPageHandler.java
@@ -20,10 +20,10 @@ package io.undertow.servlet.handlers;
 
 import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.spec.HttpServletRequestImpl;
+import io.undertow.servlet.spec.HttpServletResponseImpl;
 
 import javax.servlet.ServletOutputStream;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -111,9 +111,9 @@ public class ServletDebugPageHandler {
             out.write(sb.toString().getBytes(StandardCharsets.UTF_8));
             out.close();
         } catch (IllegalStateException e) {
-            PrintWriter writer = servletRequestContext.getOriginalResponse().getWriter();
-            writer.write(sb.toString());
-            writer.close();
+            HttpServletResponseImpl res = servletRequestContext.getOriginalResponse();
+            res.write(sb.toString());
+            res.close();
         }
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
@@ -159,11 +159,11 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
             setContentType("text/html");
             setCharacterEncoding("UTF-8");
             if(servletContext.getDeployment().getDeploymentInfo().isEscapeErrorMessage()) {
-                getWriter().write("<html><head><title>Error</title></head><body>" + escapeHtml(error) + "</body></html>");
+                write("<html><head><title>Error</title></head><body>" + escapeHtml(error) + "</body></html>");
             } else {
-                getWriter().write("<html><head><title>Error</title></head><body>" + error + "</body></html>");
+                write("<html><head><title>Error</title></head><body>" + error + "</body></html>");
             }
-            getWriter().close();
+            close();
         }
         responseDone();
     }
@@ -605,6 +605,42 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
             return originalServletContext.getSessionConfig().rewriteUrl(url, servletContext.getSession(originalServletContext, exchange, true).getId());
         } else {
             return url;
+        }
+    }
+
+    /**
+     * <p>
+     * Writes the given {@code String} to the response.
+     * </p>
+     *
+     * <p>
+     * {@link #getWriter()} is used by default but if {@link #getOutputStream()} has been already called, the method
+     * will use it to prevent any exception.
+     * </p>
+     *
+     * @param message the message to write
+     * @throws IOException if any I/O error occurs
+     */
+    public void write(final String message) throws IOException {
+        if (responseState == ResponseState.STREAM) {
+            getOutputStream().print(message);
+        } else {
+            getWriter().write(message);
+        }
+    }
+
+    /**
+     * <p>
+     * Closes the stream.
+     * </p>
+     *
+     * @throws IOException if any I/O error occurs
+     */
+    public void close() throws IOException {
+        if (responseState == ResponseState.STREAM) {
+            getOutputStream().close();
+        } else {
+            getWriter().close();
         }
     }
 


### PR DESCRIPTION
 ##When Undertow writes an error, it always calls getWriter(). The method can throw an exception if getOutputStream() has been previously called in the response's lifecycle.

This PR proposes to use getOutputStream() in that case to avoid any error thrown by the servlet container.