### PR TITLE
[UNDERTOW-937] ServletAuthenticationCallHandler.handleRequest returns

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletAuthenticationCallHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/ServletAuthenticationCallHandler.java
@@ -57,9 +57,13 @@ public class ServletAuthenticationCallHandler implements HttpHandler {
                next.handleRequest(exchange);
             }
         } else {
-            if(exchange.getStatusCode() >= StatusCodes.BAD_REQUEST && !exchange.isComplete()) {
+            if(!exchange.isComplete()) {
                 ServletRequestContext src = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
-                src.getOriginalResponse().sendError(exchange.getStatusCode());
+                if (exchange.getStatusCode() >= StatusCodes.BAD_REQUEST) {
+                    src.getOriginalResponse().sendError(exchange.getStatusCode());
+                } else {
+                    src.getOriginalResponse().sendError(StatusCodes.FORBIDDEN);
+                }
             } else {
                 exchange.endExchange();
             }


### PR DESCRIPTION
empty OK response for authorization failure

This patch adds a fallback case that sends a 403 response if the
authentication process failed, but did not set a status code.