### PR TITLE
Reduce memory consumption caused by Method.getParameterTypes()

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/EncodingFactory.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/EncodingFactory.java
@@ -295,10 +295,10 @@ public class EncodingFactory {
     private static Class<?> findEncodeMethod(final Class<? extends Encoder> encoder, final Class<?> returnType, Class<?>... otherParameters) throws DeploymentException {
         for (Method method : encoder.getMethods()) {
             if (method.getName().equals("encode") && !method.isBridge() &&
-                    method.getParameterTypes().length == 1 + otherParameters.length &&
+                    method.getParameterCount() == 1 + otherParameters.length &&
                     method.getReturnType() == returnType) {
                 boolean ok = true;
-                for (int i = 1; i < method.getParameterTypes().length; ++i) {
+                for (int i = 1; i < method.getParameterCount(); ++i) {
                     if (method.getParameterTypes()[i] != otherParameters[i - 1]) {
                         ok = false;
                         break;

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/AnnotatedEndpointFactory.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/AnnotatedEndpointFactory.java
@@ -265,8 +265,8 @@ public class AnnotatedEndpointFactory {
 
 
     private static String[] pathParams(final Method method) {
-        String[] params = new String[method.getParameterTypes().length];
-        for (int i = 0; i < method.getParameterTypes().length; ++i) {
+        String[] params = new String[method.getParameterCount()];
+        for (int i = 0; i < method.getParameterCount(); ++i) {
             PathParam param = getPathParam(method, i);
             if (param != null) {
                 params[i] = param.value();
@@ -317,7 +317,7 @@ public class AnnotatedEndpointFactory {
         BoundSingleParameter(final Method method, final Class<?> type, final boolean optional) {
             this.type = type;
             int pos = -1;
-            for (int i = 0; i < method.getParameterTypes().length; ++i) {
+            for (int i = 0; i < method.getParameterCount(); ++i) {
                 boolean pathParam = false;
                 for (Annotation annotation : method.getParameterAnnotations()[i]) {
                     if (annotation.annotationType().equals(PathParam.class)) {

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/BoundMethod.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/annotated/BoundMethod.java
@@ -49,7 +49,7 @@ final class BoundMethod {
         this.decoderRequired = decoderRequired;
         this.maxMessageSize = maxMessageSize;
         final Set<Integer> allParams = new HashSet<>();
-        for (int i = 0; i < method.getParameterTypes().length; ++i) {
+        for (int i = 0; i < method.getParameterCount(); ++i) {
             allParams.add(i);
             paramTypes.add(method.getParameterTypes()[i]);
         }
@@ -79,7 +79,7 @@ final class BoundMethod {
     }
 
     public Object invoke(final Object instance, final Map<Class<?>, Object> values) throws Exception {
-        final Object[] params = new Object[method.getParameterTypes().length];
+        final Object[] params = new Object[method.getParameterCount()];
         for (BoundParameter param : parameters) {
             param.populate(params, values);
         }
@@ -119,11 +119,16 @@ final class BoundMethod {
         if(!method.getReturnType().isAssignableFrom(this.method.getReturnType())) {
             return false;
         }
-        if(method.getParameterTypes().length != this.method.getParameterTypes().length) {
+        if(method.getParameterCount() != this.method.getParameterCount()) {
             return false;
         }
-        for(int i = 0; i < method.getParameterTypes().length; ++i) {
-            if(method.getParameterTypes()[i] != this.method.getParameterTypes()[i]) {
+        if(method.getParameterCount() == 0) {
+            return true;
+        }
+        Class<?>[] otherParameterTypes = this.method.getParameterTypes();
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for(int i = 0; i < parameterTypes.length; ++i) {
+            if(parameterTypes[i] != otherParameterTypes[i]) {
                 return false;
             }
         }


### PR DESCRIPTION
Hey,

As of Java 8 there is the possibilty to call Method.getParameterCount(), which is a much more efficient variant in case just the parameter count is needed. Method.getParameterTypes() clones the underlying parameters and therefore creates unnecessary pressure on the heap in such cases.

I revised all places to use the new method.

Cheers,
Christoph
