### PR TITLE
Fixes small bug in SecureExchangeAttribute#readAttribute()

### DIFF
--- a/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
@@ -30,7 +30,7 @@ public class SecureExchangeAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(HttpServerExchange exchange) {
-        return Boolean.toString(exchange.getProtocol().equals("https"));
+        return Boolean.toString(exchange.getProtocol().equalToString("https"));
     }
 
     @Override


### PR DESCRIPTION
Uses HttpString#equalsToString() to test the protocol of the given exchange instead of HttpString#equals().