### PR TITLE
[UNDERTOW-1050] minor: just a fix of a typo in name of JettyAlpnProvider

### DIFF
--- a/core/src/main/java/io/undertow/protocols/alpn/JettyAlpnProvider.java
+++ b/core/src/main/java/io/undertow/protocols/alpn/JettyAlpnProvider.java
@@ -146,6 +146,6 @@ public class JettyAlpnProvider implements ALPNProvider {
 
     @Override
     public String toString() {
-        return "JettyAlpnProvider{}";
+        return "JettyAlpnProvider";
     }
 }


### PR DESCRIPTION
NOTE: If approved, this has to be picked also to 1.4.x branch too.