### PR TITLE
Removed unused parameter in HeaderValues.clearInternal()

### DIFF
--- a/core/src/main/java/io/undertow/util/HeaderValues.java
+++ b/core/src/main/java/io/undertow/util/HeaderValues.java
@@ -59,10 +59,10 @@ public final class HeaderValues extends AbstractCollection<String> implements De
     public void clear() {
         final byte size = this.size;
         if (size == 0) return;
-        clearInternal(size);
+        clearInternal();
     }
 
-    private void clearInternal(byte size) {
+    private void clearInternal() {
         final Object value = this.value;
         if (value instanceof String[]) {
             final String[] strings = (String[]) value;


### PR DESCRIPTION
Hey,

just saw that the size parameter is not used anymore due to previous fixes/refactorings.

Cheers,
Christoph