### PR TITLE
Fix potential infinite loop in AbstractFramedChannel#flushSenders

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
@@ -585,7 +585,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
                     }
                 }
 
-            } catch (IOException e) {
+            } catch (IOException|RuntimeException e) {
                 safeClose(channel);
                 markWritesBroken(e);
             }


### PR DESCRIPTION
Occasionally I/O threads would get stuck in an infinite loop, throwing the following exception over and over:

`ERROR [default I/O-8] [org.xnio.listener] XNIO001007: A channel event listener threw an exception: java.lang.IllegalStateException: XNIO000017: Buffer was already freed
	at org.xnio.ByteBufferSlicePool$PooledByteBuffer.getResource(ByteBufferSlicePool.java:206)
	at org.xnio.ByteBufferSlicePool$PooledByteBuffer.getResource(ByteBufferSlicePool.java:176)
	at io.undertow.server.protocol.framed.AbstractFramedChannel.flushSenders(AbstractFramedChannel.java:481)
	at io.undertow.server.protocol.framed.AbstractFramedChannel$FrameWriteListener.handleEvent(AbstractFramedChannel.java:774)
	at io.undertow.server.protocol.framed.AbstractFramedChannel$FrameWriteListener.handleEvent(AbstractFramedChannel.java:771)
	at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
	at org.xnio.conduits.WriteReadyHandler$ChannelListenerHandler.writeReady(WriteReadyHandler.java:65)
	at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:93)
	at org.xnio.nio.WorkerThread.run(WorkerThread.java:539)
`

A change was made -- in the line of an earlier commit -- to actually handle such exceptions in AbstractFramedChannel#flushSenders. Hopefully this will then close the channel and prevent an infinite loop.

The underlying root cause could not be determined. The problem can not be reproduced at will.
