### PR TITLE
JBEAP 5865 - No warning logged for uncovered HTTP methods by security constraints	

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -21,6 +21,7 @@ package io.undertow.servlet;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Date;
+import java.util.Set;
 import javax.servlet.ServletException;
 import javax.servlet.UnavailableException;
 
@@ -32,6 +33,7 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * log messages start at 15000
@@ -120,4 +122,8 @@ public interface UndertowServletLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 15019, value = "Failed to destroy %s")
     void failedToDestroy(Object object, @Cause Exception e);
+
+    @LogMessage(level = WARN)
+    @Message(id = 15020, value = "Path %s is secured for some HTTP methods, however it is not secured for %s")
+    void unsecuredMethodsOnPath(String path, Set<String> missing);
 }

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -303,6 +303,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
         current = new SSLInformationAssociationHandler(current);
 
         final SecurityPathMatches securityPathMatches = buildSecurityConstraints();
+        securityPathMatches.logWarningsAboutUncoveredMethods();
         current = new ServletAuthenticationCallHandler(current);
 
         for(HandlerWrapper wrapper : deploymentInfo.getSecurityWrappers()) {


### PR DESCRIPTION
Backport of [e6b8983189509ddae3dbc92e2bf1fbfcf1736b3c](https://github.com/undertow-io/undertow/commit/e6b8983189509ddae3dbc92e2bf1fbfcf1736b3c) into maintenance branch (1.3) for EAP7.

Upstream Issue: [UNDERTOW-848](https://issues.jboss.org/browse/UNDERTOW-848) (already merged)
