### PR TITLE
UNDERTOW-847 fixed appending port 80 if "X-Forwarded-Port" is empty

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -92,16 +92,18 @@ public class ProxyPeerAddressHandler implements HttpHandler {
                     value = value.substring(0, index);
                 }
             }
-            int port = 80;
+            int port = 0;
+            String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
             if(forwardedPort != null) {
                 try {
                     port = Integer.parseInt(forwardedPort);
+                    hostHeader += ":" + port;
                 } catch (NumberFormatException ignore) {
                     UndertowLogger.REQUEST_LOGGER.debugf("Cannot parse port: %s", forwardedPort);
                 }
             }
+            exchange.getRequestHeaders().put(Headers.HOST, hostHeader);
             exchange.setDestinationAddress(InetSocketAddress.createUnresolved(value, port));
-            exchange.getRequestHeaders().put(Headers.HOST, NetworkUtils.formatPossibleIpv6Address(value) + ":" + port);
         }
         next.handleRequest(exchange);
     }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/UNDERTOW-847

JBEAP Jira: https://issues.jboss.org/browse/JBEAP-8087

1.4.x branch commit is: https://github.com/undertow-io/undertow/commit/a5ae059b824bd67e22e16a5e12c77293c0753a23

This is needed by EAP 7.0 CP release.