### PR TITLE
Support pooling Deflaters

### DIFF
--- a/core/src/main/java/io/undertow/conduits/DeflaterPool.java
+++ b/core/src/main/java/io/undertow/conduits/DeflaterPool.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.conduits;
+
+import java.util.zip.Deflater;
+
+/**
+ * @author ckozak
+ */
+public interface DeflaterPool {
+
+    Deflater getDeflater();
+
+    void returnDeflater(Deflater deflater);
+
+}

--- a/core/src/main/java/io/undertow/conduits/GzipStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/GzipStreamSinkConduit.java
@@ -61,7 +61,14 @@ public class GzipStreamSinkConduit extends DeflatingStreamSinkConduit {
             ConduitFactory<StreamSinkConduit> conduitFactory,
             HttpServerExchange exchange,
             int deflateLevel) {
-        super(conduitFactory, exchange, deflateLevel);
+        this(conduitFactory, exchange, new NewInstanceDeflaterPool(deflateLevel, true));
+    }
+
+    public GzipStreamSinkConduit(
+            ConduitFactory<StreamSinkConduit> conduitFactory,
+            HttpServerExchange exchange,
+            DeflaterPool deflaterPool) {
+        super(conduitFactory, exchange, deflaterPool);
         writeHeader();
         Connectors.updateResponseBytesSent(exchange, HEADER.length);
     }

--- a/core/src/main/java/io/undertow/conduits/NewInstanceDeflaterPool.java
+++ b/core/src/main/java/io/undertow/conduits/NewInstanceDeflaterPool.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.conduits;
+
+import java.util.zip.Deflater;
+
+/**
+ * @author ckozak
+ */
+public class NewInstanceDeflaterPool implements DeflaterPool {
+
+    private final int level;
+    private final boolean nowrap;
+
+    public NewInstanceDeflaterPool(int level, boolean nowrap) {
+        this.level = level;
+        this.nowrap = nowrap;
+    }
+
+    @Override
+    public Deflater getDeflater() {
+        return new Deflater(level, nowrap);
+    }
+
+    @Override
+    public void returnDeflater(Deflater deflater) {
+        deflater.end();
+    }
+}

--- a/core/src/main/java/io/undertow/server/handlers/encoding/DeflateEncodingProvider.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/DeflateEncodingProvider.java
@@ -19,7 +19,9 @@
 package io.undertow.server.handlers.encoding;
 
 import io.undertow.UndertowLogger;
+import io.undertow.conduits.DeflaterPool;
 import io.undertow.conduits.DeflatingStreamSinkConduit;
+import io.undertow.conduits.NewInstanceDeflaterPool;
 import io.undertow.server.ConduitWrapper;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.ConduitFactory;
@@ -34,14 +36,18 @@ import java.util.zip.Deflater;
  */
 public class DeflateEncodingProvider implements ContentEncodingProvider {
 
-    private final int deflateLevel;
+    private final DeflaterPool deflaterPool;
 
     public DeflateEncodingProvider() {
         this(Deflater.DEFLATED);
     }
 
     public DeflateEncodingProvider(int deflateLevel) {
-        this.deflateLevel = deflateLevel;
+        this(new NewInstanceDeflaterPool(deflateLevel, true));
+    }
+
+    public DeflateEncodingProvider(DeflaterPool deflaterPool) {
+        this.deflaterPool = deflaterPool;
     }
 
     @Override
@@ -50,7 +56,7 @@ public class DeflateEncodingProvider implements ContentEncodingProvider {
             @Override
             public StreamSinkConduit wrap(final ConduitFactory<StreamSinkConduit> factory, final HttpServerExchange exchange) {
                 UndertowLogger.REQUEST_LOGGER.tracef("Created DEFLATE response conduit for %s", exchange);
-                return new DeflatingStreamSinkConduit(factory, exchange, deflateLevel);
+                return new DeflatingStreamSinkConduit(factory, exchange, deflaterPool);
             }
         };
     }

--- a/core/src/main/java/io/undertow/server/handlers/encoding/GzipEncodingProvider.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/GzipEncodingProvider.java
@@ -19,7 +19,9 @@
 package io.undertow.server.handlers.encoding;
 
 import io.undertow.UndertowLogger;
+import io.undertow.conduits.DeflaterPool;
 import io.undertow.conduits.GzipStreamSinkConduit;
+import io.undertow.conduits.NewInstanceDeflaterPool;
 import io.undertow.server.ConduitWrapper;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.ConduitFactory;
@@ -34,14 +36,18 @@ import java.util.zip.Deflater;
  */
 public class GzipEncodingProvider implements ContentEncodingProvider {
 
-    private final int deflateLevel;
+    private final DeflaterPool deflaterPool;
 
     public GzipEncodingProvider() {
         this(Deflater.DEFAULT_COMPRESSION);
     }
 
     public GzipEncodingProvider(int deflateLevel) {
-        this.deflateLevel = deflateLevel;
+        this(new NewInstanceDeflaterPool(deflateLevel, true));
+    }
+
+    public GzipEncodingProvider(DeflaterPool deflaterPool) {
+        this.deflaterPool = deflaterPool;
     }
 
     @Override
@@ -50,7 +56,7 @@ public class GzipEncodingProvider implements ContentEncodingProvider {
             @Override
             public StreamSinkConduit wrap(final ConduitFactory<StreamSinkConduit> factory, final HttpServerExchange exchange) {
                 UndertowLogger.REQUEST_LOGGER.tracef("Created GZIP response conduit for %s", exchange);
-                return new GzipStreamSinkConduit(factory, exchange, deflateLevel);
+                return new GzipStreamSinkConduit(factory, exchange, deflaterPool);
             }
         };
     }


### PR DESCRIPTION
Gzip and Deflate encoding providers accept a DeflaterPool allowing
them to reuse deflaters to cut down on jni overhead. No pooling
implementations have been provided yet.

bugfix:
The default DeflaterPool implementation will call Deflater.end()
when finished, releasing the native ref.