### PR TITLE
Fix when occurs connection close

### DIFF
--- a/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
@@ -513,6 +513,7 @@ class HttpClientConnection extends AbstractAttachable implements Closeable, Clie
                             UndertowLogger.CLIENT_LOGGER.debugf(e, "Connection closed with IOException");
                         }
                         safeClose(channel);
+                        safeClose(HttpClientConnection.this);
                         currentRequest.setFailed(new IOException(MESSAGES.connectionClosed()));
                         return;
                     }


### PR DESCRIPTION
When occurs some errors in console/log bellow:

`java.io.IOException: UT001000: Connection closed at io.undertow.client.http.HttpClientConnection$ClientReadListener.handleEvent(HttpClientConnection.java:531) at io.undertow.client.http.HttpClientConnection$ClientReadListener.handleEvent(HttpClientConnection.java:473) at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92) at org.xnio.conduits.ReadReadyHandler$ChannelListenerHandler.readReady(ReadReadyHandler.java:66) at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:88) at org.xnio.nio.WorkerThread.run(WorkerThread.java:559)`

The undertow is not closing the connection. For simulate, use the my project with instructions in README.md: https://github.com/tibraga/uproxy

The fix is just to close the connection when occurs error of connection close.