### PR TITLE
Websockets PooledByteBuffer API

### DIFF
--- a/core/src/main/java/io/undertow/websockets/core/WebSockets.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSockets.java
@@ -18,6 +18,7 @@
 
 package io.undertow.websockets.core;
 
+import io.undertow.connector.PooledByteBuffer;
 import io.undertow.util.ImmediatePooledByteBuffer;
 import io.undertow.util.WorkerUtils;
 import org.xnio.Buffers;
@@ -133,6 +134,58 @@ public class WebSockets {
     public static <T> void sendText(final ByteBuffer message, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(message, WebSocketFrameType.TEXT, wsChannel, callback, context, timeoutmillis);
     }
+    
+    /**
+     * Sends a complete text message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     */
+    public static void sendText(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback) {
+        sendInternal(pooledData, WebSocketFrameType.TEXT, wsChannel, callback, null, -1);
+    }
+
+    /**
+     * Sends a complete text message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     */
+    public static <T> void sendText(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context) {
+        sendInternal(pooledData, WebSocketFrameType.TEXT, wsChannel, callback, context, -1);
+    }
+
+    /**
+     * Sends a complete text message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static void sendText(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.TEXT, wsChannel, callback, null, timeoutmillis);
+    }
+
+    /**
+     * Sends a complete text message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static <T> void sendText(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.TEXT, wsChannel, callback, context, timeoutmillis);
+    }
 
     /**
      * Sends a complete text message, invoking the callback when complete
@@ -153,6 +206,17 @@ public class WebSockets {
      */
     public static void sendTextBlocking(final ByteBuffer message, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(message, WebSocketFrameType.TEXT, wsChannel);
+    }
+    
+    /**
+     * Sends a complete text message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     */
+    public static void sendTextBlocking(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel) throws IOException {
+        sendBlockingInternal(pooledData, WebSocketFrameType.TEXT, wsChannel);
     }
 
     /**
@@ -246,6 +310,58 @@ public class WebSockets {
     public static <T> void sendPing(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel, callback, context, timeoutmillis);
     }
+    
+    /**
+     * Sends a complete ping message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     */
+    public static void sendPing(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback) {
+        sendInternal(pooledData, WebSocketFrameType.PING, wsChannel, callback, null, -1);
+    }
+
+    /**
+     * Sends a complete ping message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     */
+    public static <T> void sendPing(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context) {
+        sendInternal(pooledData, WebSocketFrameType.PING, wsChannel, callback, context, -1);
+    }
+
+    /**
+     * Sends a complete ping message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static void sendPing(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.PING, wsChannel, callback, null, timeoutmillis);
+    }
+
+    /**
+     * Sends a complete ping message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static <T> void sendPing(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.PING, wsChannel, callback, context, timeoutmillis);
+    }
 
     /**
      * Sends a complete ping message using blocking IO
@@ -265,6 +381,17 @@ public class WebSockets {
      */
     public static void sendPingBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel);
+    }
+    
+    /**
+     * Sends a complete ping message using blocking IO
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     */
+    public static void sendPingBlocking(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel) throws IOException {
+        sendBlockingInternal(pooledData, WebSocketFrameType.PING, wsChannel);
     }
 
     /**
@@ -360,6 +487,58 @@ public class WebSockets {
     }
 
     /**
+     * Sends a complete pong message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     */
+    public static void sendPong(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback) {
+        sendInternal(pooledData, WebSocketFrameType.PONG, wsChannel, callback, null, -1);
+    }
+
+    /**
+     * Sends a complete pong message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     */
+    public static <T> void sendPong(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context) {
+        sendInternal(pooledData, WebSocketFrameType.PONG, wsChannel, callback, context, -1);
+    }
+
+    /**
+     * Sends a complete pong message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static void sendPong(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.PONG, wsChannel, callback, null, timeoutmillis);
+    }
+
+    /**
+     * Sends a complete pong message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
+     */
+    public static <T> void sendPong(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.PONG, wsChannel, callback, context, timeoutmillis);
+    }
+
+    /**
      * Sends a complete pong message using blocking IO
      *
      * @param data The data to send
@@ -377,6 +556,17 @@ public class WebSockets {
      */
     public static void sendPongBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.PONG, wsChannel);
+    }
+    
+    /**
+     * Sends a complete pong message using blocking IO
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     */
+    public static void sendPongBlocking(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel) throws IOException {
+        sendBlockingInternal(pooledData, WebSocketFrameType.PONG, wsChannel);
     }
 
     /**
@@ -470,6 +660,56 @@ public class WebSockets {
     public static <T> void sendBinary(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);
     }
+    
+    /**
+     * Sends a complete binary message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     */
+    public static void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback) {
+        sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, null, -1);
+    }
+
+    /**
+     * Sends a complete binary message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     */
+    public static <T> void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context) {
+        sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, context, -1);
+    }
+
+    /**
+     * Sends a complete binary message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     */
+    public static void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, null, timeoutmillis);
+    }
+
+    /**
+     * Sends a complete binary message, invoking the callback when complete
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     * @param callback The callback to invoke on completion
+     * @param context The context object that will be passed to the callback on completion
+     */
+    public static <T> void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);
+    }
 
     /**
      * Sends a complete binary message using blocking IO
@@ -489,6 +729,17 @@ public class WebSockets {
      */
     public static void sendBinaryBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel);
