### PR TITLE
Fix charset parsing regression

### DIFF
--- a/core/src/main/java/io/undertow/util/Headers.java
+++ b/core/src/main/java/io/undertow/util/Headers.java
@@ -339,11 +339,7 @@ public final class Headers {
                     whiteSpace = false;
                 } else {
                     keypos = 0;
-                    if(c == ' ') {
-                        whiteSpace = true;
-                    } else {
-                        whiteSpace = false;
-                    }
+                    whiteSpace = c == ' ' || c == ';' || c == '\t';
                 }
                 if (keypos == key.length()) {
                     if (header.charAt(i + 1) == '=') {

--- a/core/src/test/java/io/undertow/util/ContentTypeParsingTestCase.java
+++ b/core/src/test/java/io/undertow/util/ContentTypeParsingTestCase.java
@@ -38,6 +38,8 @@ public class ContentTypeParsingTestCase {
         Assert.assertEquals("UTF-8", Headers.extractQuotedValueFromHeader("text/html; charset=\"UTF-8\"; foo=bar", "charset"));
         Assert.assertEquals("UTF-8", Headers.extractQuotedValueFromHeader("text/html; charset=UTF-8 foo=bar", "charset"));
         Assert.assertEquals("UTF-8", Headers.extractQuotedValueFromHeader("text/html; badcharset=bad charset=UTF-8 foo=bar", "charset"));
+        Assert.assertEquals("UTF-8", Headers.extractQuotedValueFromHeader("text/html;charset=UTF-8", "charset"));
+        Assert.assertEquals("UTF-8", Headers.extractQuotedValueFromHeader("text/html;\tcharset=UTF-8", "charset"));
     }
 
 }


### PR DESCRIPTION
Fix content type parsing regression introduced by
8ef565d9d41505d4ce0b7896326bec7b43701fb4

content type parsing fails when no whitespace is present following
the delimiter semicolon.