### PR TITLE
SPDY Connection: Make synchronized requests

### DIFF
--- a/core/src/main/java/io/undertow/client/spdy/SpdyClientConnection.java
+++ b/core/src/main/java/io/undertow/client/spdy/SpdyClientConnection.java
@@ -85,7 +85,7 @@ public class SpdyClientConnection implements ClientConnection {
     }
 
     @Override
-    public void sendRequest(ClientRequest request, ClientCallback<ClientExchange> clientCallback) {
+    public synchronized void sendRequest(ClientRequest request, ClientCallback<ClientExchange> clientCallback) {
         request.getRequestHeaders().put(PATH, request.getPath());
         request.getRequestHeaders().put(SCHEME, "https");
         request.getRequestHeaders().put(VERSION, request.getProtocol().toString());


### PR DESCRIPTION
In the SPDY protocol the order of streams is important.
Multi-thread apps that use undertow to interact with SPDY servers
must use a synchronized request in order to guarantee that streams
don't arrive in a messed order in the endpoint.