### PR TITLE
Return default charset if Content-Type header is absent.

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -582,12 +582,11 @@ public final class HttpServerExchange extends AbstractAttachable {
 
     private String extractCharset(HeaderMap headers) {
         String contentType = headers.getFirst(Headers.CONTENT_TYPE);
-        if (contentType == null) {
-            return null;
-        }
-        String value = Headers.extractQuotedValueFromHeader(contentType, "charset");
-        if(value != null) {
-            return value;
+        if (contentType != null) {
+            String value = Headers.extractQuotedValueFromHeader(contentType, "charset");
+            if (value != null) {
+                return value;
+            }
         }
         return ISO_8859_1;
     }


### PR DESCRIPTION
To be par with the Javadoc on `getRequestCharset()` and `getResponseCharset()`, also return `ISO_8859_1` instead of `null` in the case of an absent Content-Type header.