### PR TITLE
Explicit surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${version.surefire.plugin}</version>
                     <configuration>
                         <groups>${test.categories}</groups>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>


### PR DESCRIPTION
Lets have defined explicit surefire plugin version to prevent usage of different versions on different environments.