### PR TITLE
URLUtils.decode now will not decode spaces if space decoding is disabled

### DIFF
--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -104,10 +104,24 @@ public class URLUtils {
                         }
                         int pos = 0;
 
-                        while ((i< numChars)) {
+                        while ((i < numChars)) {
                             if (c == '%') {
                                 char p1 = Character.toLowerCase(s.charAt(i + 1));
                                 char p2 = Character.toLowerCase(s.charAt(i + 2));
+
+                                if (!decodeSlash && p1 == '2' && p2 == 'f') {
+                                    bytes[pos++] = (byte) c;
+                                    // should be copied with preserved upper/lower case
+                                    bytes[pos++] = (byte) s.charAt(i + 1);
+                                    bytes[pos++] = (byte) s.charAt(i + 2);
+                                    i += 3;
+
+                                    if (i < numChars) {
+                                        c = s.charAt(i);
+                                    }
+                                    continue;
+                                }
+
                                 int v = 0;
                                 if (p1 >= '0' && p1 <= '9') {
                                     v = (p1 - '0') << 4;
@@ -135,7 +149,7 @@ public class URLUtils {
                                 if (i < numChars) {
                                     c = s.charAt(i);
                                 }
-                            }else if(c == '+') {
+                            } else if (c == '+') {
                                 bytes[pos++] = (byte) ' ';
                                 ++i;
                                 if (i < numChars) {
@@ -182,14 +196,14 @@ public class URLUtils {
                 default:
                     buffer.append(c);
                     i++;
-                    if(c > 127 && !needToChange) {
+                    if (c > 127 && !needToChange) {
                         //we have non-ascii data in our URL, which sucks
                         //its hard to know exactly what to do with this, but we assume that because this data
                         //has not been properly encoded none of the other data is either
                         try {
                             char[] carray = s.toCharArray();
                             byte[] buf = new byte[carray.length];
-                            for(int l = 0;l < buf.length; ++l) {
+                            for (int l = 0; l < buf.length; ++l) {
                                 buf[l] = (byte) carray[l];
                             }
                             return new String(buf, enc);

--- a/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
@@ -1,0 +1,41 @@
+package io.undertow.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Oleksandr Radchykov
+ */
+@RunWith(Parameterized.class)
+public class URLUtilsTestCase {
+
+    @Parameterized.Parameters
+    public static Object[] spaceCodes() {
+        return new Object[] { "%2f", "%2F" };
+    }
+
+    @Parameterized.Parameter
+    public String spaceCode;
+
+    @Test
+    public void testDecodingWithEncodedAndDecodedSlashAndSlashDecodingDisabled() throws Exception {
+        String url = "http://localhost:3001/by-path/wild%20card/wild%28west%29/wild" + spaceCode + "wolf";
+
+        final String result = URLUtils.decode(url, Charset.defaultCharset().name(), false, new StringBuilder());
+        assertEquals("http://localhost:3001/by-path/wild card/wild(west)/wild" + spaceCode + "wolf", result);
+    }
+
+    @Test
+    public void testDecodingURLMustNotMutateSpaceSymbolsCaseIfSpaceDecodingDisabled() throws Exception {
+        final String url = "http://localhost:3001/wild" + spaceCode + "west";
+
+        final String result = URLUtils.decode(url, Charset.defaultCharset().name(), false, new StringBuilder());
+        assertEquals(url, result);
+    }
+
+}


### PR DESCRIPTION
URLUtils.decode now will node decode all the spaces in URL even if this option was disabled using argument of the function. Decode function now will skip '%2(f/F)' sequences in decoding loop if space deconding is turned off.

The problem was that old version(1.3.5) worked fine, but after moving the new one the correct behaviour was broken. The bug was introduced for the edge case when our URL contains spaces '/' and their symbols '%2(f/F)' it tried to decode all the spaces event if this option was disabled and then encode them back (so it should look like spaces were not touched), but in fact in `mix` cases after decoding all spaces were encoded.
Example:
http://localhost/path%20with%20space/foo%2fbar --> http://localhost/path with spaces%2Ffoo%2Fbar while http://localhost/path with spaces/foo%2fbar is expected.

- bugfix
- tests