### PR TITLE
flag addProtocol(String, HttpUpgradeListener, HttpUpgradeHandshake) m…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ChannelUpgradeHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ChannelUpgradeHandler.java
@@ -61,7 +61,7 @@ public final class ChannelUpgradeHandler implements HttpHandler {
      * @param openListener  the open listener to call
      * @param handshake     a handshake implementation that can be used to verify the client request and modify the response
      */
-    private synchronized void addProtocol(String productString, HttpUpgradeListener openListener, final HttpUpgradeHandshake handshake) {
+    public synchronized void addProtocol(String productString, HttpUpgradeListener openListener, final HttpUpgradeHandshake handshake) {
         addProtocol(productString, openListener, null, handshake);
     }
 


### PR DESCRIPTION
…ethod public again

The method was flagged as private in e446275 but this looks like an error (this method is needed to be able to access the HTTP exchange during the HTTP upgrade handshake)