### PR TITLE
Avoid a ConcurrentModificationException

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
@@ -800,6 +800,10 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
             if(receiver != null) {
                 receiver.markStreamBroken();
             }
+
+            // make a defensive copy
+            Set<AbstractFramedStreamSourceChannel<C, R, S>> receivers = new HashSet<>(
+                    this.receivers);
             for(AbstractFramedStreamSourceChannel<C, R, S> r : receivers) {
                 r.markStreamBroken();
             }


### PR DESCRIPTION
By making a defensive copy of the receivers set.

The r.markStreamBroken() method calls back the notifyClosed()
method which removes an element from the set. This cannot be done
within an interaction over the set.