### PR TITLE
ChannelFunctionFileChannel preventing creation of new instances when not needed 

### DIFF
--- a/core/src/main/java/io/undertow/websockets/core/function/ChannelFunctionFileChannel.java
+++ b/core/src/main/java/io/undertow/websockets/core/function/ChannelFunctionFileChannel.java
@@ -44,7 +44,8 @@ public class ChannelFunctionFileChannel extends FileChannel  {
 
     @Override
     public FileChannel position(long newPosition) throws IOException {
-        return new ChannelFunctionFileChannel(channel.position(newPosition), functions);
+        channel.position(newPosition);
+        return this;
     }
 
     @Override
@@ -54,7 +55,8 @@ public class ChannelFunctionFileChannel extends FileChannel  {
 
     @Override
     public  FileChannel truncate(long size) throws IOException {
-        return new ChannelFunctionFileChannel(channel.truncate(size), functions);
+        channel.truncate(size);
+        return this;
     }
 
     @Override


### PR DESCRIPTION
FileChannel.position(long) and FileChannle.truncate(int) are supposed to return itself. Fixing the code to not create new instance but rather return itself as it is supposed to.
