### PR TITLE
[UNDERTOW-1091] Invalid response code for empty host value in request

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -603,7 +603,7 @@ public final class HttpServerExchange extends AbstractAttachable {
      */
     public String getHostName() {
         String host = requestHeaders.getFirst(Headers.HOST);
-        if (host == null) {
+        if (host == null || "".equals(host.trim())) {
             host = getDestinationAddress().getHostString();
         } else {
             if (host.startsWith("[")) {


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/UNDERTOW-1091