### PR TITLE
Parse languages according to RFC7231 / RFC5646 / BCP47

### DIFF
--- a/core/src/main/java/io/undertow/util/LocaleUtils.java
+++ b/core/src/main/java/io/undertow/util/LocaleUtils.java
@@ -34,17 +34,7 @@ public class LocaleUtils {
         if (localeString == null) {
             return null;
         }
-        final String[] parts = localeString.split("-");
-        if (parts.length == 0) {
-            return null;
-        }
-        if (parts.length == 1) {
-            return new Locale(localeString, "");
-        } else if (parts.length == 2) {
-            return new Locale(parts[0], parts[1]);
-        } else {
-            return new Locale(parts[0], parts[1], parts[2]);
-        }
+        return Locale.forLanguageTag(localeString);
     }
 
     /**

--- a/core/src/test/java/io/undertow/util/LocaleUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/LocaleUtilsTestCase.java
@@ -1,5 +1,7 @@
 package io.undertow.util;
 
+import java.util.Locale;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -7,7 +9,7 @@ public class LocaleUtilsTestCase {
 
     @Test
     public void testGetLocaleFromInvalidString() throws Exception {
-        Assert.assertNull(LocaleUtils.getLocaleFromString("-"));
+        Assert.assertEquals(LocaleUtils.getLocaleFromString("-"), new Locale(""));
     }
 
 }


### PR DESCRIPTION
According to the newer standard RFC7231 (HTTP/1.1), the Accept-Language can
be used to indicate the desired languages by using language tags as defined
in RFC5646 (BCP 47).

This obsoletes the older standards RFC2616 and RFC2068, which had a different
definition for the content of Accept-Language.

Nevertheless, the newer definition is a superset of the old one, and therefore
the language tag parser should be changed to accept the newer BCP47 compatible
tags (which should not make any difference for almost all real world language
tags).

As we should parse language tags (i.e. user generated content) as lenient as possible, we simply can use Locale.forLanguageTag, which itself does all the magic to parse given inputs as lenient as possible.