### PR TITLE
Switch to enhanced EnumSet in DigestAuthenticationMechanism

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/DigestAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/DigestAuthenticationMechanism.java
@@ -47,7 +47,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
     private static final Set<DigestAuthorizationToken> MANDATORY_REQUEST_TOKENS;
 
     static {
-        Set<DigestAuthorizationToken> mandatoryTokens = new HashSet<>();
+        Set<DigestAuthorizationToken> mandatoryTokens = EnumSet.noneOf(DigestAuthorizationToken.class);
         mandatoryTokens.add(DigestAuthorizationToken.USERNAME);
         mandatoryTokens.add(DigestAuthorizationToken.REALM);
         mandatoryTokens.add(DigestAuthorizationToken.NONCE);
@@ -183,7 +183,7 @@ public class DigestAuthenticationMechanism implements AuthenticationMechanism {
         DigestContext context = exchange.getAttachment(DigestContext.ATTACHMENT_KEY);
         Map<DigestAuthorizationToken, String> parsedHeader = context.getParsedHeader();
         // Step 1 - Verify the set of tokens received to ensure valid values.
-        Set<DigestAuthorizationToken> mandatoryTokens = new HashSet<>(MANDATORY_REQUEST_TOKENS);
+        Set<DigestAuthorizationToken> mandatoryTokens = EnumSet.copyOf(MANDATORY_REQUEST_TOKENS);
         if (!supportedAlgorithms.contains(DigestAlgorithm.MD5)) {
             // If we don't support MD5 then the client must choose an algorithm as we can not fall back to MD5.
             mandatoryTokens.add(DigestAuthorizationToken.ALGORITHM);

--- a/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
+++ b/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
@@ -23,7 +23,7 @@ import io.undertow.security.idm.DigestAlgorithm;
 import io.undertow.security.impl.DigestAuthorizationToken;
 import io.undertow.security.impl.DigestQop;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class ParseDigestAuthorizationTokenTestCase {
     public void testChrome_22() {
         final String header = "username=\"userTwo\", realm=\"Digest_Realm\", nonce=\"Yxmkh5liIOYNMTM1MTUyNjQzMTE4NJziT7YLEOEJ4QEN1py4Yog=\", uri=\"/\", algorithm=MD5, response=\"5b26e00233607e8a714cd1d910692e08\", opaque=\"00000000000000000000000000000000\", qop=auth, nc=00000001, cnonce=\"8c008c8ce43dc0a7\"";
 
-        Map<DigestAuthorizationToken, String> expected = new HashMap<>(10);
+        Map<DigestAuthorizationToken, String> expected = new EnumMap<>(DigestAuthorizationToken.class);
         expected.put(DigestAuthorizationToken.USERNAME, "userTwo");
         expected.put(DigestAuthorizationToken.REALM, "Digest_Realm");
         expected.put(DigestAuthorizationToken.NONCE, "Yxmkh5liIOYNMTM1MTUyNjQzMTE4NJziT7YLEOEJ4QEN1py4Yog=");
@@ -70,7 +70,7 @@ public class ParseDigestAuthorizationTokenTestCase {
     public void testCurl_7() {
         final String header = "username=\"userTwo\", realm=\"Digest_Realm\", nonce=\"5CgZ39vhie0NMTM1MTUyNDc4ODkwNMwr6sWKVSGfhXB4jBtkupY=\", uri=\"/\", cnonce=\"MTYwOTQ4\", nc=00000001, qop=\"auth\", response=\"c3c1ce9945a0c36d54860eda7846018b\", opaque=\"00000000000000000000000000000000\", algorithm=\"MD5\"";
 
-        Map<DigestAuthorizationToken, String> expected = new HashMap<>(10);
+        Map<DigestAuthorizationToken, String> expected = new EnumMap<>(DigestAuthorizationToken.class);
         expected.put(DigestAuthorizationToken.USERNAME, "userTwo");
         expected.put(DigestAuthorizationToken.REALM, "Digest_Realm");
         expected.put(DigestAuthorizationToken.NONCE, "5CgZ39vhie0NMTM1MTUyNDc4ODkwNMwr6sWKVSGfhXB4jBtkupY=");
@@ -89,7 +89,7 @@ public class ParseDigestAuthorizationTokenTestCase {
     public void testFirefox_16() {
         final String header = "username=\"userOne\", realm=\"Digest_Realm\", nonce=\"nBhFxtSS6rkNMTM1MTUyNjE2MjgyNWA/xW/LOH53vhXGq/2B/yQ=\", uri=\"/\", algorithm=MD5, response=\"b0adb1025da2de0d16f44131858bad6f\", opaque=\"00000000000000000000000000000000\", qop=auth, nc=00000001, cnonce=\"8127726535363b07\"";
 
-        Map<DigestAuthorizationToken, String> expected = new HashMap<>(10);
+        Map<DigestAuthorizationToken, String> expected = new EnumMap<>(DigestAuthorizationToken.class);
         expected.put(DigestAuthorizationToken.USERNAME, "userOne");
         expected.put(DigestAuthorizationToken.REALM, "Digest_Realm");
         expected.put(DigestAuthorizationToken.NONCE, "nBhFxtSS6rkNMTM1MTUyNjE2MjgyNWA/xW/LOH53vhXGq/2B/yQ=");
@@ -108,7 +108,7 @@ public class ParseDigestAuthorizationTokenTestCase {
     public void testOpera_12() {
         final String header = "username=\"userOne\", realm=\"Digest_Realm\", uri=\"/\", algorithm=MD5, nonce=\"D2floAc+FhkNMTM1MTUyMzY2ODc4Mhbi2Zrcuv1lvdgEaPXa+bg=\", cnonce=\"v722VYJEeG28C3SoXS8BEWThGHPDOlXgUCCts70i7Fc=\", opaque=\"00000000000000000000000000000000\", qop=auth, nc=00000001, response=\"8106a5d19bc67982527cbb576658f9d6\"";
 
-        Map<DigestAuthorizationToken, String> expected = new HashMap<>(10);
+        Map<DigestAuthorizationToken, String> expected = new EnumMap<>(DigestAuthorizationToken.class);
         expected.put(DigestAuthorizationToken.USERNAME, "userOne");
         expected.put(DigestAuthorizationToken.REALM, "Digest_Realm");
         expected.put(DigestAuthorizationToken.DIGEST_URI, "/");


### PR DESCRIPTION
Hey,

I just noticed that we could switch to an enhanced EnumSet instead of a HashSet for mandatory tokens inside DigestAuthenticationMechanism. As it's backed by a simple array, access to the tokens will be much faster. 

While doing so, I adjusted a test inside the same context of digests to use an EnumMap instead of a HashMap.

Cheerio,
Christoph