### PR TITLE
UNDERTOW-1020 / UNDERTOW-1021 for 1.4.x branch

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -115,7 +115,7 @@ public interface UndertowLogger extends BasicLogger {
     void ioException(@Cause IOException e);
 
     @LogMessage(level = DEBUG)
-    @Message(id = 5014, value = "Failed to parse HTTP request")
+    @Message(id = 5014, value = "Failed to parse request")
     void failedToParseRequest(@Cause Exception e);
 
     @LogMessage(level = ERROR)

--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -32,9 +32,9 @@ import io.undertow.predicate.PredicateBuilder;
 import io.undertow.protocols.http2.HpackException;
 import io.undertow.security.api.AuthenticationMechanism;
 import io.undertow.server.handlers.builder.HandlerBuilder;
-import io.undertow.server.protocol.http.HttpRequestParser;
 import io.undertow.util.HttpString;
 import io.undertow.util.ParameterLimitException;
+import io.undertow.util.BadRequestException;
 
 /**
  * @author Stuart Douglas
@@ -150,7 +150,7 @@ public interface UndertowMessages {
     String authenticationFailed(final String userName);
 
     @Message(id = 39, value = "To many query parameters, cannot have more than %s query parameters")
-    HttpRequestParser.BadRequestException tooManyQueryParameters(int noParams);
+    BadRequestException tooManyQueryParameters(int noParams);
 
     @Message(id = 40, value = "To many headers, cannot have more than %s header")
     String tooManyHeaders(int noParams);
@@ -274,7 +274,7 @@ public interface UndertowMessages {
     IllegalArgumentException notAValidRegularExpressionPattern(String pattern);
 
     @Message(id = 81, value = "Bad request")
-    RuntimeException badRequest();
+    BadRequestException badRequest();
 
     @Message(id = 82, value = "Host %s already registered")
     RuntimeException hostAlreadyRegistered(Object host);

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -58,6 +58,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import io.undertow.util.ParameterLimitException;
+import io.undertow.util.BadRequestException;
 import io.undertow.util.URLUtils;
 
 /**
@@ -575,9 +576,4 @@ public class AjpRequestParser {
         OTHER
     }
 
-    public static class BadRequestException extends Exception {
-        public BadRequestException(String msg) {
-            super(msg);
-        }
-    }
 }

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -52,6 +52,7 @@ import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.util.TreeMap;
 
+import io.undertow.UndertowLogger;
 import io.undertow.UndertowMessages;
 import io.undertow.security.impl.ExternalAuthenticationMechanism;
 import io.undertow.server.HttpServerExchange;
@@ -259,6 +260,7 @@ public class AjpRequestParser {
                         try {
                             URLUtils.parsePathParms(result.value.substring(colon + 1), exchange, encoding, doDecode && result.containsUrlCharacters, maxParameters);
                         } catch (ParameterLimitException e) {
+                            UndertowLogger.REQUEST_IO_LOGGER.failedToParseRequest(e);
                             state.badRequest = true;
                         }
                     }
@@ -324,6 +326,7 @@ public class AjpRequestParser {
                 } else {
                     state.numHeaders = result.value;
                     if(state.numHeaders > maxHeaders) {
+                        UndertowLogger.REQUEST_IO_LOGGER.failedToParseRequest(new BadRequestException(UndertowMessages.MESSAGES.tooManyHeaders(maxHeaders)));
                         state.badRequest = true;
                     }
                 }
@@ -412,6 +415,7 @@ public class AjpRequestParser {
                         try {
                             URLUtils.parseQueryString(resultAsQueryString, exchange, encoding, doDecode, maxParameters);
                         } catch (ParameterLimitException e) {
+                            UndertowLogger.REQUEST_IO_LOGGER.failedToParseRequest(e);
                             state.badRequest = true;
                         }
                     } else if (state.currentAttribute.equals(REMOTE_USER)) {

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -193,7 +193,7 @@ public class AjpRequestParser {
                     return;
                 } else {
                     if (result.value != 0x1234) {
-                        throw UndertowMessages.MESSAGES.wrongMagicNumber(result.value);
+                        throw new BadRequestException(UndertowMessages.MESSAGES.wrongMagicNumber(result.value));
                     }
                 }
             }
@@ -228,7 +228,7 @@ public class AjpRequestParser {
                     if (method > 0 && method < 28) {
                         exchange.setRequestMethod(HTTP_METHODS[method]);
                     } else if((method & 0xFF) != 0xFF) {
-                        throw new IllegalArgumentException("Unknown method type " + method);
+                        throw new BadRequestException("Unknown method type " + method);
                     }
                 }
             }

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -35,6 +35,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
 import io.undertow.util.URLUtils;
+import io.undertow.util.BadRequestException;
 import org.xnio.OptionMap;
 
 import static io.undertow.util.Headers.ACCEPT_CHARSET_STRING;
@@ -795,7 +796,7 @@ public abstract class HttpRequestParser {
         return true;
     }
 
-    protected void handleAfterVersion(ByteBuffer buffer, ParseState state) {
+    protected void handleAfterVersion(ByteBuffer buffer, ParseState state) throws BadRequestException {
         boolean newLine = state.leftOver == '\n';
         while (buffer.hasRemaining()) {
             final byte next = buffer.get();
@@ -852,12 +853,6 @@ public abstract class HttpRequestParser {
         }
         return results;
 
-    }
-
-    public static class BadRequestException extends Exception {
-        public BadRequestException(String msg) {
-            super(msg);
-        }
     }
 
 }

--- a/core/src/main/java/io/undertow/util/BadRequestException.java
+++ b/core/src/main/java/io/undertow/util/BadRequestException.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.util;
+
+/**
+ * Exception that is thrown when bad request is detected
+ *
+ * @author Stuart Douglas
+ */
+public class BadRequestException extends Exception {
+
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(Throwable cause) {
+        super(cause);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
@@ -23,6 +23,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
+import io.undertow.util.BadRequestException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -62,7 +63,7 @@ public class AjpParsingUnitTestCase {
 
 
     @Test
-    public void testAjpParsing() throws IOException, AjpRequestParser.BadRequestException {
+    public void testAjpParsing() throws IOException, BadRequestException {
         final ByteBuffer buffer = AjpParsingUnitTestCase.buffer.duplicate();
         HttpServerExchange result = new HttpServerExchange(null);
         final AjpRequestParseState state = new AjpRequestParseState();
@@ -75,7 +76,7 @@ public class AjpParsingUnitTestCase {
     }
 
     @Test
-    public void testByteByByteAjpParsing() throws IOException, AjpRequestParser.BadRequestException {
+    public void testByteByByteAjpParsing() throws IOException, BadRequestException {
         final ByteBuffer buffer = AjpParsingUnitTestCase.buffer.duplicate();
 
         HttpServerExchange result = new HttpServerExchange(null);

--- a/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/ParserResumeTestCase.java
@@ -24,6 +24,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
+import io.undertow.util.BadRequestException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,7 +57,7 @@ public class ParserResumeTestCase {
     }
 
     @Test
-    public void testOneCharacterAtATime() throws HttpRequestParser.BadRequestException {
+    public void testOneCharacterAtATime() throws BadRequestException {
         context.reset();
         byte[] in = DATA.getBytes();
         HttpServerExchange result = new HttpServerExchange(null);
@@ -73,7 +74,7 @@ public class ParserResumeTestCase {
         runAssertions(result);
     }
 
-    private void testResume(final int split, byte[] in) throws HttpRequestParser.BadRequestException {
+    private void testResume(final int split, byte[] in) throws BadRequestException {
         context.reset();
         HttpServerExchange result = new HttpServerExchange(null);
         ByteBuffer buffer = ByteBuffer.wrap(in);

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -25,6 +25,7 @@ import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.Protocols;
+import io.undertow.util.BadRequestException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -49,7 +50,7 @@ public class SimpleParserTestCase {
     private final ParseState parseState = new ParseState();
 
     @Test
-    public void testEncodedSlashDisallowed() throws HttpRequestParser.BadRequestException {
+    public void testEncodedSlashDisallowed() throws BadRequestException {
         byte[] in = "GET /somepath%2FotherPath HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -61,7 +62,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testEncodedSlashAllowed() throws HttpRequestParser.BadRequestException {
+    public void testEncodedSlashAllowed() throws BadRequestException {
         byte[] in = "GET /somepath%2fotherPath HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -73,7 +74,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testColonSlashInURL() throws HttpRequestParser.BadRequestException {
+    public void testColonSlashInURL() throws BadRequestException {
         byte[] in = "GET /a/http://myurl.com/b/c HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -85,7 +86,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testColonSlashInFullURL() throws HttpRequestParser.BadRequestException {
+    public void testColonSlashInFullURL() throws BadRequestException {
         byte[] in = "GET http://foo.com/a/http://myurl.com/b/c HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -98,7 +99,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testPathParameters() throws HttpRequestParser.BadRequestException {
+    public void testPathParameters() throws BadRequestException {
         byte[] in = "GET /somepath;p1 HTTP/1.1\r\n\r\n".getBytes();
         ParseState context = new ParseState();
         HttpServerExchange result = new HttpServerExchange(null);
@@ -122,7 +123,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testFullUrlRootPath() throws HttpRequestParser.BadRequestException {
+    public void testFullUrlRootPath() throws BadRequestException {
         byte[] in = "GET http://myurl.com HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -133,7 +134,7 @@ public class SimpleParserTestCase {
         Assert.assertEquals("http://myurl.com", result.getRequestURI());
     }
     @Test
-    public void testSimpleRequest() throws HttpRequestParser.BadRequestException {
+    public void testSimpleRequest() throws BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: some\r\n    value\r\n\r\n".getBytes();
         runTest(in);
     }
@@ -141,7 +142,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testSimpleRequestWithHeaderCaching() throws HttpRequestParser.BadRequestException {
+    public void testSimpleRequestWithHeaderCaching() throws BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: foo\r\n\r\n".getBytes();
         runTest(in, "foo");
         in = "GET /somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader:       foo\r\n\r\n".getBytes();
@@ -154,26 +155,26 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testCarriageReturnLineEnds() throws HttpRequestParser.BadRequestException {
+    public void testCarriageReturnLineEnds() throws BadRequestException {
 
         byte[] in = "GET /somepath HTTP/1.1\rHost:   www.somehost.net\rOtherHeader: some\r    value\r\r\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testLineFeedsLineEnds() throws HttpRequestParser.BadRequestException {
+    public void testLineFeedsLineEnds() throws BadRequestException {
         byte[] in = "GET /somepath HTTP/1.1\nHost:   www.somehost.net\nOtherHeader: some\n    value\n\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testTabWhitespace() throws HttpRequestParser.BadRequestException {
+    public void testTabWhitespace() throws BadRequestException {
         byte[] in = "GET\t/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
         runTest(in);
     }
 
     @Test
-    public void testCanonicalPath() throws HttpRequestParser.BadRequestException {
+    public void testCanonicalPath() throws BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -184,7 +185,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testNoHeaders() throws HttpRequestParser.BadRequestException {
+    public void testNoHeaders() throws BadRequestException {
         byte[] in = "GET\t/aa\tHTTP/1.1\n\n\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -195,7 +196,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testQueryParams() throws HttpRequestParser.BadRequestException {
+    public void testQueryParams() throws BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath?a=b&b=c&d&e&f=\tHTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -213,7 +214,7 @@ public class SimpleParserTestCase {
     }
 
     @Test
-    public void testSameHttpStringReturned() throws HttpRequestParser.BadRequestException {
+    public void testSameHttpStringReturned() throws BadRequestException {
         byte[] in = "GET\thttp://www.somehost.net/somepath\tHTTP/1.1\nHost: \t www.somehost.net\nAccept-Charset:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context1 = new ParseState();
@@ -244,7 +245,7 @@ public class SimpleParserTestCase {
 
 
     @Test
-    public void testEmptyQueryParams() throws HttpRequestParser.BadRequestException {
+    public void testEmptyQueryParams() throws BadRequestException {
         byte[] in = "GET /clusterbench/requestinfo//?;?=44&test=OK;devil=3&&&&&&&&&&&&&&&&&&&&&&&&&&&&777=666 HTTP/1.1\r\n\r\n".getBytes();
 
         final ParseState context = new ParseState();
@@ -259,7 +260,7 @@ public class SimpleParserTestCase {
         Assert.assertEquals("44", result.getQueryParameters().get(";?").getFirst());
     }
     @Test
-    public void testNonEncodedAsciiCharacters() throws UnsupportedEncodingException, HttpRequestParser.BadRequestException {
+    public void testNonEncodedAsciiCharacters() throws UnsupportedEncodingException, BadRequestException {
         byte[] in = "GET /bÃ¥r HTTP/1.1\r\n\r\n".getBytes("ISO-8859-1");
 
         final ParseState context = new ParseState();
@@ -270,10 +271,10 @@ public class SimpleParserTestCase {
         Assert.assertEquals("/bÃ¥r", result.getRequestURI()); //not decoded
     }
 
-    private void runTest(final byte[] in) throws HttpRequestParser.BadRequestException {
+    private void runTest(final byte[] in) throws BadRequestException {
         runTest(in, "some value");
     }
-    private void runTest(final byte[] in, String lastHeader) throws HttpRequestParser.BadRequestException {
+    private void runTest(final byte[] in, String lastHeader) throws BadRequestException {
         parseState.reset();
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.EMPTY).handle(ByteBuffer.wrap(in), parseState, result);


### PR DESCRIPTION
This PR contains the following changes:

- UNDERTOW-1021 AJP listener should log at DEBUG level when handling 400 Bad Request like wrong magic number and invalid Content-Length
- UNDERTOW-1020 AjpRequestParser should output DEBUG log when exceeding max-parameters/max-headers
- Consolidate Http/AjpRequestParser's BadRequestException into the io.undertow.util package
