### PR TITLE
fixed appending port 80 if "X-Forwarded-Port" is empty

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -93,16 +93,15 @@ public class ProxyPeerAddressHandler implements HttpHandler {
                 }
             }
             int port = 0;
+            String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
             if(forwardedPort != null) {
                 try {
                     port = Integer.parseInt(forwardedPort);
+                    hostHeader += ":" + port;
                 } catch (NumberFormatException ignore) {
                     UndertowLogger.REQUEST_LOGGER.debugf("Cannot parse port: %s", forwardedPort);
                 }
             }
-            String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
-            if (port != 0)
-               hostHeader += ":" + port;
             exchange.getRequestHeaders().put(Headers.HOST, hostHeader);
             exchange.setDestinationAddress(InetSocketAddress.createUnresolved(value, port));
         }

--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -92,7 +92,7 @@ public class ProxyPeerAddressHandler implements HttpHandler {
                     value = value.substring(0, index);
                 }
             }
-            int port = 80;
+            int port = 0;
             if(forwardedPort != null) {
                 try {
                     port = Integer.parseInt(forwardedPort);
@@ -100,8 +100,11 @@ public class ProxyPeerAddressHandler implements HttpHandler {
                     UndertowLogger.REQUEST_LOGGER.debugf("Cannot parse port: %s", forwardedPort);
                 }
             }
+            String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
+            if (port != 0)
+               hostHeader += ":" + port;
+            exchange.getRequestHeaders().put(Headers.HOST, hostHeader);
             exchange.setDestinationAddress(InetSocketAddress.createUnresolved(value, port));
-            exchange.getRequestHeaders().put(Headers.HOST, NetworkUtils.formatPossibleIpv6Address(value) + ":" + port);
         }
         next.handleRequest(exchange);
     }


### PR DESCRIPTION
A suggestion to address port handling in ProxyPeerAddressHandler.
See https://issues.jboss.org/browse/UNDERTOW-756