### PR TITLE
[JBEAP-6716,UNDERTOW-881] AJP and HTTP/2 listeners ignore max header …

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -149,7 +149,7 @@ public interface UndertowMessages {
     RuntimeException tooManyQueryParameters(int noParams);
 
     @Message(id = 40, value = "To many headers, cannot have more than %s header")
-    RuntimeException tooManyHeaders(int noParams);
+    String tooManyHeaders(int noParams);
 
     @Message(id = 41, value = "Channel is closed")
     ClosedChannelException channelIsClosed();

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -77,6 +77,8 @@ public class UndertowOptions {
      */
     public static final Option<Integer> NO_REQUEST_TIMEOUT = Option.simple(UndertowOptions.class, "NO_REQUEST_TIMEOUT", Integer.class);
 
+    public static final int DEFAULT_MAX_PARAMETERS = 1000;
+
     /**
      * The maximum number of parameters that will be parsed. This is used to protect against hash vulnerabilities.
      * <p>
@@ -86,6 +88,8 @@ public class UndertowOptions {
      * Defaults to 1000
      */
     public static final Option<Integer> MAX_PARAMETERS = Option.simple(UndertowOptions.class, "MAX_PARAMETERS", Integer.class);
+
+    public static final int DEFAULT_MAX_HEADERS = 200;
 
     /**
      * The maximum number of headers that will be parsed. This is used to protect against hash vulnerabilities.

--- a/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
@@ -129,6 +129,7 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
     private int receiveMaxFrameSize = DEFAULT_MAX_FRAME_SIZE;
     private int unackedReceiveMaxFrameSize = DEFAULT_MAX_FRAME_SIZE; //the old max frame size, this gets updated when our setting frame is acked
     private int maxHeaderListSize = -1;
+    private final int maxHeaders;
 
     /**
      * How much data we have told the remote endpoint we are prepared to accept.
@@ -178,6 +179,7 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
         this.initialReceiveWindowSize = settings.get(UndertowOptions.HTTP2_SETTINGS_INITIAL_WINDOW_SIZE, DEFAULT_INITIAL_WINDOW_SIZE);
 
         this.protocol = protocol == null ? Http2OpenListener.HTTP2 : protocol;
+        this.maxHeaders = settings.get(UndertowOptions.MAX_HEADERS, clientSide ? -1 : UndertowOptions.DEFAULT_MAX_HEADERS);
 
         encoderHeaderTableSize = settings.get(UndertowOptions.HTTP2_SETTINGS_HEADER_TABLE_SIZE, Hpack.DEFAULT_TABLE_SIZE);
         receiveMaxFrameSize = settings.get(UndertowOptions.HTTP2_SETTINGS_MAX_FRAME_SIZE, DEFAULT_MAX_FRAME_SIZE);
@@ -744,6 +746,10 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
 
     HpackDecoder getDecoder() {
         return decoder;
+    }
+
+    int getMaxHeaders() {
+        return maxHeaders;
     }
 
     @Override

--- a/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
@@ -79,7 +79,7 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                     if (streamId == 0) {
                         throw new ConnectionErrorException(Http2Channel.ERROR_PROTOCOL_ERROR, UndertowMessages.MESSAGES.streamIdMustNotBeZeroForFrameType(Http2Channel.FRAME_TYPE_HEADERS));
                     }
-                    parser = new Http2HeadersParser(length, http2Channel.getDecoder());
+                    parser = new Http2HeadersParser(length, http2Channel.getDecoder(), http2Channel.getMaxHeaders());
                     if(allAreClear(flags, Http2Channel.HEADERS_FLAG_END_HEADERS)) {
                         continuationParser = (Http2HeadersParser) parser;
                     }
@@ -99,7 +99,7 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                     break;
                 }
                 case FRAME_TYPE_PUSH_PROMISE: {
-                    parser = new Http2PushPromiseParser(length, http2Channel.getDecoder());
+                    parser = new Http2PushPromiseParser(length, http2Channel.getDecoder(), http2Channel.getMaxHeaders());
                     if(allAreClear(flags, Http2Channel.HEADERS_FLAG_END_HEADERS)) {
                         continuationParser = (Http2HeadersParser) parser;
                     }

--- a/core/src/main/java/io/undertow/protocols/http2/Http2HeaderBlockParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2HeaderBlockParser.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
 import org.xnio.Bits;
 
 import io.undertow.util.HeaderMap;
@@ -40,14 +41,19 @@ abstract class Http2HeaderBlockParser extends Http2PushBackParser implements Hpa
     private final HpackDecoder decoder;
     private int frameRemaining = -1;
     private boolean invalid = false;
+    private final int maxHeaders;
 
-    Http2HeaderBlockParser(int frameLength, HpackDecoder decoder) {
+    Http2HeaderBlockParser(int frameLength, HpackDecoder decoder, int maxHeaders) {
         super(frameLength);
         this.decoder = decoder;
+        this.maxHeaders = maxHeaders;
     }
 
     @Override
     protected void handleData(ByteBuffer resource, Http2FrameHeaderParser header) throws IOException {
+        if(maxHeaders > 0 && headerMap.size() >= maxHeaders) {
+            throw new IOException(UndertowMessages.MESSAGES.tooManyHeaders(maxHeaders));
+        }
         boolean continuationFramesComing = Bits.anyAreClear(header.flags, Http2Channel.HEADERS_FLAG_END_HEADERS);
         if (frameRemaining == -1) {
             frameRemaining = header.length;

--- a/core/src/main/java/io/undertow/protocols/http2/Http2HeadersParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2HeadersParser.java
@@ -35,8 +35,8 @@ class Http2HeadersParser extends Http2HeaderBlockParser {
     private boolean headersEndStream = false;
     private boolean exclusive;
 
-    Http2HeadersParser(int frameLength, HpackDecoder hpackDecoder) {
-        super(frameLength, hpackDecoder);
+    Http2HeadersParser(int frameLength, HpackDecoder hpackDecoder, int maxHeaders) {
+        super(frameLength, hpackDecoder, maxHeaders);
     }
 
     @Override

--- a/core/src/main/java/io/undertow/protocols/http2/Http2PushPromiseParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2PushPromiseParser.java
@@ -33,8 +33,8 @@ class Http2PushPromiseParser extends Http2HeaderBlockParser {
     private int promisedStreamId;
     private static final int STREAM_MASK = ~(1 << 7);
 
-    Http2PushPromiseParser(int frameLength, HpackDecoder hpackDecoder) {
-        super(frameLength, hpackDecoder);
+    Http2PushPromiseParser(int frameLength, HpackDecoder hpackDecoder, int maxHeaders) {
+        super(frameLength, hpackDecoder, maxHeaders);
     }
 
     @Override

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
@@ -82,7 +82,7 @@ public class AjpOpenListener implements OpenListener {
         PooledByteBuffer buf = pool.allocate();
         this.bufferSize = buf.getBuffer().remaining();
         buf.close();
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS));
         connectorStatistics = new ConnectorStatisticsImpl();
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
     }
@@ -153,7 +153,7 @@ public class AjpOpenListener implements OpenListener {
         }
         this.undertowOptions = undertowOptions;
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS));
     }
 
     @Override

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -67,6 +67,8 @@ public class AjpRequestParser {
 
     private final String encoding;
     private final boolean doDecode;
+    private final int maxParameters;
+    private final int maxHeaders;
 
     private static final HttpString[] HTTP_HEADERS;
 
@@ -169,13 +171,15 @@ public class AjpRequestParser {
         ATTRIBUTES[13] = STORED_METHOD;
     }
 
-    public AjpRequestParser(String encoding, boolean doDecode) {
+    public AjpRequestParser(String encoding, boolean doDecode, int maxParameters, int maxHeaders) {
         this.encoding = encoding;
         this.doDecode = doDecode;
+        this.maxParameters = maxParameters;
+        this.maxHeaders = maxHeaders;
     }
 
 
-    public void parse(final ByteBuffer buf, final AjpRequestParseState state, final HttpServerExchange exchange) throws IOException {
+    public void parse(final ByteBuffer buf, final AjpRequestParseState state, final HttpServerExchange exchange) throws IOException, BadRequestException {
         if (!buf.hasRemaining()) {
             return;
         }
@@ -250,7 +254,7 @@ public class AjpRequestParser {
                         exchange.setRequestURI(result.value);
                         exchange.setRequestPath(res);
                         exchange.setRelativePath(res);
-                        URLUtils.parsePathParms(result.value.substring(colon + 1), exchange, encoding, doDecode && result.containsUrlCharacters);
+                        URLUtils.parsePathParms(result.value.substring(colon + 1), exchange, encoding, doDecode && result.containsUrlCharacters, maxParameters);
                     }
                 } else {
                     state.state = AjpRequestParseState.READING_REQUEST_URI;
@@ -313,6 +317,9 @@ public class AjpRequestParser {
                     return;
                 } else {
                     state.numHeaders = result.value;
+                    if(state.numHeaders > maxHeaders) {
+                        throw new BadRequestException(UndertowMessages.MESSAGES.tooManyHeaders(state.numHeaders));
+                    }
                 }
             }
             case AjpRequestParseState.READING_HEADERS: {
@@ -392,8 +399,9 @@ public class AjpRequestParser {
                     }
                     //query string.
                     if (state.currentAttribute.equals(QUERY_STRING)) {
-                        exchange.setQueryString(result == null ? "" : result);
-                        URLUtils.parseQueryString(result, exchange, encoding, doDecode);
+                        String resultAsQueryString = result == null ? "" : result;
+                        exchange.setQueryString(resultAsQueryString);
+                        URLUtils.parseQueryString(resultAsQueryString, exchange, encoding, doDecode, maxParameters);
                     } else if (state.currentAttribute.equals(REMOTE_USER)) {
                         exchange.putAttachment(ExternalAuthenticationMechanism.EXTERNAL_PRINCIPAL, result);
                     } else if (state.currentAttribute.equals(AUTH_TYPE)) {
@@ -554,6 +562,11 @@ public class AjpRequestParser {
         URL,
         QUERY_STRING,
         OTHER
+    }
 
+    public static class BadRequestException extends Exception {
+        public BadRequestException(String msg) {
+            super(msg);
+        }
     }
 }

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -68,6 +68,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
     private final StringBuilder decodeBuffer = new StringBuilder();
     private final boolean allowEncodingSlash;
     private final int bufferSize;
+    private final int maxParameters;
 
 
 
@@ -89,6 +90,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         this.maxEntitySize = undertowOptions.get(UndertowOptions.MAX_ENTITY_SIZE, UndertowOptions.DEFAULT_MAX_ENTITY_SIZE);
         this.allowEncodingSlash = undertowOptions.get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
         this.decode = undertowOptions.get(UndertowOptions.DECODE_URL, true);
+        this.maxParameters = undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS);
         if (undertowOptions.get(UndertowOptions.DECODE_URL, true)) {
             this.encoding = undertowOptions.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
         } else {
@@ -144,7 +146,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         exchange.getRequestHeaders().put(Headers.HOST, exchange.getRequestHeaders().getFirst(AUTHORITY));
 
         final String path = exchange.getRequestHeaders().getFirst(PATH);
-        Connectors.setExchangeRequestPath(exchange, path, encoding, decode, allowEncodingSlash, decodeBuffer);
+        Connectors.setExchangeRequestPath(exchange, path, encoding, decode, allowEncodingSlash, decodeBuffer, maxParameters);
         SSLSession session = channel.getSslSession();
         if(session != null) {
             connection.setSslSessionInfo(new Http2SslSessionInfo(channel));
@@ -202,7 +204,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         exchange.setRequestMethod(initial.getRequestMethod());
         exchange.setQueryString(initial.getQueryString());
         String uri = exchange.getQueryString().isEmpty() ? initial.getRequestURI() : initial.getRequestURI() + '?' + exchange.getQueryString();
-        Connectors.setExchangeRequestPath(exchange, uri, encoding, decode, allowEncodingSlash, decodeBuffer);
+        Connectors.setExchangeRequestPath(exchange, uri, encoding, decode, allowEncodingSlash, decodeBuffer, maxParameters);
 
         SSLSession session = channel.getSslSession();
         if(session != null) {

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -397,7 +397,7 @@ public class Http2ServerConnection extends ServerConnection {
             exchange.setRequestMethod(method);
             exchange.setProtocol(Protocols.HTTP_1_1);
             exchange.setRequestScheme(this.exchange.getRequestScheme());
-            Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false), new StringBuilder());
+            Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
 
             Connectors.terminateRequest(exchange);
             getIoThread().execute(new Runnable() {

--- a/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
@@ -23,13 +23,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.xnio.IoUtils;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
-import org.junit.Assert;
-import org.junit.Test;
-import org.xnio.IoUtils;
 
 /**
  * @author Stuart Douglas
@@ -55,11 +55,11 @@ public class AjpParsingUnitTestCase {
         }
     }
 
-    public static final AjpRequestParser AJP_REQUEST_PARSER = new AjpRequestParser("UTF-8", true);
+    public static final AjpRequestParser AJP_REQUEST_PARSER = new AjpRequestParser("UTF-8", true, 100, 100);
 
 
     @Test
-    public void testAjpParsing() throws IOException {
+    public void testAjpParsing() throws IOException, AjpRequestParser.BadRequestException {
         final ByteBuffer buffer = AjpParsingUnitTestCase.buffer.duplicate();
         HttpServerExchange result = new HttpServerExchange(null);
         final AjpRequestParseState state = new AjpRequestParseState();
@@ -72,7 +72,7 @@ public class AjpParsingUnitTestCase {
     }
 
     @Test
-    public void testByteByByteAjpParsing() throws IOException {
+    public void testByteByByteAjpParsing() throws IOException, AjpRequestParser.BadRequestException {
         final ByteBuffer buffer = AjpParsingUnitTestCase.buffer.duplicate();
 
         HttpServerExchange result = new HttpServerExchange(null);

--- a/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
@@ -53,7 +53,7 @@ public class ParserResumeTestCase {
     }
 
     @Test
-    public void testOneCharacterAtATime() {
+    public void testOneCharacterAtATime() throws HttpRequestParser.BadRequestException {
         context.reset();
         byte[] in = DATA.getBytes();
         HttpServerExchange result = new HttpServerExchange(null);
@@ -70,7 +70,7 @@ public class ParserResumeTestCase {
         runAssertions(result);
     }
 
-    private void testResume(final int split, byte[] in) {
+    private void testResume(final int split, byte[] in) throws HttpRequestParser.BadRequestException {
         context.reset();
         HttpServerExchange result = new HttpServerExchange(null);
         ByteBuffer buffer = ByteBuffer.wrap(in);

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -46,7 +46,7 @@ public class SimpleParserTestCase {
     private final ParseState parseState = new ParseState();
 
     @Test
-    public void testEncodedSlashDisallowed() {
+    public void testEncodedSlashDisallowed() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath%2FotherPath HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -58,7 +58,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testEncodedSlashAllowed() {
+    public void testEncodedSlashAllowed() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath%2fotherPath HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -70,7 +70,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testColonSlashInURL() {
+    public void testColonSlashInURL() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /a/http://myurl.com/b/c HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -82,7 +82,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testColonSlashInFullURL() {
+    public void testColonSlashInFullURL() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET http://foo.com/a/http://myurl.com/b/c HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -95,7 +95,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testPathParameters() {
+    public void testPathParameters() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath;p1 HTTP/1.1\r\n\r\n".getBytes();
         ParseState context = new ParseState();
         HttpServerExchange result = new HttpServerExchange(null);
@@ -119,7 +119,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testFullUrlRootPath() {
+    public void testFullUrlRootPath() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET http://myurl.com HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -130,7 +130,7 @@ public class SimpleParserTestCase {
         Assert.assertEquals("http://myurl.com", result.getRequestURI());
     }
     @Test
-    public void testSimpleRequest() {
+    public void testSimpleRequest() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: some\r\n    value\r\n\r\n".getBytes();
         runTest(in);
     }
@@ -138,7 +138,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testSimpleRequestWithHeaderCaching() {
+    public void testSimpleRequestWithHeaderCaching() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: foo\r\n\r\n".getBytes();
         runTest(in, "foo");
         in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader:       foo\r\n\r\n".getBytes();
@@ -151,26 +151,26 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testCarriageReturnLineEnds() {
+    public void testCarriageReturnLineEnds() throws HttpRequestParser.BadRequestException {
 
         byte[] in = "GET /somepath HTTP/1.1\rHost:   www.somehost.net\rOtherHeader: some\r    value\r\r\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testLineFeedsLineEnds() {
+    public void testLineFeedsLineEnds() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\nHost:   www.somehost.net\nOtherHeader: some\n    value\n\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testTabWhitespace() {
+    public void testTabWhitespace() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET\t/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testCanonicalPath() {
+    public void testCanonicalPath() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -181,7 +181,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testNoHeaders() {
+    public void testNoHeaders() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET\t/aa\tHTTP/1.1\n\n\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -192,7 +192,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testQueryParams() {
+    public void testQueryParams() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath?a=b&b=c&d&e&f=\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -210,7 +210,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testSameHttpStringReturned() {
+    public void testSameHttpStringReturned() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nAccept-Charset:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context1 = new ParseState();
@@ -241,7 +241,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testEmptyQueryParams() {
+    public void testEmptyQueryParams() throws HttpRequestParser.BadRequestException {
         byte[] in = "GET /clusterbench/requestinfo//?;?=44&test=OK;devil=3&&&&&&&&&&&&&&&&&&&&&&&&&&&&777=666 HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -256,7 +256,7 @@ public class SimpleParserTestCase {
         Assert.assertEquals("44", result.getQueryParameters().get(";?").getFirst());
     }
     @Test
-    public void testNonEncodedAsciiCharacters() throws UnsupportedEncodingException {
+    public void testNonEncodedAsciiCharacters() throws UnsupportedEncodingException, HttpRequestParser.BadRequestException {
         byte[] in = "GET /bÃ¥r HTTP/1.1\r\n\r\n".getBytes("ISO-8859-1");
 
         final ParseState context = new ParseState();
@@ -267,10 +267,10 @@ public class SimpleParserTestCase {
         Assert.assertEquals("/bÃ¥r", result.getRequestURI()); //not decoded
     }
 
-    private void runTest(final byte[] in) {
+    private void runTest(final byte[] in) throws HttpRequestParser.BadRequestException {
         runTest(in, "some value");
     }
-    private void runTest(final byte[] in, String lastHeader) {
+    private void runTest(final byte[] in, String lastHeader) throws HttpRequestParser.BadRequestException {
         parseState.reset();
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.EMPTY).handle(ByteBuffer.wrap(in), parseState, result);


### PR DESCRIPTION
…and parameter limits

Backport of https://github.com/undertow-io/undertow/commit/ce5ffeb6395c0ffea865c0e6255dd9f3db4297e6 into maintenance branch for EAP 7.0

EAP 7.0 JIRA: https://issues.jboss.org/browse/JBEAP-6716
Upstream JIRA: https://issues.jboss.org/browse/UNDERTOW-881