### PR TITLE
UNDERTOW-545 - SPNEGO test fixed.

### DIFF
--- a/core/src/test/java/io/undertow/server/security/KerberosKDCUtil.java
+++ b/core/src/test/java/io/undertow/server/security/KerberosKDCUtil.java
@@ -104,9 +104,9 @@ class KerberosKDCUtil {
         if (initialised) {
             return false;
         }
+        setupEnvironment();
         startLdapServer();
         startKDC();
-        setupEnvironment();
 
         initialised = true;
         return true;

--- a/core/src/test/resources/krb5.conf
+++ b/core/src/test/resources/krb5.conf
@@ -1,7 +1,7 @@
 [libdefaults]
 	default_realm = UNDERTOW.IO
-	default_tgs_enctypes = des-cbc-md5,des3-cbc-sha1-kd
-	default_tkt_enctypes = des-cbc-md5,des3-cbc-sha1-kd
+	default_tgs_enctypes = aes128-cts-hmac-sha1-96,des-cbc-md5,des3-cbc-sha1-kd
+	default_tkt_enctypes = aes128-cts-hmac-sha1-96,des-cbc-md5,des3-cbc-sha1-kd
 	kdc_timeout = 5000
 	dns_lookup_realm = false
 	dns_lookup_kdc = false


### PR DESCRIPTION
* Updated enctypes in krb5.conf to enctypes properly working also on IBM JDK
* Setup environment for krb5.conf location moved before actually starting the server.
* Solved issue when token decoded from the header contains improperly 0 bytes at the end, making the token byte[] corrupted by using Base64.decode.