### PR TITLE
Initialize the temporary directory before running SCIs

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -180,7 +180,10 @@ public class DeploymentManagerImpl implements DeploymentManager {
                     //now create the servlets and filters that we know about. We can still get more later
                     createServletsAndFilters(deployment, deploymentInfo);
 
-                    //first run the SCI's
+                    //first initialize the temp dir
+                    initializeTempDir(servletContext, deploymentInfo);
+
+                    //then run the SCI's
                     for (final ServletContainerInitializerInfo sci : deploymentInfo.getServletContainerInitializers()) {
                         final InstanceHandle<? extends ServletContainerInitializer> instance = sci.getInstanceFactory().createInstance();
                         try {
@@ -197,7 +200,6 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
                     initializeErrorPages(deployment, deploymentInfo);
                     initializeMimeMappings(deployment, deploymentInfo);
-                    initializeTempDir(servletContext, deploymentInfo);
                     listeners.contextInitialized();
                     //run
 

--- a/servlet/src/test/java/io/undertow/servlet/test/listener/servletcontext/TestSci.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/listener/servletcontext/TestSci.java
@@ -18,6 +18,8 @@
 
 package io.undertow.servlet.test.listener.servletcontext;
 
+import org.junit.Assert;
+
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextAttributeEvent;
@@ -37,6 +39,7 @@ public class TestSci implements ServletContainerInitializer {
     public void onStartup(Set<Class<?>> c, ServletContext ctx) throws ServletException {
         ctx.addListener(new DynamicListener());
         ctx.setAttribute("testDL", "foo");
+        Assert.assertNotNull(ctx.getAttribute(ServletContext.TEMPDIR));
     }
 
     public static class DynamicListener implements ServletContextAttributeListener {


### PR DESCRIPTION
Failure to do so can cause an NPE on startup unless deployments
are created with:
```java
Servlets.deployment()
    .setTempDir(new File(System.getProperty("java.io.tmpdir")))
```