+    }
+    
+    /**
+     * Sends a complete binary message using blocking IO
+     * Automatically frees the pooled byte buffer when done.
+     *
+     * @param pooledData The data to send, it will be freed when done
+     * @param wsChannel The web socket channel
+     */
+    public static void sendBinaryBlocking(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel) throws IOException {
+        sendBlockingInternal(pooledData, WebSocketFrameType.BINARY, wsChannel);
     }
 
     /**
@@ -628,12 +879,18 @@ public class WebSockets {
     public static void sendCloseBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendCloseBlocking(new CloseMessage(data), wsChannel);
     }
-
+    
     private static <T> void sendInternal(final ByteBuffer data, WebSocketFrameType type, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        sendInternal(new ImmediatePooledByteBuffer(data), type, wsChannel, callback, context, timeoutmillis);
+    }
+
+    private static <T> void sendInternal(final PooledByteBuffer pooledData, WebSocketFrameType type, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
+        boolean closePooledData = true;
         try {
             StreamSinkFrameChannel channel = wsChannel.send(type);
             // TODO chunk data into some MTU-like thing to control packet size
-            if(!channel.send(new ImmediatePooledByteBuffer(data))) {
+            closePooledData = false; // channel.send takes ownership of pooledData so it no longer needs to be closed
+            if(!channel.send(pooledData)) {
                 throw WebSocketMessages.MESSAGES.unableToSendOnNewChannel();
             }
             flushChannelAsync(wsChannel, callback, channel, context, timeoutmillis);
@@ -642,6 +899,10 @@ public class WebSockets {
                 callback.onError(wsChannel, context, e);
             } else {
                 IoUtils.safeClose(wsChannel);
+            }
+        } finally {
+            if ( closePooledData ) {
+                pooledData.close();
             }
         }
     }
@@ -706,17 +967,30 @@ public class WebSockets {
     }
 
     private static void sendBlockingInternal(final ByteBuffer data, WebSocketFrameType type, final WebSocketChannel wsChannel) throws IOException {
-        StreamSinkFrameChannel channel = wsChannel.send(type);
-        // TODO chunk data into some MTU-like thing to control packet size
-        if(!channel.send(new ImmediatePooledByteBuffer(data))) {
-            throw WebSocketMessages.MESSAGES.unableToSendOnNewChannel();
-        }
-        channel.shutdownWrites();
-        while (!channel.flush()) {
-            channel.awaitWritable();
-        }
-        if (type == WebSocketFrameType.CLOSE && wsChannel.isCloseFrameReceived()) {
-            IoUtils.safeClose(wsChannel);
+        sendBlockingInternal(new ImmediatePooledByteBuffer(data), type, wsChannel);
+    }
+    
+    private static void sendBlockingInternal(final PooledByteBuffer pooledData, WebSocketFrameType type, final WebSocketChannel wsChannel) throws IOException {
+        boolean closePooledData = true;
+        try {
+            StreamSinkFrameChannel channel = wsChannel.send(type);
+            // TODO chunk data into some MTU-like thing to control packet size
+            closePooledData = false; // channel.send takes ownership of pooledData so it no longer needs to be closed
+            if(!channel.send(pooledData)) {
+                throw WebSocketMessages.MESSAGES.unableToSendOnNewChannel();
+            }
+            
+            channel.shutdownWrites();
+            while (!channel.flush()) {
+                channel.awaitWritable();
+            }
+            if (type == WebSocketFrameType.CLOSE && wsChannel.isCloseFrameReceived()) {
+                IoUtils.safeClose(wsChannel);
+            }
+        } finally {
+            if (closePooledData) {
+                pooledData.close();
+            }
         }
     }
 

--- a/core/src/main/java/io/undertow/websockets/core/WebSockets.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSockets.java
@@ -118,6 +118,7 @@ public class WebSockets {
      * @param message The text to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendText(final ByteBuffer message, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(message, WebSocketFrameType.TEXT, wsChannel, callback, null, timeoutmillis);
@@ -130,6 +131,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendText(final ByteBuffer message, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(message, WebSocketFrameType.TEXT, wsChannel, callback, context, timeoutmillis);
@@ -248,6 +250,7 @@ public class WebSockets {
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendPing(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.PING, wsChannel, callback, null, timeoutmillis);
@@ -260,6 +263,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendPing(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.PING, wsChannel, callback, context, timeoutmillis);
@@ -294,6 +298,7 @@ public class WebSockets {
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendPing(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel, callback, null, timeoutmillis);
@@ -306,6 +311,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendPing(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel, callback, context, timeoutmillis);
@@ -423,6 +429,7 @@ public class WebSockets {
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendPong(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.PONG, wsChannel, callback, null, timeoutmillis);
@@ -435,6 +442,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendPong(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.PONG, wsChannel, callback, context, timeoutmillis);
@@ -469,6 +477,7 @@ public class WebSockets {
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendPong(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PONG, wsChannel, callback, null, timeoutmillis);
@@ -481,6 +490,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendPong(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PONG, wsChannel, callback, context, timeoutmillis);
@@ -570,7 +580,7 @@ public class WebSockets {
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
@@ -581,7 +591,7 @@ public class WebSockets {
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
@@ -593,30 +603,32 @@ public class WebSockets {
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendBinary(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.BINARY, wsChannel, callback, null, timeoutmillis);
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendBinary(final ByteBuffer data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(data, WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
@@ -627,7 +639,7 @@ public class WebSockets {
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
@@ -639,23 +651,25 @@ public class WebSockets {
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendBinary(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel, callback, null, timeoutmillis);
     }
 
     /**
-     * Sends a complete text message, invoking the callback when complete
+     * Sends a complete binary message, invoking the callback when complete
      *
      * @param data The data to send
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendBinary(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);
@@ -693,6 +707,7 @@ public class WebSockets {
      * @param pooledData The data to send, it will be freed when done
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<Void> callback, long timeoutmillis) {
         sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, null, timeoutmillis);
@@ -706,6 +721,7 @@ public class WebSockets {
      * @param wsChannel The web socket channel
      * @param callback The callback to invoke on completion
      * @param context The context object that will be passed to the callback on completion
+     * @param timeoutmillis the timeout in milliseconds
      */
     public static <T> void sendBinary(final PooledByteBuffer pooledData, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(pooledData, WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);

--- a/core/src/main/java/io/undertow/websockets/core/WebSockets.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSockets.java
@@ -136,7 +136,7 @@ public class WebSockets {
     public static <T> void sendText(final ByteBuffer message, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(message, WebSocketFrameType.TEXT, wsChannel, callback, context, timeoutmillis);
     }
-    
+
     /**
      * Sends a complete text message, invoking the callback when complete
      * Automatically frees the pooled byte buffer when done.
@@ -209,7 +209,7 @@ public class WebSockets {
     public static void sendTextBlocking(final ByteBuffer message, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(message, WebSocketFrameType.TEXT, wsChannel);
     }
-    
+
     /**
      * Sends a complete text message, invoking the callback when complete
      * Automatically frees the pooled byte buffer when done.
@@ -316,7 +316,7 @@ public class WebSockets {
     public static <T> void sendPing(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel, callback, context, timeoutmillis);
     }
-    
+
     /**
      * Sends a complete ping message, invoking the callback when complete
      * Automatically frees the pooled byte buffer when done.
@@ -388,7 +388,7 @@ public class WebSockets {
     public static void sendPingBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.PING, wsChannel);
     }
-    
+
     /**
      * Sends a complete ping message using blocking IO
      * Automatically frees the pooled byte buffer when done.
@@ -567,7 +567,7 @@ public class WebSockets {
     public static void sendPongBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.PONG, wsChannel);
     }
-    
+
     /**
      * Sends a complete pong message using blocking IO
      * Automatically frees the pooled byte buffer when done.
@@ -674,7 +674,7 @@ public class WebSockets {
     public static <T> void sendBinary(final ByteBuffer[] data, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel, callback, context, timeoutmillis);
     }
-    
+
     /**
      * Sends a complete binary message, invoking the callback when complete
      * Automatically frees the pooled byte buffer when done.
@@ -746,7 +746,7 @@ public class WebSockets {
     public static void sendBinaryBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(mergeBuffers(data), WebSocketFrameType.BINARY, wsChannel);
     }
-    
+
     /**
      * Sends a complete binary message using blocking IO
      * Automatically frees the pooled byte buffer when done.
@@ -895,7 +895,7 @@ public class WebSockets {
     public static void sendCloseBlocking(final ByteBuffer[] data, final WebSocketChannel wsChannel) throws IOException {
         sendCloseBlocking(new CloseMessage(data), wsChannel);
     }
-    
+
     private static <T> void sendInternal(final ByteBuffer data, WebSocketFrameType type, final WebSocketChannel wsChannel, final WebSocketCallback<T> callback, T context, long timeoutmillis) {
         sendInternal(new ImmediatePooledByteBuffer(data), type, wsChannel, callback, context, timeoutmillis);
     }
@@ -985,7 +985,7 @@ public class WebSockets {
     private static void sendBlockingInternal(final ByteBuffer data, WebSocketFrameType type, final WebSocketChannel wsChannel) throws IOException {
         sendBlockingInternal(new ImmediatePooledByteBuffer(data), type, wsChannel);
     }
-    
+
     private static void sendBlockingInternal(final PooledByteBuffer pooledData, WebSocketFrameType type, final WebSocketChannel wsChannel) throws IOException {
         boolean closePooledData = true;
         try {
@@ -995,7 +995,6 @@ public class WebSockets {
             if(!channel.send(pooledData)) {
                 throw WebSocketMessages.MESSAGES.unableToSendOnNewChannel();
             }
-            
             channel.shutdownWrites();
             while (!channel.flush()) {
                 channel.awaitWritable();


### PR DESCRIPTION
Adds PooledByteBuffer overloads to all the send methods of the WebSockets class.

Also fixes some documentation inconsistencies.