### PR TITLE
UNDERTOW-1095 UNDERTOW-1096 Add correct quoting cookie and RFC6265 compliant cookie validation

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -538,4 +538,10 @@ public interface UndertowMessages {
     @Message(id = 172, value = "An invalid path [%s] was specified for this cookie")
     IllegalArgumentException invalidCookiePath(String value);
 
+    @Message(id = 173, value = "An invalid control character [%s] was present in the cookie value or attribute")
+    IllegalArgumentException invalidControlCharacter(String value);
+
+    @Message(id = 174, value = "An invalid escape character in cookie value")
+    IllegalArgumentException invalidEscapeCharacter();
+
 }

--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -528,4 +528,14 @@ public interface UndertowMessages {
 
     @Message(id = 166, value = "Pooled object is closed")
     IllegalStateException objectIsClosed();
+
+    @Message(id = 170, value = "An invalid character [ASCII code: %s] was present in the cookie value")
+    IllegalArgumentException invalidCookieValue(String value);
+
+    @Message(id = 171, value = "An invalid domain [%s] was specified for this cookie")
+    IllegalArgumentException invalidCookieDomain(String value);
+
+    @Message(id = 172, value = "An invalid path [%s] was specified for this cookie")
+    IllegalArgumentException invalidCookiePath(String value);
+
 }

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -188,6 +188,8 @@ public class UndertowOptions {
      */
     public static final Option<Boolean> ENABLE_RFC6265_COOKIE_VALIDATION = Option.simple(UndertowOptions.class, "ENABLE_RFC6265_COOKIE_VALIDATION", Boolean.class);
 
+    public static final boolean DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION = false;
+
     /**
      * If we should attempt to use SPDY for HTTPS connections.
      *

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -182,6 +182,14 @@ public class UndertowOptions {
     public static final Option<Boolean> ALLOW_EQUALS_IN_COOKIE_VALUE = Option.simple(UndertowOptions.class, "ALLOW_EQUALS_IN_COOKIE_VALUE", Boolean.class);
 
     /**
+     * If this is true then Undertow will enable RFC6265 compliant cookie validation for Set-Cookie header instead of legacy backward compatible behavior.
+     *
+     * default is false
+     */
+    public static final Option<Boolean> ENABLE_RFC6265_COOKIE_VALIDATION = Option.simple(UndertowOptions.class, "ENABLE_RFC6265_COOKIE_VALIDATION", Boolean.class);
+
+
+    /**
      * If we should attempt to use SPDY for HTTPS connections.
      *
      * SPDY is no longer supported, use HTTP/2 instead

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -188,7 +188,6 @@ public class UndertowOptions {
      */
     public static final Option<Boolean> ENABLE_RFC6265_COOKIE_VALIDATION = Option.simple(UndertowOptions.class, "ENABLE_RFC6265_COOKIE_VALIDATION", Boolean.class);
 
-
     /**
      * If we should attempt to use SPDY for HTTPS connections.
      *

--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -93,7 +93,7 @@ public class Connectors {
      */
     public static void flattenCookies(final HttpServerExchange exchange) {
         Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
-        boolean enableRfc6265Validation = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, false);
+        boolean enableRfc6265Validation = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, UndertowOptions.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION);
         if (cookies != null) {
             for (Map.Entry<String, Cookie> entry : cookies.entrySet()) {
                 exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(entry.getValue(), enableRfc6265Validation));

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -45,6 +45,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.NetworkUtils;
 import io.undertow.util.Protocols;
+import io.undertow.util.Rfc6265CookieSupport;
 import io.undertow.util.StatusCodes;
 import org.jboss.logging.Logger;
 import org.xnio.Buffers;
@@ -1118,6 +1119,17 @@ public final class HttpServerExchange extends AbstractAttachable {
      * @param cookie The cookie
      */
     public HttpServerExchange setResponseCookie(final Cookie cookie) {
+
+        if (cookie.getValue() != null && !cookie.getValue().isEmpty()) {
+            Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        }
+        if (cookie.getPath() != null && !cookie.getPath().isEmpty()) {
+            Rfc6265CookieSupport.validatePath(cookie.getPath());
+        }
+        if (cookie.getDomain() != null && !cookie.getDomain().isEmpty()) {
+            Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+        }
+
         if (responseCookies == null) {
             responseCookies = new TreeMap<>(); //hashmap is slow to allocate in JDK7
         }

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -1119,17 +1119,17 @@ public final class HttpServerExchange extends AbstractAttachable {
      * @param cookie The cookie
      */
     public HttpServerExchange setResponseCookie(final Cookie cookie) {
-
-        if (cookie.getValue() != null && !cookie.getValue().isEmpty()) {
-            Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        if(getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, false)) {
+            if (cookie.getValue() != null && !cookie.getValue().isEmpty()) {
+                Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+            }
+            if (cookie.getPath() != null && !cookie.getPath().isEmpty()) {
+                Rfc6265CookieSupport.validatePath(cookie.getPath());
+            }
+            if (cookie.getDomain() != null && !cookie.getDomain().isEmpty()) {
+                Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+            }
         }
-        if (cookie.getPath() != null && !cookie.getPath().isEmpty()) {
-            Rfc6265CookieSupport.validatePath(cookie.getPath());
-        }
-        if (cookie.getDomain() != null && !cookie.getDomain().isEmpty()) {
-            Rfc6265CookieSupport.validateDomain(cookie.getDomain());
-        }
-
         if (responseCookies == null) {
             responseCookies = new TreeMap<>(); //hashmap is slow to allocate in JDK7
         }

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -1119,7 +1119,7 @@ public final class HttpServerExchange extends AbstractAttachable {
      * @param cookie The cookie
      */
     public HttpServerExchange setResponseCookie(final Cookie cookie) {
-        if(getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, false)) {
+        if(getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, UndertowOptions.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION)) {
             if (cookie.getValue() != null && !cookie.getValue().isEmpty()) {
                 Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
             }

--- a/core/src/main/java/io/undertow/util/DateUtils.java
+++ b/core/src/main/java/io/undertow/util/DateUtils.java
@@ -74,14 +74,21 @@ public class DateUtils {
 
     private static final String OLD_COOKIE_PATTERN = "EEE, dd-MMM-yyyy HH:mm:ss z";
 
-
     private static final String COMMON_LOG_PATTERN = "[dd/MMM/yyyy:HH:mm:ss Z]";
-
 
     private static final ThreadLocal<SimpleDateFormat> COMMON_LOG_PATTERN_FORMAT = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
             SimpleDateFormat df = new SimpleDateFormat(COMMON_LOG_PATTERN, LOCALE_US);
+            return df;
+        }
+    };
+
+    private static final ThreadLocal<SimpleDateFormat> OLD_COOKIE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df = new SimpleDateFormat(OLD_COOKIE_PATTERN, LOCALE_US);
+            df.setTimeZone(GMT_ZONE);
             return df;
         }
     };
@@ -103,9 +110,7 @@ public class DateUtils {
 
 
     public static String toOldCookieDateString(final Date date) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(OLD_COOKIE_PATTERN, LOCALE_US);
-        dateFormat.setTimeZone(GMT_ZONE);
-        return dateFormat.format(date);
+        return OLD_COOKIE_FORMAT.get().format(date);
     }
 
     public static String toCommonLogFormat(final Date date) {

--- a/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
+++ b/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
@@ -1,0 +1,389 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.undertow.util;
+
+import io.undertow.UndertowMessages;
+import io.undertow.server.handlers.Cookie;
+
+import java.util.Date;
+
+/**
+ * Class that contains static constants and utility methods for legacy Set-Cookie format.
+ * Porting from JBossWeb and Tomcat code.
+ */
+public final class LegacyCookieSupport {
+
+    // --------------------------------------------------------------- Constants
+
+    /**
+     * If set to true, we parse cookies strictly according to the servlet,
+     * cookie and HTTP specs by default.
+     */
+    private static final boolean STRICT_SERVLET_COMPLIANCE;
+
+    /**
+     * If true, separators that are not explicitly dis-allowed by the v0 cookie
+     * spec but are disallowed by the HTTP spec will be allowed in v0 cookie
+     * names and values. These characters are: \"()/:<=>?@[\\]{} Note that the
+     * inclusion of / depend on the value of {@link #FWD_SLASH_IS_SEPARATOR}.
+     */
+    private static final boolean ALLOW_HTTP_SEPARATORS_IN_V0;
+
+    /**
+     * If set to false, we don't use the IE6/7 Max-Age/Expires work around.
+     * Default is usually true. If STRICT_SERVLET_COMPLIANCE==true then default
+     * is false. Explicitly setting always takes priority.
+     */
+    private static final boolean ALWAYS_ADD_EXPIRES;
+
+    /**
+     * If set to true, the <code>/</code> character will be treated as a
+     * separator. Default is false.
+     */
+    private static final boolean FWD_SLASH_IS_SEPARATOR;
+
+    /**
+     * The list of separators that apply to version 0 cookies. To quote the
+     * spec, these are comma, semi-colon and white-space. The HTTP spec
+     * definition of linear white space is [CRLF] 1*( SP | HT )
+     */
+    private static final char[] V0_SEPARATORS = {',', ';', ' ', '\t'};
+    private static final boolean[] V0_SEPARATOR_FLAGS = new boolean[128];
+
+    /**
+     * The list of separators that apply to version 1 cookies. This may or may
+     * not include '/' depending on the setting of
+     * {@link #FWD_SLASH_IS_SEPARATOR}.
+     */
+    private static final char[] HTTP_SEPARATORS;
+    private static final boolean[] HTTP_SEPARATOR_FLAGS = new boolean[128];
+
+    private static final String ancientDate;
+
+    static {
+
+        STRICT_SERVLET_COMPLIANCE = Boolean.valueOf(System.getProperty(
+                "io.undertow.legacy.cookie.STRICT_SERVLET_COMPLIANCE",
+                "true"));
+
+        ALLOW_HTTP_SEPARATORS_IN_V0 = Boolean.valueOf(System.getProperty(
+                "io.undertow.legacy.cookie.ALLOW_HTTP_SEPARATORS_IN_V0",
+                "false"));
+
+        FWD_SLASH_IS_SEPARATOR = Boolean.valueOf(System.getProperty(
+                "io.undertow.legacy.cookie.FWD_SLASH_IS_SEPARATOR",
+                "false"));
+
+        String alwaysAddExpires = System.getProperty(
+                "io.undertow.legacy.cookie.ALWAYS_ADD_EXPIRES");
+        if (alwaysAddExpires == null) {
+            ALWAYS_ADD_EXPIRES = !STRICT_SERVLET_COMPLIANCE;
+        } else {
+            ALWAYS_ADD_EXPIRES = Boolean.valueOf(alwaysAddExpires);
+        }
+        /*
+        Excluding the '/' char by default violates the RFC, but
+        it looks like a lot of people put '/'
+        in unquoted values: '/': ; //47
+        '\t':9 ' ':32 '\"':34 '(':40 ')':41 ',':44 ':':58 ';':59 '<':60
+        '=':61 '>':62 '?':63 '@':64 '[':91 '\\':92 ']':93 '{':123 '}':125
+        */
+        if (FWD_SLASH_IS_SEPARATOR) {
+            HTTP_SEPARATORS = new char[]{'\t', ' ', '\"', '(', ')', ',', '/',
+                    ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '{', '}'};
+        } else {
+            HTTP_SEPARATORS = new char[]{'\t', ' ', '\"', '(', ')', ',',
+                    ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '{', '}'};
+        }
+        for (int i = 0; i < 128; i++) {
+            V0_SEPARATOR_FLAGS[i] = false;
+            HTTP_SEPARATOR_FLAGS[i] = false;
+        }
+        for (char V0_SEPARATOR : V0_SEPARATORS) {
+            V0_SEPARATOR_FLAGS[V0_SEPARATOR] = true;
+        }
+        for (char HTTP_SEPARATOR : HTTP_SEPARATORS) {
+            HTTP_SEPARATOR_FLAGS[HTTP_SEPARATOR] = true;
+        }
+
+        ancientDate = DateUtils.toOldCookieDateString(new Date(10000));
+    }
+
+    // ----------------------------------------------------------------- Methods
+
+    /**
+     * Returns true if the byte is a separator as defined by V0 of the cookie
+     * spec.
+     */
+    private static boolean isV0Separator(final char c) {
+        if (c < 0x20 || c >= 0x7f) {
+            if (c != 0x09) {
+                throw UndertowMessages.MESSAGES.invalidControlCharacter(Integer.toString(c));
+            }
+        }
+
+        return V0_SEPARATOR_FLAGS[c];
+    }
+
+    private static boolean isV0Token(String value) {
+        if( value==null) return false;
+
+        int i = 0;
+        int len = value.length();
+
+        if (alreadyQuoted(value)) {
+            i++;
+            len--;
+        }
+
+        for (; i < len; i++) {
+            char c = value.charAt(i);
+
+            if (isV0Separator(c))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the byte is a separator as defined by V1 of the cookie
+     * spec, RFC2109.
+     * @throws IllegalArgumentException if a control character was supplied as
+     *         input
+     */
+    private static boolean isHttpSeparator(final char c) {
+        if (c < 0x20 || c >= 0x7f) {
+            if (c != 0x09) {
+                throw UndertowMessages.MESSAGES.invalidControlCharacter(Integer.toString(c));
+            }
+        }
+
+        return HTTP_SEPARATOR_FLAGS[c];
+    }
+
+    private static boolean isHttpToken(String value) {
+        if( value==null) return false;
+
+        int i = 0;
+        int len = value.length();
+
+        if (alreadyQuoted(value)) {
+            i++;
+            len--;
+        }
+
+        for (; i < len; i++) {
+            char c = value.charAt(i);
+
+            if (isHttpSeparator(c))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean alreadyQuoted(String value) {
+        if (value==null || value.length() < 2) return false;
+        return (value.charAt(0)=='\"' && value.charAt(value.length()-1)=='\"');
+    }
+
+    public static String generateLegacyCookieString(final Cookie cookie) {
+
+        StringBuilder buf = new StringBuilder();
+
+        // Servlet implementation checks name
+        buf.append(cookie.getName());
+        buf.append("=");
+        // Servlet implementation does not check anything else
+
+        // Start by adjusting the cookie version with the cookie attibutes
+        int newVersion = adjustedCookieVersion(cookie);
+
+        String value = cookie.getValue();
+        String path = cookie.getPath();
+        String domain = cookie.getDomain();
+        String comment = cookie.getComment();
+
+        // Now build the cookie header
+        // Value
+        maybeQuote(buf, value);
+
+        // Add version 1 specific information
+        if (newVersion == 1) {
+            // Version=1 ... required
+            buf.append ("; Version=1");
+
+            // Comment=comment
+            if (comment != null) {
+                buf.append ("; Comment=");
+                maybeQuote(buf, comment);
+            }
+        }
+
+        // Add domain information, if present
+        if (domain != null) {
+            buf.append("; Domain=");
+            maybeQuote(buf, domain);
+        }
+
+        // Max-Age=secs ... or use old "Expires" format
+        if (cookie.getMaxAge() != null && cookie.getMaxAge() >= 0) {
+            if (newVersion > 0) {
+                buf.append ("; Max-Age=");
+                buf.append (cookie.getMaxAge());
+            }
+            // IE6, IE7 and possibly other browsers don't understand Max-Age.
+            // They do understand Expires, even with V1 cookies!
+            if (newVersion == 0 || ALWAYS_ADD_EXPIRES) {
+                // Wdy, DD-Mon-YY HH:MM:SS GMT ( Expires Netscape format )
+                buf.append ("; Expires=");
+                // To expire immediately we need to set the time in past
+                if (cookie.getMaxAge() == 0) {
+                    buf.append(ancientDate);
+                } else {
+                    buf.append(DateUtils.toOldCookieDateString(new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000L)));
+                }
+            }
+        }
+
+        // Path=path
+        if (path != null) {
+            buf.append ("; Path=");
+            maybeQuote(buf, path);
+        }
+
+        // Secure
+        if (cookie.isSecure()) {
+          buf.append ("; Secure");
+        }
+
+        // HttpOnly
+        if (cookie.isHttpOnly()) {
+            buf.append("; HttpOnly");
+        }
+
+        return buf.toString();
+    }
+
+    /**
+     * Quotes values if required.
+     * @param buf
+     * @param value
+     */
+    public static void maybeQuote(StringBuilder buf, String value) {
+        if (value==null || value.length()==0) {
+            buf.append("\"\"");
+        } else if (alreadyQuoted(value)) {
+            buf.append('"');
+            buf.append(escapeDoubleQuotes(value,1,value.length()-1));
+            buf.append('"');
+        } else if (isHttpToken(value) && !ALLOW_HTTP_SEPARATORS_IN_V0 ||
+                isV0Token(value) && ALLOW_HTTP_SEPARATORS_IN_V0) {
+            buf.append('"');
+            buf.append(escapeDoubleQuotes(value,0,value.length()));
+            buf.append('"');
+        } else {
+            buf.append(value);
+        }
+    }
+
+    /**
+     * Escapes any double quotes in the given string.
+     *
+     * @param s the input string
+     * @param beginIndex start index inclusive
+     * @param endIndex exclusive
+     * @return The (possibly) escaped string
+     */
+    private static String escapeDoubleQuotes(String s, int beginIndex, int endIndex) {
+
+        if (s == null || s.length() == 0 || s.indexOf('"') == -1) {
+            return s;
+        }
+
+        StringBuilder b = new StringBuilder();
+        for (int i = beginIndex; i < endIndex; i++) {
+            char c = s.charAt(i);
+            if (c == '\\' ) {
+                b.append(c);
+                //ignore the character after an escape, just append it
+                if (++i>=endIndex) throw UndertowMessages.MESSAGES.invalidEscapeCharacter();
+                b.append(s.charAt(i));
+            } else if (c == '"')
+                b.append('\\').append('"');
+            else
+                b.append(c);
+        }
+
+        return b.toString();
+    }
+
+    public static int adjustedCookieVersion(Cookie cookie) {
+
+        /*
+         * The spec allows some latitude on when to send the version attribute
+         * with a Set-Cookie header. To be nice to clients, we'll make sure the
+         * version attribute is first. That means checking the various things
+         * that can cause us to switch to a v1 cookie first.
+         *_
+         * Note that by checking for tokens we will also throw an exception if a
+         * control character is encountered.
+         */
+
+        int version = cookie.getVersion();
+
+        String value = cookie.getValue();
+        String path = cookie.getPath();
+        String domain = cookie.getDomain();
+        String comment = cookie.getComment();
+
+        // If it is v0, check if we need to switch
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(value) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(value))) {
+            // HTTP token in value - need to use v1
+            version = 1;
+        }
+
+        if (version == 0 && comment != null) {
+            // Using a comment makes it a v1 cookie
+            version = 1;
+        }
+
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(path) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(path))) {
+            // HTTP token in path - need to use v1
+            version = 1;
+        }
+
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(domain) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(domain))) {
+            // HTTP token in domain - need to use v1
+            version = 1;
+        }
+
+        return version;
+    }
+
+    // ------------------------------------------------------------- Constructor
+    private LegacyCookieSupport() {
+        // Utility class. Don't allow instances to be created.
+    }
+}

--- a/core/src/main/java/io/undertow/util/Rfc6265CookieSupport.java
+++ b/core/src/main/java/io/undertow/util/Rfc6265CookieSupport.java
@@ -1,0 +1,99 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.util;
+
+import io.undertow.UndertowMessages;
+import java.util.BitSet;
+
+/**
+ * Class that contains utility methods for dealing with RFC6265 Cookies.
+ *
+ */
+public final class Rfc6265CookieSupport {
+
+    private static final BitSet domainValid = new BitSet(128);
+
+    static {
+        for (char c = '0'; c <= '9'; c++) {
+            domainValid.set(c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            domainValid.set(c);
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            domainValid.set(c);
+        }
+        domainValid.set('.');
+        domainValid.set('-');
+    }
+
+    public static void validateCookieValue(String value) {
+        int start = 0;
+        int end = value.length();
+
+        if (end > 1 && value.charAt(0) == '"' && value.charAt(end - 1) == '"') {
+            start = 1;
+            end--;
+        }
+
+        char[] chars = value.toCharArray();
+        for (int i = start; i < end; i++) {
+            char c = chars[i];
+            if (c < 0x21 || c == 0x22 || c == 0x2c || c == 0x3b || c == 0x5c || c == 0x7f) {
+                throw UndertowMessages.MESSAGES.invalidCookieValue(Integer.toString(c));
+            }
+        }
+    }
+
+    public static void validateDomain(String domain) {
+        int i = 0;
+        int prev = -1;
+        int cur = -1;
+        char[] chars = domain.toCharArray();
+        while (i < chars.length) {
+            prev = cur;
+            cur = chars[i];
+            if (!domainValid.get(cur)) {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            // labels must start with a letter or number
+            if ((prev == '.' || prev == -1) && (cur == '.' || cur == '-')) {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            // labels must end with a letter or number
+            if (prev == '-' && cur == '.') {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            i++;
+        }
+        // domain must end with a label
+        if (cur == '.' || cur == '-') {
+            throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+        }
+    }
+
+    public static void validatePath(String path) {
+        char[] chars = path.toCharArray();
+
+        for (int i = 0; i < chars.length; i++) {
+            char ch = chars[i];
+            if (ch < 0x20 || ch > 0x7E || ch == ';') {
+                throw UndertowMessages.MESSAGES.invalidCookiePath(path);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -278,4 +278,62 @@ public class CookiesTestCase {
     public void testInvalidSameSiteCookie() {
         Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_E_COYOTE; path=/; SameSite=test");
     }
+
+    // RFC6265 allows US-ASCII characters excluding CTLs, whitespace,
+    // double quote, comma, semicolon and backslash as cookie value.
+    // This does not change even if value is quoted.
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue() {
+        // whitespace is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_ E_COYOTE; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue1() {
+        // whitespace is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_ E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue2() {
+        // double quote si not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_\\\"E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue3() {
+        // comma is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_,E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue4() {
+        // semicolon is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_;E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue5() {
+        /// backslash is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_\\E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+
+    // RFC6265 allows any CHAR except CTLs or ";" as cookie path
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInPath() {
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_E_COYOTE; path=\"/ex;ample\"; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        Rfc6265CookieSupport.validatePath(cookie.getPath());
+        Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInDomain() {
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_E_COYOTE; path=/example; domain=\"ex;ample.com\"");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        Rfc6265CookieSupport.validatePath(cookie.getPath());
+        Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+    }
+
 }


### PR DESCRIPTION
RFC6265 (Section 4.1 Set-Cookie) states that Servers SHOULD NOT send
Set-Cookie headers that fail to conform the defined grammer.

For example, cookie value should be US-ASCII characters excluding
CTLs, whitespace, double quote, comma, semicolon, and backslash.

Port validation logics for cookie value, path and domain attributes
from org.apache.tomcat.util.http.Rfc6265CookieProcessor in Tomcat 8.x.

Also add some test cases for RFC6265 cookie validation.