### PR TITLE
Add null-checks when stopping server

### DIFF
--- a/core/src/main/java/io/undertow/Undertow.java
+++ b/core/src/main/java/io/undertow/Undertow.java
@@ -208,15 +208,17 @@ public final class Undertow {
     }
 
     public synchronized void stop() {
-        for (AcceptingChannel<? extends StreamConnection> channel : channels) {
-            IoUtils.safeClose(channel);
+        if (channels != null) {
+            for (AcceptingChannel<? extends StreamConnection> channel : channels) {
+                IoUtils.safeClose(channel);
+            }
+            channels = null;
         }
-        channels = null;
 
         /*
          * Only shutdown the worker if it was created during start()
          */
-        if (internalWorker) {
+        if (internalWorker && worker != null) {
             worker.shutdownNow();
             worker = null;
         }

--- a/core/src/test/java/io/undertow/server/StopTestCase.java
+++ b/core/src/test/java/io/undertow/server/StopTestCase.java
@@ -1,0 +1,26 @@
+package io.undertow.server;
+
+import org.junit.Test;
+import org.xnio.Options;
+
+import io.undertow.Undertow;
+
+public class StopTestCase {
+
+    @Test
+    public void testStopUndertowNotStarted() {
+        Undertow.builder().build().stop();
+    }
+
+    @Test
+    public void testStopUndertowAfterExceptionDuringStart() {
+        // Making the NioXnioWorker constructor throw an exception, resulting in the Undertow.worker field not getting set.
+        Undertow undertow = Undertow.builder().setWorkerOption(Options.WORKER_IO_THREADS, -1).build();
+        try {
+            undertow.start();
+        }
+        catch (RuntimeException e) {
+        }
+        undertow.stop();
+    }
+}


### PR DESCRIPTION
Undertow should not throw a NullPointerException if stopping a server
that is not correctly started.

This could also be merged to the most recent 1.X branch as well.