### PR TITLE
EncodingHandler doesn't wrap exchanges without available channel

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/encoding/EncodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/EncodingHandler.java
@@ -62,7 +62,7 @@ public class EncodingHandler implements HttpHandler {
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
         AllowedContentEncodings encodings = contentEncodingRepository.getContentEncodings(exchange);
-        if (encodings == null) {
+        if (encodings == null || !exchange.isResponseChannelAvailable()) {
             next.handleRequest(exchange);
         } else if (encodings.isNoEncodingsAllowed()) {
             noEncodingHandler.handleRequest(exchange);


### PR DESCRIPTION
Ran into this while attempting to load jsp, the forward request causes a `UT000004: getResponseChannel() has already been called`