### PR TITLE
UNDERTOW-853 SPDY: SpdyClientConnection.sendRequest() shouldn't be synchronized

### DIFF
--- a/core/src/main/java/io/undertow/client/spdy/SpdyClientConnection.java
+++ b/core/src/main/java/io/undertow/client/spdy/SpdyClientConnection.java
@@ -85,7 +85,7 @@ public class SpdyClientConnection implements ClientConnection {
     }
 
     @Override
-    public synchronized void sendRequest(ClientRequest request, ClientCallback<ClientExchange> clientCallback) {
+    public void sendRequest(ClientRequest request, ClientCallback<ClientExchange> clientCallback) {
         request.getRequestHeaders().put(PATH, request.getPath());
         request.getRequestHeaders().put(SCHEME, "https");
         request.getRequestHeaders().put(VERSION, request.getProtocol().toString());


### PR DESCRIPTION
Revert "SPDY Connection: Make synchronized requests"

This reverts commit 595322a869494ba03610773b2e8084da8d4a8372.