### PR TITLE
change defaultEncoding value form 'ISO-8859-1' to 'UTF-8'

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -89,7 +89,7 @@ public class DeploymentInfo implements Cloneable {
     private boolean invalidateSessionOnLogout = false;
     private int defaultCookieVersion = 0;
     private SessionPersistenceManager sessionPersistenceManager;
-    private String defaultEncoding = "ISO-8859-1";
+    private String defaultEncoding = "UTF-8";
     private String urlEncoding = null;
     private boolean ignoreFlush = false;
     private AuthorizationManager authorizationManager = DefaultAuthorizationManager.INSTANCE;


### PR DESCRIPTION
If Chinese characters are not displayed properly，when i try submit a form.