### PR TITLE
[1.4] UNDERTOW-932 hot standby broken + UNDERTOW-898 deterministic failover

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Context.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Context.java
@@ -213,4 +213,10 @@ class Context {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Context{" +
+                ", path='" + path + '\'' +
+                '}';
+    }
 }

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
@@ -591,7 +591,7 @@ class MCMPHandler implements HttpHandler {
     /**
      * Process <tt>INFO</tt> request
      *
-     * @throws Exception
+     * @throws IOException
      */
     protected void processInfo(HttpServerExchange exchange) throws IOException {
         final String data = processInfoString();
@@ -634,7 +634,7 @@ class MCMPHandler implements HttpHandler {
      * Process <tt>DUMP</tt> request
      *
      * @param exchange
-     * @throws java.io.IOException
+     * @throws IOException
      */
     protected void processDump(HttpServerExchange exchange) throws IOException {
         final String data = processDumpString();
@@ -714,7 +714,7 @@ class MCMPHandler implements HttpHandler {
     /**
      * If the process is OK, then add 200 HTTP status and its "OK" phrase
      *
-     * @throws Exception
+     * @throws IOException
      */
     static void processOK(HttpServerExchange exchange) throws IOException {
         exchange.setStatusCode(StatusCodes.OK);

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
@@ -264,12 +264,9 @@ public class ModCluster {
             return this;
         }
 
-        public void setMaxRetries(int maxRetries) {
+        public Builder setMaxRetries(int maxRetries) {
             this.maxRetries = maxRetries;
-        }
-
-        public long getTtl() {
-            return ttl;
+            return this;
         }
 
         public Builder setTtl(long ttl) {

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
@@ -54,6 +54,7 @@ public class ModCluster {
     private final XnioWorker xnioWorker;
     private final ModClusterContainer container;
     private final int maxRetries;
+    private final boolean deterministicFailover;
 
     private final String serverID = UUID.randomUUID().toString(); // TODO
 
@@ -65,6 +66,7 @@ public class ModCluster {
         this.queueNewRequests = builder.queueNewRequests;
         this.healthCheckInterval = builder.healthCheckInterval;
         this.removeBrokenNodes = builder.removeBrokenNodes;
+        this.deterministicFailover = builder.deterministicFailover;
         this.healthChecker = builder.healthChecker;
         this.maxRequestTime = builder.maxRequestTime;
         this.ttl = builder.ttl;
@@ -119,6 +121,10 @@ public class ModCluster {
 
     public boolean isUseAlias() {
         return useAlias;
+    }
+
+    public boolean isDeterministicFailover() {
+        return deterministicFailover;
     }
 
     /**
@@ -206,8 +212,9 @@ public class ModCluster {
         private NodeHealthChecker healthChecker = NodeHealthChecker.NO_CHECK;
         private long healthCheckInterval = TimeUnit.SECONDS.toMillis(10);
         private long removeBrokenNodes = TimeUnit.MINUTES.toMillis(1);
-        public OptionMap clientOptions = OptionMap.EMPTY;
-        public int maxRetries;
+        private OptionMap clientOptions = OptionMap.EMPTY;
+        private int maxRetries;
+        private boolean deterministicFailover = false;
 
         private Builder(XnioWorker xnioWorker, UndertowClient client, XnioSsl xnioSsl) {
             this.xnioSsl = xnioSsl;
@@ -266,6 +273,11 @@ public class ModCluster {
 
         public Builder setMaxRetries(int maxRetries) {
             this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder setDeterministicFailover(boolean deterministicFailover) {
+            this.deterministicFailover = deterministicFailover;
             return this;
         }
 

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
@@ -394,8 +394,8 @@ class ModClusterContainer implements ModClusterController {
      *
      * @param domain   the load balancing domain, if known
      * @param jvmRoute the original jvmRoute
+     * @param entry    the resolved virtual host entry
      * @return the context, {@code null} if not found
-     * @oaram entry      the resolved virtual host entry
      */
     Context findFailoverNode(final VirtualHost.HostEntry entry, final String domain, final String jvmRoute, final boolean forceStickySession) {
         String failOverDomain = null;

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
@@ -132,16 +132,17 @@ class ModClusterContainer implements ModClusterController {
             final Map<String, Cookie> cookies = exchange.getRequestCookies();
             if (balancer.isStickySession()) {
                 if (cookies.containsKey(balancer.getStickySessionCookie())) {
-                    final String jvmRoute = getJVMRoute(cookies.get(balancer.getStickySessionCookie()).getValue());
+                    final String session = cookies.get(balancer.getStickySessionCookie()).getValue();
+                    final String jvmRoute = getJVMRoute(session);
                     if (jvmRoute != null) {
-                        return new ModClusterProxyTarget.ExistingSessionTarget(jvmRoute, entry.getValue(), this, balancer.isStickySessionForce());
+                        return new ModClusterProxyTarget.ExistingSessionTarget(session, jvmRoute, entry.getValue(), this, balancer.isStickySessionForce());
                     }
                 }
                 if (exchange.getPathParameters().containsKey(balancer.getStickySessionPath())) {
-                    final String id = exchange.getPathParameters().get(balancer.getStickySessionPath()).getFirst();
-                    final String jvmRoute = getJVMRoute(id);
+                    final String session = exchange.getPathParameters().get(balancer.getStickySessionPath()).getFirst();
+                    final String jvmRoute = getJVMRoute(session);
                     if (jvmRoute != null) {
-                        return new ModClusterProxyTarget.ExistingSessionTarget(jvmRoute, entry.getValue(), this, balancer.isStickySessionForce());
+                        return new ModClusterProxyTarget.ExistingSessionTarget(session, jvmRoute, entry.getValue(), this, balancer.isStickySessionForce());
                     }
                 }
             }
@@ -392,12 +393,47 @@ class ModClusterContainer implements ModClusterController {
     /**
      * Try to find a failover node within the same load balancing group.
      *
-     * @param domain   the load balancing domain, if known
-     * @param jvmRoute the original jvmRoute
-     * @param entry    the resolved virtual host entry
+     * @param entry              the resolved virtual host entry
+     * @param domain             the load balancing domain, if known
+     * @param session            the actual value of JSESSIONID/jsessionid cookie/parameter
+     * @param jvmRoute           the original jvmRoute
+     * @param forceStickySession whether sticky sessions are forced
      * @return the context, {@code null} if not found
      */
-    Context findFailoverNode(final VirtualHost.HostEntry entry, final String domain, final String jvmRoute, final boolean forceStickySession) {
+    Context findFailoverNode(final VirtualHost.HostEntry entry, final String domain, final String session, final String jvmRoute, final boolean forceStickySession) {
+
+        // If configured, deterministically choose the failover target by calculating hash of the session ID modulo number of electable nodes
+        if (modCluster.isDeterministicFailover()) {
+            List<String> candidates = new ArrayList<>(entry.getNodes().size());
+            for (String route : entry.getNodes()) {
+                Node node = nodes.get(route);
+                if (node != null && !node.isInErrorState() && !node.isHotStandby()) {
+                    candidates.add(route);
+                }
+            }
+
+            // If there are no available regular nodes, all hot standby nodes become candidates
+            if (candidates.isEmpty()) {
+                for (String route : entry.getNodes()) {
+                    Node node = nodes.get(route);
+                    if (node != null && !node.isInErrorState() && node.isHotStandby()) {
+                        candidates.add(route);
+                    }
+                }
+            }
+
+            if (candidates.isEmpty()) {
+                return null;
+            }
+
+            String sessionId = session.substring(0, session.indexOf('.'));
+            int index = (int) (Math.abs((long) sessionId.hashCode()) % candidates.size());
+            Collections.sort(candidates);
+            String electedRoute = candidates.get(index);
+            UndertowLogger.ROOT_LOGGER.debugf("Using deterministic failover target: %s", electedRoute);
+            return entry.getContextForNode(electedRoute);
+        }
+
         String failOverDomain = null;
         if (domain == null) {
             final Node node = nodes.get(jvmRoute);
@@ -428,7 +464,6 @@ class ModClusterContainer implements ModClusterController {
      * Map a request to virtual host.
      *
      * @param exchange the http exchange
-     * @return
      */
     private PathMatcher.PathMatch<VirtualHost.HostEntry> mapVirtualHost(final HttpServerExchange exchange) {
         final String context = exchange.getRelativePath();

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
@@ -36,6 +36,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
 
     class ExistingSessionTarget implements ModClusterProxyTarget {
 
+        private final String session;
         private final String jvmRoute;
         private final VirtualHost.HostEntry entry;
         private final boolean forceStickySession;
@@ -43,7 +44,8 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
 
         private Context resolved;
 
-        public ExistingSessionTarget(String jvmRoute, VirtualHost.HostEntry entry, ModClusterContainer container, boolean forceStickySession) {
+        public ExistingSessionTarget(String session, String jvmRoute, VirtualHost.HostEntry entry, ModClusterContainer container, boolean forceStickySession) {
+            this.session = session;
             this.jvmRoute = jvmRoute;
             this.entry = entry;
             this.container = container;
@@ -59,7 +61,6 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
         }
 
         void resolveNode() {
-
             final Context context = entry.getContextForNode(jvmRoute);
             if (context != null && context.checkAvailable(true)) {
                 final Node node = context.getNode();
@@ -68,7 +69,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
                 return;
             }
             final String domain = context != null ? context.getNode().getNodeConfig().getDomain() : null;
-            this.resolved = container.findFailoverNode(entry, domain, jvmRoute, forceStickySession);
+            this.resolved = container.findFailoverNode(entry, domain, session, jvmRoute, forceStickySession);
         }
 
         @Override

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Node.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Node.java
@@ -335,7 +335,7 @@ class Node {
         int oldState, newState;
         for (;;) {
             oldState = this.state;
-            newState = oldState | HOT_STANDBY;
+            newState = oldState & ~(ERROR | ERROR_MASK) | HOT_STANDBY;
             if (stateUpdater.compareAndSet(this, oldState, newState)) {
                 lbStatus.updateLoad(0);
                 return;

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Node.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Node.java
@@ -508,4 +508,11 @@ class Node {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Node{" +
+                "jvmRoute='" + jvmRoute + '\'' +
+                ", contexts=" + contexts +
+                '}';
+    }
 }

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/VirtualHost.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/VirtualHost.java
@@ -171,16 +171,20 @@ public class VirtualHost {
          * Get a context for a jvmRoute.
          *
          * @param jvmRoute    the jvm route
-         * @return
          */
         protected Context getContextForNode(final String jvmRoute) {
             return contexts.get(jvmRoute);
         }
 
         /**
+         * Get list of nodes as jvmRoutes.
+         */
+        protected Collection<String> getNodes() {
+            return Collections.unmodifiableCollection(contexts.keySet());
+        }
+
+        /**
          * Get all registered contexts.
-         *
-         * @return
          */
         protected Collection<Context> getContexts() {
             return Collections.unmodifiableCollection(contexts.values());


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-932
mod_cluster hot standby workers are always in error mode resulting in 503

https://issues.jboss.org/browse/UNDERTOW-898
Failover targets should be chosen deterministically 

Also includes work for (not yet done in native module)
https://issues.jboss.org/browse/MODCLUSTER-557
Hot standby workers should be excluded from the deterministic failover candidate list