### PR TITLE
UNDERTOW-1085 Fix NullPointerException

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
@@ -472,6 +472,9 @@ public class ServletPathMatches {
     }
 
     private static ServletChain servletChain(HttpHandler next, final ManagedServlet managedServlet, final String servletPath, final DeploymentInfo deploymentInfo, boolean defaultServlet, MappingMatch mappingMatch, String pattern) {
+        if (deploymentInfo.isSecurityDisabled()) {
+            return new ServletChain(next, managedServlet, servletPath, defaultServlet, mappingMatch, pattern);
+        }
         HttpHandler servletHandler = new ServletSecurityRoleHandler(next, deploymentInfo.getAuthorizationManager());
         servletHandler = wrapHandlers(servletHandler, managedServlet.getServletInfo().getHandlerChainWrappers());
         return new ServletChain(servletHandler, managedServlet, servletPath, defaultServlet, mappingMatch, pattern);


### PR DESCRIPTION
If DeploymentInfo.securityDisabled is true ServletPathMatches throws NullPointerException.