### PR TITLE
test fix / workaround for wildfly shutdown with MCC that hasn't called close.

### DIFF
--- a/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
@@ -612,7 +612,7 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
             engine.closeInbound();
         } catch (SSLException e) {
             UndertowLogger.REQUEST_IO_LOGGER.trace("Exception closing read side of SSL channel", e);
-            IoUtils.safeClose(delegate);
+            IoUtils.safeClose(connection, delegate);
         }
 
         state |= FLAG_READ_CLOSED | FLAG_ENGINE_INBOUND_SHUTDOWN | FLAG_READ_SHUTDOWN;


### PR DESCRIPTION
This is a workaround for JBEAP-11176 (which ends up not having anythign to do with the external SASL mechanism, just a programmatic MCC that never calls MCC.close(). [https://issues.jboss.org/browse/JBEAP-11176]

@stuartwdouglas What do you think should be happening here? In this state, when notifyReadClosed() gets called and throws (SslConduit:614) the underlying connection never seems to get closed, so either closing it explicitly, or calling notifyWriteClosed() seems to be required in this state.

FWIW, the other state here is:
  runListener: false, FLAG_WRITE_CLOSED: not set, FLAG_WRITE_REQUIRES_READ: not set.

Also at the time, the client has completed execution and exited.