### PR TITLE
Extend PathTemplate (match method) to support wildcard matching in path string

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
@@ -90,6 +90,12 @@ public class RoutingHandlerTestCase {
                 });
 
         DefaultServer.setRootHandler(Handlers.routing()
+                .add(Methods.GET, "/wild/{test}/*", new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        exchange.getResponseSender().send("wild:" + exchange.getQueryParameters().get("test") + ":" + exchange.getQueryParameters().get("*"));
+                    }
+                })
                 .add(Methods.GET, "/foo", new HttpHandler() {
                     @Override
                     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -184,6 +190,21 @@ public class RoutingHandlerTestCase {
             result = client.execute(delete);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             Assert.assertEquals("DELETE bar", HttpClientUtils.readResponse(result));
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+
+    @Test
+    public void testWildCardRoutingTemplateHandler() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/wild/test/card");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            Assert.assertEquals("wild:[test]:[card]", HttpClientUtils.readResponse(result));
 
         } finally {
             client.getConnectionManager().shutdown();

--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -67,6 +67,19 @@ public class PathTemplateTestCase {
         testMatch("/{value}", "/{value}", "value", "{value}");
     }
 
+    @Test
+    public void wildCardTests() {
+        // wildcard matches
+        testMatch("/*", "/docs/mydoc/test","*","docs/mydoc/test");
+        testMatch("/docs/*", "/docs/mydoc/test","*","mydoc/test");
+        testMatch("/docs*", "/docs/mydoc/test","*","/mydoc/test");
+        testMatch("/docs/*", "/docs/mydoc/test/test2","*","mydoc/test/test2");
+        testMatch("/docs/{docId}/*", "/docs/mydoc/test", "docId", "mydoc", "*","test");
+        testMatch("/docs/{docId}/*", "/docs/mydoc/", "docId", "mydoc", "*","");
+        testMatch("/docs/{docId}/*", "/docs/mydoc/test/test2/test3/test4", "docId", "mydoc", "*","test/test2/test3/test4");
+        testMatch("/docs/{docId}/{docId2}/*", "/docs/mydoc/test/test2/test3/test4", "docId", "mydoc","docId2", "test", "*","test2/test3/test4");
+    }
+
     @Test(expected=IllegalArgumentException.class)
     public void testNullPath() {
         PathTemplate.create(null);


### PR DESCRIPTION
hallo *,

i extend PathTemplate to support wildcard matching in path string
for example path url like /docs/{docId}/* match /docs/test/my.

i hope that is ok for the first pull request.

Thanks,
Arek