### PR TITLE
enhanced routing handler to support wildcards of pathtemplates

### DIFF
--- a/core/src/main/java/io/undertow/util/PathTemplate.java
+++ b/core/src/main/java/io/undertow/util/PathTemplate.java
@@ -45,7 +45,7 @@ public class PathTemplate implements Comparable<PathTemplate> {
     private final String templateString;
     private final boolean template;
     private final String base;
-    private final List<Part> parts;
+    final List<Part> parts;
     private final Set<String> parameterNames;
 
     private PathTemplate(String templateString, final boolean template, final String base, final List<Part> parts, Set<String> parameterNames) {
@@ -87,6 +87,10 @@ public class PathTemplate implements Comparable<PathTemplate> {
                 case 0: {
                     if (c == '/') {
                         state = 1;
+                    } else if (c == '*') {
+                        base = path.substring(0, i + 1);
+                        stringStart = i;
+                        state = 5;
                     } else {
                         state = 0;
                     }
@@ -97,6 +101,10 @@ public class PathTemplate implements Comparable<PathTemplate> {
                         base = path.substring(0, i);
                         stringStart = i + 1;
                         state = 2;
+                    } else if (c == '*') {
+                        base = path.substring(0, i + 1);
+                        stringStart = i;
+                        state = 5;
                     } else if (c != '/') {
                         state = 0;
                     }
@@ -162,7 +170,7 @@ public class PathTemplate implements Comparable<PathTemplate> {
                 templates.add(part.part);
             }
         }
-        return new PathTemplate(path, state > 1, base, parts, templates);
+        return new PathTemplate(path, state > 1 && !base.contains("*"), base, parts, templates);
     }
 
     /**

--- a/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
+++ b/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
@@ -64,15 +64,12 @@ public class PathTemplateMatcher<T> {
                     }
                 }
             } else if (pathLength < length) {
-                char c = path.charAt(pathLength);
-                if (c == '/') {
-                    String part = path.substring(0, pathLength);
-                    Set<PathTemplateHolder> entry = pathTemplateMap.get(part);
-                    if (entry != null) {
-                        PathMatchResult<T> res = handleStemMatch(entry, path, params);
-                        if (res != null) {
-                            return res;
-                        }
+                String part = path.substring(0, pathLength);
+                Set<PathTemplateHolder> entry = pathTemplateMap.get(part);
+                if (entry != null) {
+                    PathMatchResult<T> res = handleStemMatch(entry, path, params);
+                    if (res != null) {
+                        return res;
                     }
                 }
             }
@@ -118,10 +115,15 @@ public class PathTemplateMatcher<T> {
     }
 
     private String trimBase(PathTemplate template) {
+        String retval = template.getBase();
+
         if (template.getBase().endsWith("/") && !template.getParameterNames().isEmpty()) {
-            return template.getBase().substring(0, template.getBase().length() - 1);
+            return retval.substring(0, retval.length() - 1);
         }
-        return template.getBase();
+        if (retval.endsWith("*")) {
+            return retval.substring(0, retval.length() - 1);
+        }
+        return retval;
     }
 
     private void buildLengths() {

--- a/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
@@ -96,6 +96,18 @@ public class RoutingHandlerTestCase {
                         exchange.getResponseSender().send("wild:" + exchange.getQueryParameters().get("test") + ":" + exchange.getQueryParameters().get("*"));
                     }
                 })
+                .add(Methods.GET, "/wilder/*", new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        exchange.getResponseSender().send("wilder:" + exchange.getQueryParameters().get("*"));
+                    }
+                })
+                .add(Methods.GET, "/wildest*", new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        exchange.getResponseSender().send("wildest:" + exchange.getQueryParameters().get("*"));
+                    }
+                })
                 .add(Methods.GET, "/foo", new HttpHandler() {
                     @Override
                     public void handleRequest(HttpServerExchange exchange) throws Exception {
@@ -206,6 +218,15 @@ public class RoutingHandlerTestCase {
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             Assert.assertEquals("wild:[test]:[card]", HttpClientUtils.readResponse(result));
 
+            get = new HttpGet(DefaultServer.getDefaultServerURL() + "/wilder/test/card");
+            result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            Assert.assertEquals("wilder:[test/card]", HttpClientUtils.readResponse(result));
+
+            get = new HttpGet(DefaultServer.getDefaultServerURL() + "/wildestBeast");
+            result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            Assert.assertEquals("wildest:[Beast]", HttpClientUtils.readResponse(result));
         } finally {
             client.getConnectionManager().shutdown();
         }

--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -104,7 +104,22 @@ public class PathTemplateTestCase {
         PathTemplate pathTemplate = PathTemplate.create(template);
         Assert.assertTrue("Failed. Template: " + pathTemplate, pathTemplate.matches(path, params));
         Assert.assertEquals(expected, params);
+        if(template.endsWith("*") && ! template.contains("{")){
+            Assert.assertEquals("Failed. Template: "+pathTemplate+"Must have a part representing the wildcard",1,new PathTemplateFriend(pathTemplate).getPartAmount());
+        }
 
+    }
+
+    static class PathTemplateFriend {
+        private final PathTemplate template;
+
+        PathTemplateFriend(PathTemplate template) {
+            this.template = template;
+        }
+
+        int getPartAmount() {
+            return template.parts.size();
+        }
     }
 
 }


### PR DESCRIPTION
I have beeen using undertow routing manager and discovered that wildcard support was kinda off.
**/bla/{blubb}/*** is supported where as 
**/bla/*** is not supported.
So I digged into it and discovered that the _PathTemplate_ supports wildcards just fine.
I did the following to get the wildcard support fully running in the _PathTemplateMatcher_:

1. added corresponding tests
1. changed  _PathTemplate.create_ method to create a Part with **'*'**
1. changed _PathTemplateMatcher.match_ to consider wildcards correctly
1. changed _PathTemplateMatcher.trimBase_ to cut away **'*'**