### PR TITLE
Added a MiddlewareBuilder for easily chaining HttpHandlers

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -478,4 +478,7 @@ public interface UndertowMessages {
 
     @Message(id = 148, value = "Expected server hello")
     SSLHandshakeException expectedServerHello();
+
+    @Message(id = 149, value = "Middleware Function cannot be null")
+    IllegalArgumentException middlewareFunctionCannotBeNull();
 }

--- a/core/src/main/java/io/undertow/server/handlers/MiddlewareBuilder.java
+++ b/core/src/main/java/io/undertow/server/handlers/MiddlewareBuilder.java
@@ -1,0 +1,37 @@
+package io.undertow.server.handlers;
+
+import java.util.function.Function;
+
+import io.undertow.UndertowMessages;
+import io.undertow.server.HttpHandler;
+
+public class MiddlewareBuilder {
+    private final Function<HttpHandler, HttpHandler> function;
+
+    private MiddlewareBuilder(Function<HttpHandler, HttpHandler> function) {
+        middlewareFunctionNotNull(function);
+        this.function = function;
+    }
+
+    public static MiddlewareBuilder begin(Function<HttpHandler, HttpHandler> function) {
+        return new MiddlewareBuilder(function);
+    }
+
+    /*
+     * Since the before function is always passed in we want to apply it first
+     * to make the chained calls apply in order instead of reverse.
+     */
+    public MiddlewareBuilder next(Function<HttpHandler, HttpHandler> before) {
+        return new MiddlewareBuilder(function.compose(before));
+    }
+
+    public HttpHandler complete(HttpHandler handler) {
+        return function.apply(handler);
+    }
+
+    private static void middlewareFunctionNotNull(final Function<HttpHandler, HttpHandler> function) {
+        if (function == null) {
+            throw UndertowMessages.MESSAGES.middlewareFunctionCannotBeNull();
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/server/handlers/MiddlewareBuilderTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/MiddlewareBuilderTestCase.java
@@ -1,0 +1,81 @@
+package io.undertow.server.handlers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+
+
+@RunWith(DefaultServer.class)
+public class MiddlewareBuilderTestCase {
+
+    /*
+     * Simple handler for testing that just adds a constant string to an array.
+     */
+    private static final class ArrayListAppendingHandler implements HttpHandler {
+        private final HttpHandler next;
+        private final List<String> list;
+        private final String toAppend;
+
+        ArrayListAppendingHandler(HttpHandler next, List<String> list, String toAppend) {
+            Handlers.handlerNotNull(next);
+            this.next = next;
+            this.list = list;
+            this.toAppend = toAppend;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            list.add(toAppend);
+            next.handleRequest(exchange);
+        }
+    }
+
+    @Test
+    public void testHandlersApplyInCorrectOrder() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+
+            List<String> handlerOrder = new ArrayList<>();
+            List<String> expectedHandlerOrder = new ArrayList<>(Arrays.asList("foo", "bar", "baz"));
+
+            HttpHandler middlewareHandler =
+                MiddlewareBuilder.begin((next) -> new ArrayListAppendingHandler(next, handlerOrder, "foo"))
+                                 .next((next) -> new ArrayListAppendingHandler(next, handlerOrder, "bar"))
+                                 .next((next) -> new ArrayListAppendingHandler(next, handlerOrder, "baz"))
+                                 .complete(ResponseCodeHandler.HANDLE_200);
+
+            DefaultServer.setRootHandler(middlewareHandler);
+
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            Assert.assertEquals(expectedHandlerOrder, handlerOrder);
+            HttpClientUtils.readResponse(result);
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testHandlersThrowsExceptionOnNull() throws IOException {
+        MiddlewareBuilder.begin(null)
+                         .complete(ResponseCodeHandler.HANDLE_200);
+    }
+
+}


### PR DESCRIPTION
This is something I added on a side project of mine and thought it might be useful. If there is already a way to do this or you have any suggestions please let me know. If you feel it doesn't belong thats also fine.

Here is a more real world example of how I use it on my side project.
```
private static final HttpHandler wrapWithMiddleware(HttpHandler handler) {
    return MiddlewareBuilder.begin(BlockingHandler::new)
                            .next(CustomHandlers::requestLogging)
                            .next(CustomHandlers::statusCodeMetrics)
                            .next(Server::exceptionHandler)
                            .complete(handler);
}
```