### PR TITLE
Make build work on JDK9

### DIFF
--- a/http2-test-suite/pom.xml
+++ b/http2-test-suite/pom.xml
@@ -41,6 +41,7 @@
         <dump>false</dump>
         <https>false</https>
         <test.ipv6>false</test.ipv6>
+        <surefire.argLine/>
     </properties>
 
     <dependencies>
@@ -70,12 +71,6 @@
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-nio</artifactId>
             <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.mortbay.jetty.alpn</groupId>
-            <artifactId>alpn-boot</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -188,10 +183,28 @@
                         <test.level>${test.level}</test.level>
                         <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
                     </systemPropertyVariables>
-                    <argLine>-Xbootclasspath/p:${org.mortbay.jetty.alpn:alpn-boot:jar}</argLine>
+                    <argLine>${surefire.argLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>not-jdk9</id>
+            <activation>
+                <jdk>9!</jdk>
+            </activation>
+            <properties>
+                <surefire.argLine>-Xbootclasspath/p:${org.mortbay.jetty.alpn:alpn-boot:jar}</surefire.argLine>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mortbay.jetty.alpn</groupId>
+                    <artifactId>alpn-boot</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>19</version>
+        <version>20</version>
     </parent>
 
     <groupId>io.undertow</groupId>
@@ -90,7 +90,6 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
         <version.io.undertow.build.checkstyle-config>1.0.1.Final</version.io.undertow.build.checkstyle-config>
-        <version.org.mortbay.jetty.alpn.jdk7>7.0.0.v20140317</version.org.mortbay.jetty.alpn.jdk7>
         <version.org.mortbay.jetty.alpn.jdk8.old>8.0.0.v20140317</version.org.mortbay.jetty.alpn.jdk8.old>
         <version.org.mortbay.jetty.alpn.jdk8.old.25>8.1.2.v20141202</version.org.mortbay.jetty.alpn.jdk8.old.25>
         <version.org.mortbay.jetty.alpn.jdk8.old.31>8.1.3.v20150130</version.org.mortbay.jetty.alpn.jdk8.old.31>
@@ -98,17 +97,14 @@
         <version.org.mortbay.jetty.alpn.jdk8.old.60>8.1.5.v20150921</version.org.mortbay.jetty.alpn.jdk8.old.60>
         <version.org.mortbay.jetty.alpn.jdk8.old.66>8.1.6.v20151105</version.org.mortbay.jetty.alpn.jdk8.old.66>
         <version.org.mortbay.jetty.alpn.jdk8>8.1.7.v20160121</version.org.mortbay.jetty.alpn.jdk8>
-        <version.org.mortbay.jetty.alpn>${version.org.mortbay.jetty.alpn.jdk7}</version.org.mortbay.jetty.alpn>
         <version.org.eclipse.jetty.alpn>1.0.0</version.org.eclipse.jetty.alpn>
         <alpn-boot-string></alpn-boot-string>
 
-        <jdk.min.version>1.8</jdk.min.version>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
         <version.com.twitter.hpack>0.10.1</version.com.twitter.hpack>
 
         <!-- Non-default maven plugin versions and configuration -->
-        <version.org.zanata.plugin>3.7.4</version.org.zanata.plugin>
+        <!-- use older version of checkstyle as newer one is more strict -->
+         <version.checkstyle>6.8</version.checkstyle>
     </properties>
 
     <modules>
@@ -130,7 +126,7 @@
             <plugin>
                 <groupId>org.zanata</groupId>
                 <artifactId>zanata-maven-plugin</artifactId>
-                <version>${version.org.zanata.plugin}</version>
+                <version>${version.zanata.plugin}</version>
                 <configuration>
                     <!-- Process sub-modules separately, sharing parent config -->
                     <enableModules>true</enableModules>
@@ -156,6 +152,7 @@
                         <failsOnError>true</failsOnError>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <useFile/>
+                        <excludes>**/*$logger.java,**/*$bundle.java</excludes>
                     </configuration>
                     <dependencies>
                         <dependency>
@@ -409,13 +406,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.mortbay.jetty.alpn</groupId>
-                <artifactId>alpn-boot</artifactId>
-                <version>${version.org.mortbay.jetty.alpn}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.el</artifactId>
                 <version>${version.org.glassfish.el}</version>
@@ -478,6 +468,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -498,6 +489,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -518,6 +510,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -538,6 +531,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -558,6 +552,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -579,6 +574,7 @@
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
                     <scope>test</scope>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                 </dependency>
             </dependencies>
             <modules>
@@ -598,6 +594,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -618,6 +615,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -638,6 +636,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -658,6 +657,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -678,6 +678,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -698,6 +699,7 @@
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -705,21 +707,25 @@
                 <module>http2-test-suite</module>
             </modules>
         </profile>
-        <profile>
-            <id>jdk7</id>
+       <!-- <profile>&lt;!&ndash; add apln-boot dependancy only when we are not running on JDK9 &ndash;&gt;
+            <id>not-jdk9</id>
             <activation>
-                <jdk>1.7</jdk>
+                <jdk>9!</jdk>
             </activation>
-            <properties>
-                <alpn-boot-string>-Xbootclasspath/p:${org.mortbay.jetty.alpn:alpn-boot:jar}</alpn-boot-string>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.mortbay.jetty.alpn</groupId>
                     <artifactId>alpn-boot</artifactId>
+                    <version>${version.org.mortbay.jetty.alpn}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>-->
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
             <modules>
                 <module>http2-test-suite</module>
             </modules>


### PR DESCRIPTION
Make master work on JDK9. 
JDK comes with APLN by default so no classpath hacks are required.