### PR TITLE
[UNDERTOW-931] Fix removal of ChannelUpgradeHandler's protocol.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ChannelUpgradeHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ChannelUpgradeHandler.java
@@ -132,7 +132,7 @@ public final class ChannelUpgradeHandler implements HttpHandler {
         while (it.hasNext()) {
             Holder holder = it.next();
             if (holder.channelListener == openListener) {
-                it.remove();
+                holders.remove(holder);
                 break;
             }
         }
@@ -157,7 +157,7 @@ public final class ChannelUpgradeHandler implements HttpHandler {
         while (it.hasNext()) {
             Holder holder = it.next();
             if (holder.listener == upgradeListener) {
-                it.remove();
+                holders.remove(holder);
                 break;
             }
         }


### PR DESCRIPTION
Call holders.remove(holder) instead of it.remove() that is not supported
for a CopyOnWriteArrayList's iterator.

JIRA: https://issues.jboss.org/browse/UNDERTOW-931