### PR TITLE
UNDERTOW-976 SingleSignOnAuthenticationMechanism fails to destroy SSO following session invalidation if session was registered with SSO on remote node

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
+++ b/core/src/main/java/io/undertow/security/impl/SingleSignOnAuthenticationMechanism.java
@@ -134,10 +134,10 @@ public class SingleSignOnAuthenticationMechanism implements AuthenticationMechan
                 log.tracef("SSO_SESSION_ATTRIBUTE not found. Creating it with SSO ID %s as value.", sso.getId());
             }
             session.setAttribute(SSO_SESSION_ATTRIBUTE, sso.getId());
-            SessionManager manager = session.getSessionManager();
-            if (seenSessionManagers.add(manager)) {
-                manager.registerSessionListener(listener);
-            }
+        }
+        SessionManager manager = session.getSessionManager();
+        if (seenSessionManagers.add(manager)) {
+            manager.registerSessionListener(listener);
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-976