### PR TITLE
Introducing UnitTests category.

### DIFF
--- a/core/src/test/java/io/undertow/client/http/ResponseParserResumeTestCase.java
+++ b/core/src/test/java/io/undertow/client/http/ResponseParserResumeTestCase.java
@@ -18,11 +18,13 @@
 
 package io.undertow.client.http;
 
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.util.HttpString;
 import io.undertow.util.Protocols;
 import io.undertow.util.StatusCodes;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.nio.ByteBuffer;
 
@@ -31,6 +33,7 @@ import java.nio.ByteBuffer;
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class ResponseParserResumeTestCase {
 
     public static final String DATA = "HTTP/1.1 200 OK\r\nHost:   www.somehost.net\r\nOtherHeader: some\r\n    value\r\nHostee:another\r\nAccept-garbage:   a\r\n\r\ntttt";

--- a/core/src/test/java/io/undertow/predicate/PredicateParsingTestCase.java
+++ b/core/src/test/java/io/undertow/predicate/PredicateParsingTestCase.java
@@ -18,17 +18,20 @@
 
 package io.undertow.predicate;
 
-import java.util.HashMap;
-
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class PredicateParsingTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/protocols/http2/HpackHuffmanEncodingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/protocols/http2/HpackHuffmanEncodingUnitTestCase.java
@@ -18,14 +18,17 @@
 
 package io.undertow.protocols.http2;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.nio.ByteBuffer;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class HpackHuffmanEncodingUnitTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/protocols/http2/HpackSpecExamplesUnitTestCase.java
+++ b/core/src/test/java/io/undertow/protocols/http2/HpackSpecExamplesUnitTestCase.java
@@ -18,18 +18,21 @@
 
 package io.undertow.protocols.http2;
 
-import java.nio.ByteBuffer;
-import org.junit.Assert;
-import org.junit.Test;
-
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.nio.ByteBuffer;
 
 /**
  * HPACK unit test case, based on examples from the spec
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class HpackSpecExamplesUnitTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
@@ -18,19 +18,22 @@
 
 package io.undertow.server.handlers;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.server.handlers.builder.HandlerParser;
 import io.undertow.util.StatusCodes;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 /**
  * Unit tests for peer security handler
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class IPAddressAccessControlHandlerUnitTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/server/handlers/UserAgentAccessControlHandlerUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/UserAgentAccessControlHandlerUnitTestCase.java
@@ -17,19 +17,23 @@
  */
 package io.undertow.server.handlers;
 
-import static io.undertow.attribute.ExchangeAttributes.requestHeader;
-import static io.undertow.util.Headers.USER_AGENT;
-import static org.junit.Assert.*;
+import io.undertow.testutils.category.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.net.UnknownHostException;
 
-import org.junit.Test;
+import static io.undertow.attribute.ExchangeAttributes.requestHeader;
+import static io.undertow.util.Headers.USER_AGENT;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for peer security handler
  *
  * @author Andre Dietisheim
  */
+@Category(UnitTest.class)
 public class UserAgentAccessControlHandlerUnitTestCase {
 
     private static final String PATTERN_IE_ALL = "Mozilla.+\\(compatible; MSIE .+";

--- a/core/src/test/java/io/undertow/server/handlers/builder/PredicatedHandlersParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/builder/PredicatedHandlersParserTestCase.java
@@ -18,6 +18,7 @@
 
 package io.undertow.server.handlers.builder;
 
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.predicate.ContainsPredicate;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -32,6 +33,7 @@ import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,6 +42,7 @@ import java.util.List;
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class PredicatedHandlersParserTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/server/handlers/file/PathResourceManagerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/file/PathResourceManagerTestCase.java
@@ -1,18 +1,20 @@
 package io.undertow.server.handlers.file;
 
+import io.undertow.testutils.category.UnitTest;
+import io.undertow.server.handlers.resource.PathResourceManager;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Test;
-import io.undertow.server.handlers.resource.PathResourceManager;
-
 /**
  * @author Tomaz Cerar (c) 2016 Red Hat Inc.
  */
-
+@Category(UnitTest.class)
 public class PathResourceManagerTestCase {
 
 

--- a/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
@@ -18,22 +18,25 @@
 
 package io.undertow.server.protocol.ajp;
 
+import io.undertow.testutils.category.UnitTest;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.Methods;
+import io.undertow.util.Protocols;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.xnio.IoUtils;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.xnio.IoUtils;
-import io.undertow.server.HttpServerExchange;
-import io.undertow.util.Headers;
-import io.undertow.util.Methods;
-import io.undertow.util.Protocols;
-
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class AjpParsingUnitTestCase {
 
     private static final ByteBuffer buffer;

--- a/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
@@ -18,22 +18,25 @@
 
 package io.undertow.server.protocol.http;
 
-import java.nio.ByteBuffer;
-
 import io.undertow.UndertowOptions;
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.xnio.OptionMap;
+
+import java.nio.ByteBuffer;
 
 /**
  * Tests that the parser can resume when it is given partial input
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class ParserResumeTestCase {
 
     public static final String DATA = "GET http://www.somehost.net/apath+with+spaces%20and%20I%C3%B1t%C3%ABrn%C3%A2ti%C3%B4n%C3%A0li%C5%BE%C3%A6ti%C3%B8n?key1=value1&key2=I%C3%B1t%C3%ABrn%C3%A2ti%C3%B4n%C3%A0li%C5%BE%C3%A6ti%C3%B8n HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: some\r\n    value\r\nHostee:another\r\nAccept-garbage:   a\r\n\r\ntttt";

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -18,10 +18,8 @@
 
 package io.undertow.server.protocol.http;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
-
 import io.undertow.UndertowOptions;
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
@@ -29,7 +27,11 @@ import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.xnio.OptionMap;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
 
 /**
  * Basic test of the HTTP parser functionality.
@@ -41,6 +43,7 @@ import org.xnio.OptionMap;
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class SimpleParserTestCase {
 
     private final ParseState parseState = new ParseState();

--- a/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
+++ b/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
@@ -17,16 +17,17 @@
  */
 package io.undertow.server.security;
 
-import static org.junit.Assert.assertEquals;
-
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.security.idm.DigestAlgorithm;
 import io.undertow.security.impl.DigestAuthorizationToken;
 import io.undertow.security.impl.DigestQop;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.EnumMap;
 import java.util.Map;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Test case to test the parsing of the Authorization header for Digest requests.
@@ -39,6 +40,7 @@ import org.junit.Test;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
+@Category(UnitTest.class)
 public class ParseDigestAuthorizationTokenTestCase {
 
     private void doTest(final String header, final Map<DigestAuthorizationToken, String> expected) {

--- a/core/src/test/java/io/undertow/testutils/category/FunctionalTest.java
+++ b/core/src/test/java/io/undertow/testutils/category/FunctionalTest.java
@@ -1,0 +1,7 @@
+package io.undertow.testutils.category;
+
+/**
+ * Marker class used by JUnit categories representing unit tests
+ */
+public interface FunctionalTest {
+}

--- a/core/src/test/java/io/undertow/testutils/category/UnitTest.java
+++ b/core/src/test/java/io/undertow/testutils/category/UnitTest.java
@@ -1,0 +1,7 @@
+package io.undertow.testutils.category;
+
+/**
+ * Marker class used by JUnit categories representing unit tests
+ */
+public interface UnitTest {
+}

--- a/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
@@ -18,14 +18,17 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests canonicalization of the path
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class CanonicalPathUtilsTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/ContentTypeParsingTestCase.java
+++ b/core/src/test/java/io/undertow/util/ContentTypeParsingTestCase.java
@@ -18,12 +18,15 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class ContentTypeParsingTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -19,6 +19,10 @@
 package io.undertow.util;
 
 import io.undertow.server.handlers.Cookie;
+import io.undertow.testutils.category.UnitTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Arrays;
 import java.util.Calendar;
@@ -26,12 +30,10 @@ import java.util.Date;
 import java.util.Map;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class CookiesTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/DateUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/DateUtilsTestCase.java
@@ -17,9 +17,11 @@
  */
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -28,6 +30,7 @@ import java.util.TimeZone;
 /**
  * @author Tomasz Knyziak
  */
+@Category(UnitTest.class)
 public class DateUtilsTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/ETagUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/ETagUtilsTestCase.java
@@ -18,12 +18,15 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class ETagUtilsTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/FlexBase64TestCase.java
+++ b/core/src/test/java/io/undertow/util/FlexBase64TestCase.java
@@ -19,10 +19,12 @@
 package io.undertow.util;
 
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-
+@Category(UnitTest.class)
 public class FlexBase64TestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/HeaderMapTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderMapTestCase.java
@@ -18,16 +18,23 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
+@Category(UnitTest.class)
 public final class HeaderMapTestCase {
 
     private static final List<HttpString> HTTP_STRING_LIST = Arrays.asList(Headers.CONNECTION, Headers.HOST, Headers.UPGRADE, Headers.CONTENT_MD5, Headers.KEEP_ALIVE, Headers.RESPONSE_AUTH, Headers.CONTENT_DISPOSITION, Headers.DEFLATE, Headers.NEGOTIATE, Headers.USER_AGENT, Headers.REFERER, Headers.TRANSFER_ENCODING, Headers.FROM);

--- a/core/src/test/java/io/undertow/util/HeaderOrderTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderOrderTestCase.java
@@ -18,6 +18,11 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -25,15 +30,13 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 /**
  * Tests that the headers in the Headers class have the correct order. The headers
  * are assigned an explicit ordering integer to allow for super fast comparisons.
  *
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class HeaderOrderTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/HeaderTokenParserTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderTokenParserTestCase.java
@@ -19,14 +19,17 @@
 package io.undertow.util;
 
 import io.undertow.security.impl.DigestAuthorizationToken;
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.Collections;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class HeaderTokenParserTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/HeaderValuesTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderValuesTestCase.java
@@ -18,13 +18,16 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.*;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
+@Category(UnitTest.class)
 public final class HeaderValuesTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/HeadersUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeadersUtilsTestCase.java
@@ -18,14 +18,17 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Tests param extraction of a header
  *
  * @author Tim Terlegård
  */
+@Category(UnitTest.class)
 public class HeadersUtilsTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/HttpStringTestCase.java
+++ b/core/src/test/java/io/undertow/util/HttpStringTestCase.java
@@ -18,8 +18,10 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -30,6 +32,7 @@ import java.io.ObjectOutputStream;
 /**
  * @author Matej Lazar
  */
+@Category(UnitTest.class)
 public class HttpStringTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/LocaleUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/LocaleUtilsTestCase.java
@@ -1,10 +1,13 @@
 package io.undertow.util;
 
-import java.util.Locale;
-
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import java.util.Locale;
+
+@Category(UnitTest.class)
 public class LocaleUtilsTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
+++ b/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
@@ -20,8 +20,10 @@ package io.undertow.util;
 
 import io.undertow.server.DefaultByteBufferPool;
 import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -32,6 +34,7 @@ import java.util.List;
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class MimeDecodingTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/NodeStatusCodesTestCase.java
+++ b/core/src/test/java/io/undertow/util/NodeStatusCodesTestCase.java
@@ -18,12 +18,15 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class NodeStatusCodesTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/PathMatcherTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathMatcherTestCase.java
@@ -1,7 +1,9 @@
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test the path matcher to ensure that it can handle different cases and
@@ -11,6 +13,7 @@ import org.junit.Test;
  * @author Chris Ruffalo
  *
  */
+@Category(UnitTest.class)
 public class PathMatcherTestCase {
 
     /**

--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -18,8 +18,10 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +30,7 @@ import java.util.TreeSet;
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class PathTemplateTestCase {
 
     @Test

--- a/core/src/test/java/io/undertow/util/SubstringMapTestCase.java
+++ b/core/src/test/java/io/undertow/util/SubstringMapTestCase.java
@@ -18,8 +18,10 @@
 
 package io.undertow.util;
 
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,6 +32,7 @@ import java.util.Set;
 /**
  * @author Stuart Douglas
  */
+@Category(UnitTest.class)
 public class SubstringMapTestCase {
 
     public static final int NUM_TEST_VALUES = 1000;

--- a/core/src/test/java/io/undertow/util/TestVersion.java
+++ b/core/src/test/java/io/undertow/util/TestVersion.java
@@ -19,12 +19,15 @@
 package io.undertow.util;
 
 import io.undertow.Version;
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
  */
+@Category(UnitTest.class)
 public class TestVersion {
 
     @Test

--- a/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
@@ -18,18 +18,20 @@
 
 package io.undertow.util;
 
-import java.nio.charset.Charset;
-
+import io.undertow.testutils.category.UnitTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.nio.charset.Charset;
 
 import static org.junit.Assert.assertEquals;
 /**
  * @author Oleksandr Radchykov
  */
 @RunWith(Parameterized.class)
+@Category(UnitTest.class)
 public class URLUtilsTestCase {
 
     @Parameterized.Parameters

--- a/core/src/test/java/io/undertow/websockets/extensions/CompressionUtilsTest.java
+++ b/core/src/test/java/io/undertow/websockets/extensions/CompressionUtilsTest.java
@@ -18,13 +18,15 @@
 
 package io.undertow.websockets.extensions;
 
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
-
+import io.undertow.testutils.category.UnitTest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
 
 
 /**
@@ -32,6 +34,7 @@ import org.junit.Test;
  *
  * @author Lucas Ponce
  */
+@Category(UnitTest.class)
 public class CompressionUtilsTest {
 
     private static Inflater decompress;

--- a/core/src/test/java/io/undertow/websockets/extensions/WebSocketExtensionParserTest.java
+++ b/core/src/test/java/io/undertow/websockets/extensions/WebSocketExtensionParserTest.java
@@ -18,17 +18,20 @@
 
 package io.undertow.websockets.extensions;
 
-import java.util.List;
-
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.websockets.WebSocketExtension;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
 
 /**
  * A test class for WebSocket Extensions parsing operations.
  *
  * @author Lucas Ponce
  */
+@Category(UnitTest.class)
 public class WebSocketExtensionParserTest {
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,8 @@
         <!-- Surefire args -->
         <surefire.jpda.args/>
         <surefire.system.args>-ea ${surefire.jpda.args} -Xmx1024m</surefire.system.args>
+        <!--by default run all tests-->
+        <test.categories>io.undertow.testutils.category.UnitTest OR NOT io.undertow.testutils.category.UnitTest</test.categories>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
@@ -198,6 +200,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
+                        <groups>${test.categories}</groups>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     </configuration>
                 </plugin>
@@ -544,6 +547,30 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>only-unit-tests</id>
+            <activation>
+                <property>
+                    <name>onlyUnitTests</name>
+                </property>
+            </activation>
+            <properties>
+                <test.categories>io.undertow.testutils.category.UnitTest</test.categories>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>skip-unit-tests</id>
+            <activation>
+                <property>
+                    <name>skipUnitTests</name>
+                </property>
+            </activation>
+            <properties>
+                <test.categories>NOT io.undertow.testutils.category.UnitTest</test.categories>
+            </properties>
         </profile>
     </profiles>
 

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/ClassUtilsTest.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/ClassUtilsTest.java
@@ -17,24 +17,27 @@
  */
 package io.undertow.websockets.jsr.test;
 
+import io.undertow.testutils.category.UnitTest;
 import io.undertow.websockets.jsr.util.ClassUtils;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
-import javax.websocket.EncodeException;
-import javax.websocket.Encoder;
-import javax.websocket.EndpointConfig;
-import javax.websocket.MessageHandler;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import javax.websocket.EncodeException;
+import javax.websocket.Encoder;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
 
 /**
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>
  */
+@Category(UnitTest.class)
 public class ClassUtilsTest {
 
     @Test


### PR DESCRIPTION
Unit tests marked by JUnit category, allowing to execute only unit tests (might be useful for doing only quick check without need to execute more extensive tests) and included profiles which are able execute either only unit tests or the remaining ones (functional ones, which usually start the Undertow server and are more time consuming).

The default behavior is maintained and still all tests are executed.