### PR TITLE
UNDERTOW-1095 UNDERTOW-1096 for 1.3.x branch

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -457,4 +457,20 @@ public interface UndertowMessages {
 
     @Message(id = 165, value = "Invalid character %s in request-target")
     String invalidCharacterInRequestTarget(char next);
+
+    @Message(id = 168, value = "An invalid character [ASCII code: %s] was present in the cookie value")
+    IllegalArgumentException invalidCookieValue(String value);
+
+    @Message(id = 169, value = "An invalid domain [%s] was specified for this cookie")
+    IllegalArgumentException invalidCookieDomain(String value);
+
+    @Message(id = 170, value = "An invalid path [%s] was specified for this cookie")
+    IllegalArgumentException invalidCookiePath(String value);
+
+    @Message(id = 173, value = "An invalid control character [%s] was present in the cookie value or attribute")
+    IllegalArgumentException invalidControlCharacter(String value);
+
+    @Message(id = 174, value = "An invalid escape character in cookie value")
+    IllegalArgumentException invalidEscapeCharacter();
+
 }

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -186,7 +186,7 @@ public class UndertowOptions {
      */
     public static final Option<Boolean> ENABLE_RFC6265_COOKIE_VALIDATION = Option.simple(UndertowOptions.class, "ENABLE_RFC6265_COOKIE_VALIDATION", Boolean.class);
 
-    public static final boolean DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION = false;
+    public static final boolean DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION = Boolean.getBoolean("io.undertow.cookie.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION");
 
     /**
      * If we should attempt to use SPDY for HTTPS connections.

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -180,6 +180,15 @@ public class UndertowOptions {
     public static final Option<Boolean> ALLOW_EQUALS_IN_COOKIE_VALUE = Option.simple(UndertowOptions.class, "ALLOW_EQUALS_IN_COOKIE_VALUE", Boolean.class);
 
     /**
+     * If this is true then Undertow will enable RFC6265 compliant cookie validation for Set-Cookie header instead of legacy backward compatible behavior.
+     *
+     * default is false
+     */
+    public static final Option<Boolean> ENABLE_RFC6265_COOKIE_VALIDATION = Option.simple(UndertowOptions.class, "ENABLE_RFC6265_COOKIE_VALIDATION", Boolean.class);
+
+    public static final boolean DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION = false;
+
+    /**
      * If we should attempt to use SPDY for HTTPS connections.
      */
     public static final Option<Boolean> ENABLE_SPDY = Option.simple(UndertowOptions.class, "ENABLE_SPDY", Boolean.class);

--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -27,6 +27,7 @@ import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
+import io.undertow.util.LegacyCookieSupport;
 import io.undertow.util.ParameterLimitException;
 import io.undertow.util.StatusCodes;
 import io.undertow.util.URLUtils;
@@ -90,9 +91,10 @@ public class Connectors {
      */
     public static void flattenCookies(final HttpServerExchange exchange) {
         Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
+        boolean enableRfc6265Validation = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, UndertowOptions.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION);
         if (cookies != null) {
             for (Map.Entry<String, Cookie> entry : cookies.entrySet()) {
-                exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(entry.getValue()));
+                exchange.getResponseHeaders().add(Headers.SET_COOKIE, getCookieString(entry.getValue(), enableRfc6265Validation));
             }
         }
     }
@@ -143,13 +145,17 @@ public class Connectors {
         exchange.resetRequestChannel();
     }
 
-    private static String getCookieString(final Cookie cookie) {
-        switch (cookie.getVersion()) {
-            case 0:
-                return addVersion0ResponseCookieToExchange(cookie);
-            case 1:
-            default:
-                return addVersion1ResponseCookieToExchange(cookie);
+    private static String getCookieString(final Cookie cookie, boolean enableRfc6265Validation) {
+        if(enableRfc6265Validation) {
+            return addRfc6265ResponseCookieToExchange(cookie);
+        } else {
+            switch (LegacyCookieSupport.adjustedCookieVersion(cookie)) {
+                case 0:
+                    return addVersion0ResponseCookieToExchange(cookie);
+                case 1:
+                default:
+                    return addVersion1ResponseCookieToExchange(cookie);
+            }
         }
     }
 
@@ -157,18 +163,73 @@ public class Connectors {
         exchange.setRequestStartTime(System.nanoTime());
     }
 
-    private static String addVersion0ResponseCookieToExchange(final Cookie cookie) {
+    private static String addRfc6265ResponseCookieToExchange(final Cookie cookie) {
         final StringBuilder header = new StringBuilder(cookie.getName());
         header.append("=");
         header.append(cookie.getValue());
-
         if (cookie.getPath() != null) {
-            header.append("; path=");
+            header.append("; Path=");
             header.append(cookie.getPath());
         }
         if (cookie.getDomain() != null) {
-            header.append("; domain=");
+            header.append("; Domain=");
             header.append(cookie.getDomain());
+        }
+        if (cookie.isDiscard()) {
+            header.append("; Discard");
+        }
+        if (cookie.isSecure()) {
+            header.append("; Secure");
+        }
+        if (cookie.isHttpOnly()) {
+            header.append("; HttpOnly");
+        }
+        if (cookie.getMaxAge() != null) {
+            if (cookie.getMaxAge() >= 0) {
+                header.append("; Max-Age=");
+                header.append(cookie.getMaxAge());
+            }
+            // Microsoft IE and Microsoft Edge don't understand Max-Age so send
+            // expires as well. Without this, persistent cookies fail with those
+            // browsers. They do understand Expires, even with V1 cookies.
+            // So, we add Expires header when Expires is not explicitly specified.
+            if (cookie.getExpires() == null) {
+                if (cookie.getMaxAge() == 0) {
+                    Date expires = new Date();
+                    expires.setTime(0);
+                    header.append("; Expires=");
+                    header.append(DateUtils.toOldCookieDateString(expires));
+                } else if (cookie.getMaxAge() > 0) {
+                    Date expires = new Date();
+                    expires.setTime(expires.getTime() + cookie.getMaxAge() * 1000L);
+                    header.append("; Expires=");
+                    header.append(DateUtils.toOldCookieDateString(expires));
+                }
+            }
+        }
+        if (cookie.getExpires() != null) {
+            header.append("; Expires=");
+            header.append(DateUtils.toDateString(cookie.getExpires()));
+        }
+        if (cookie.getComment() != null && !cookie.getComment().isEmpty()) {
+            header.append("; Comment=");
+            header.append(cookie.getComment());
+        }
+        return header.toString();
+    }
+
+    private static String addVersion0ResponseCookieToExchange(final Cookie cookie) {
+        final StringBuilder header = new StringBuilder(cookie.getName());
+        header.append("=");
+        LegacyCookieSupport.maybeQuote(header, cookie.getValue());
+
+        if (cookie.getPath() != null) {
+            header.append("; path=");
+            LegacyCookieSupport.maybeQuote(header, cookie.getPath());
+        }
+        if (cookie.getDomain() != null) {
+            header.append("; domain=");
+            LegacyCookieSupport.maybeQuote(header, cookie.getDomain());
         }
         if (cookie.isSecure()) {
             header.append("; secure");
@@ -204,15 +265,15 @@ public class Connectors {
 
         final StringBuilder header = new StringBuilder(cookie.getName());
         header.append("=");
-        header.append(cookie.getValue());
+        LegacyCookieSupport.maybeQuote(header, cookie.getValue());
         header.append("; Version=1");
         if (cookie.getPath() != null) {
             header.append("; Path=");
-            header.append(cookie.getPath());
+            LegacyCookieSupport.maybeQuote(header, cookie.getPath());
         }
         if (cookie.getDomain() != null) {
             header.append("; Domain=");
-            header.append(cookie.getDomain());
+            LegacyCookieSupport.maybeQuote(header, cookie.getDomain());
         }
         if (cookie.isDiscard()) {
             header.append("; Discard");
@@ -228,6 +289,23 @@ public class Connectors {
                 header.append("; Max-Age=");
                 header.append(cookie.getMaxAge());
             }
+            // Microsoft IE and Microsoft Edge don't understand Max-Age so send
+            // expires as well. Without this, persistent cookies fail with those
+            // browsers. They do understand Expires, even with V1 cookies.
+            // So, we add Expires header when Expires is not explicitly specified.
+            if (cookie.getExpires() == null) {
+                if (cookie.getMaxAge() == 0) {
+                    Date expires = new Date();
+                    expires.setTime(0);
+                    header.append("; Expires=");
+                    header.append(DateUtils.toOldCookieDateString(expires));
+                } else if (cookie.getMaxAge() > 0) {
+                    Date expires = new Date();
+                    expires.setTime(expires.getTime() + cookie.getMaxAge() * 1000L);
+                    header.append("; Expires=");
+                    header.append(DateUtils.toOldCookieDateString(expires));
+                }
+            }
         }
         if (cookie.getExpires() != null) {
             header.append("; Expires=");
@@ -235,7 +313,7 @@ public class Connectors {
         }
         if (cookie.getComment() != null && !cookie.getComment().isEmpty()) {
             header.append("; Comment=");
-            header.append(cookie.getComment());
+            LegacyCookieSupport.maybeQuote(header, cookie.getComment());
         }
         return header.toString();
     }

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -44,6 +44,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.NetworkUtils;
 import io.undertow.util.Protocols;
+import io.undertow.util.Rfc6265CookieSupport;
 import io.undertow.util.StatusCodes;
 import org.jboss.logging.Logger;
 import org.xnio.Buffers;
@@ -1109,6 +1110,17 @@ public final class HttpServerExchange extends AbstractAttachable {
      * @param cookie The cookie
      */
     public HttpServerExchange setResponseCookie(final Cookie cookie) {
+        if(getConnection().getUndertowOptions().get(UndertowOptions.ENABLE_RFC6265_COOKIE_VALIDATION, UndertowOptions.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION)) {
+            if (cookie.getValue() != null && !cookie.getValue().isEmpty()) {
+                Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+            }
+            if (cookie.getPath() != null && !cookie.getPath().isEmpty()) {
+                Rfc6265CookieSupport.validatePath(cookie.getPath());
+            }
+            if (cookie.getDomain() != null && !cookie.getDomain().isEmpty()) {
+                Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+            }
+        }
         if (responseCookies == null) {
             responseCookies = new TreeMap<>(); //hashmap is slow to allocate in JDK7
         }

--- a/core/src/main/java/io/undertow/util/DateUtils.java
+++ b/core/src/main/java/io/undertow/util/DateUtils.java
@@ -74,14 +74,21 @@ public class DateUtils {
 
     private static final String OLD_COOKIE_PATTERN = "EEE, dd-MMM-yyyy HH:mm:ss z";
 
-
     private static final String COMMON_LOG_PATTERN = "[dd/MMM/yyyy:HH:mm:ss Z]";
-
 
     private static final ThreadLocal<SimpleDateFormat> COMMON_LOG_PATTERN_FORMAT = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
             SimpleDateFormat df = new SimpleDateFormat(COMMON_LOG_PATTERN, LOCALE_US);
+            return df;
+        }
+    };
+
+    private static final ThreadLocal<SimpleDateFormat> OLD_COOKIE_FORMAT = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df = new SimpleDateFormat(OLD_COOKIE_PATTERN, LOCALE_US);
+            df.setTimeZone(GMT_ZONE);
             return df;
         }
     };
@@ -103,9 +110,7 @@ public class DateUtils {
 
 
     public static String toOldCookieDateString(final Date date) {
-        SimpleDateFormat dateFormat = new SimpleDateFormat(OLD_COOKIE_PATTERN, LOCALE_US);
-        dateFormat.setTimeZone(GMT_ZONE);
-        return dateFormat.format(date);
+        return OLD_COOKIE_FORMAT.get().format(date);
     }
 
     public static String toCommonLogFormat(final Date date) {

--- a/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
+++ b/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.undertow.util;
+
+import io.undertow.UndertowMessages;
+import io.undertow.server.handlers.Cookie;
+
+/**
+ * Class that contains static constants and utility methods for legacy Set-Cookie format.
+ * Porting from JBossWeb and Tomcat code.
+ *
+ * Note that in general we do not use system properties for configuration, however as these are
+ * legacy options that are not widely used an exception has been made in this case.
+ *
+ */
+public final class LegacyCookieSupport {
+
+    // --------------------------------------------------------------- Constants
+
+
+    /**
+     * If true, separators that are not explicitly dis-allowed by the v0 cookie
+     * spec but are disallowed by the HTTP spec will be allowed in v0 cookie
+     * names and values. These characters are: \"()/:<=>?@[\\]{} Note that the
+     * inclusion of / depend on the value of {@link #FWD_SLASH_IS_SEPARATOR}.
+     *
+     * Defaults to false.
+     */
+    private static final boolean ALLOW_HTTP_SEPARATORS_IN_V0 = Boolean.getBoolean("io.undertow.legacy.cookie.ALLOW_HTTP_SEPARATORS_IN_V0");
+
+
+    /**
+     * If set to true, the <code>/</code> character will be treated as a
+     * separator. Default is false.
+     */
+    private static final boolean FWD_SLASH_IS_SEPARATOR = Boolean.getBoolean("io.undertow.legacy.cookie.FWD_SLASH_IS_SEPARATOR");
+
+    /**
+     * The list of separators that apply to version 0 cookies. To quote the
+     * spec, these are comma, semi-colon and white-space. The HTTP spec
+     * definition of linear white space is [CRLF] 1*( SP | HT )
+     */
+    private static final char[] V0_SEPARATORS = {',', ';', ' ', '\t'};
+    private static final boolean[] V0_SEPARATOR_FLAGS = new boolean[128];
+
+    /**
+     * The list of separators that apply to version 1 cookies. This may or may
+     * not include '/' depending on the setting of
+     * {@link #FWD_SLASH_IS_SEPARATOR}.
+     */
+    private static final char[] HTTP_SEPARATORS;
+    private static final boolean[] HTTP_SEPARATOR_FLAGS = new boolean[128];
+
+    static {
+        /*
+        Excluding the '/' char by default violates the RFC, but
+        it looks like a lot of people put '/'
+        in unquoted values: '/': ; //47
+        '\t':9 ' ':32 '\"':34 '(':40 ')':41 ',':44 ':':58 ';':59 '<':60
+        '=':61 '>':62 '?':63 '@':64 '[':91 '\\':92 ']':93 '{':123 '}':125
+        */
+        if (FWD_SLASH_IS_SEPARATOR) {
+            HTTP_SEPARATORS = new char[]{'\t', ' ', '\"', '(', ')', ',', '/',
+                    ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '{', '}'};
+        } else {
+            HTTP_SEPARATORS = new char[]{'\t', ' ', '\"', '(', ')', ',',
+                    ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']', '{', '}'};
+        }
+        for (int i = 0; i < 128; i++) {
+            V0_SEPARATOR_FLAGS[i] = false;
+            HTTP_SEPARATOR_FLAGS[i] = false;
+        }
+        for (char V0_SEPARATOR : V0_SEPARATORS) {
+            V0_SEPARATOR_FLAGS[V0_SEPARATOR] = true;
+        }
+        for (char HTTP_SEPARATOR : HTTP_SEPARATORS) {
+            HTTP_SEPARATOR_FLAGS[HTTP_SEPARATOR] = true;
+        }
+    }
+
+    // ----------------------------------------------------------------- Methods
+
+    /**
+     * Returns true if the byte is a separator as defined by V0 of the cookie
+     * spec.
+     */
+    private static boolean isV0Separator(final char c) {
+        if (c < 0x20 || c >= 0x7f) {
+            if (c != 0x09) {
+                throw UndertowMessages.MESSAGES.invalidControlCharacter(Integer.toString(c));
+            }
+        }
+
+        return V0_SEPARATOR_FLAGS[c];
+    }
+
+    private static boolean isV0Token(String value) {
+        if( value==null) return false;
+
+        int i = 0;
+        int len = value.length();
+
+        if (alreadyQuoted(value)) {
+            i++;
+            len--;
+        }
+
+        for (; i < len; i++) {
+            char c = value.charAt(i);
+
+            if (isV0Separator(c))
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the byte is a separator as defined by V1 of the cookie
+     * spec, RFC2109.
+     * @throws IllegalArgumentException if a control character was supplied as
+     *         input
+     */
+    private static boolean isHttpSeparator(final char c) {
+        if (c < 0x20 || c >= 0x7f) {
+            if (c != 0x09) {
+                throw UndertowMessages.MESSAGES.invalidControlCharacter(Integer.toString(c));
+            }
+        }
+
+        return HTTP_SEPARATOR_FLAGS[c];
+    }
+
+    private static boolean isHttpToken(String value) {
+        if( value==null) return false;
+
+        int i = 0;
+        int len = value.length();
+
+        if (alreadyQuoted(value)) {
+            i++;
+            len--;
+        }
+
+        for (; i < len; i++) {
+            char c = value.charAt(i);
+
+            if (isHttpSeparator(c))
+                return true;
+        }
+        return false;
+    }
+
+    private static boolean alreadyQuoted(String value) {
+        if (value==null || value.length() < 2) return false;
+        return (value.charAt(0)=='\"' && value.charAt(value.length()-1)=='\"');
+    }
+
+    /**
+     * Quotes values if required.
+     * @param buf
+     * @param value
+     */
+    public static void maybeQuote(StringBuilder buf, String value) {
+        if (value==null || value.length()==0) {
+            buf.append("\"\"");
+        } else if (alreadyQuoted(value)) {
+            buf.append('"');
+            buf.append(escapeDoubleQuotes(value,1,value.length()-1));
+            buf.append('"');
+        } else if ((isHttpToken(value) && !ALLOW_HTTP_SEPARATORS_IN_V0) ||
+                (isV0Token(value) && ALLOW_HTTP_SEPARATORS_IN_V0)) {
+            buf.append('"');
+            buf.append(escapeDoubleQuotes(value,0,value.length()));
+            buf.append('"');
+        } else {
+            buf.append(value);
+        }
+    }
+
+    /**
+     * Escapes any double quotes in the given string.
+     *
+     * @param s the input string
+     * @param beginIndex start index inclusive
+     * @param endIndex exclusive
+     * @return The (possibly) escaped string
+     */
+    private static String escapeDoubleQuotes(String s, int beginIndex, int endIndex) {
+
+        if (s == null || s.length() == 0 || s.indexOf('"') == -1) {
+            return s;
+        }
+
+        StringBuilder b = new StringBuilder();
+        for (int i = beginIndex; i < endIndex; i++) {
+            char c = s.charAt(i);
+            if (c == '\\' ) {
+                b.append(c);
+                //ignore the character after an escape, just append it
+                if (++i>=endIndex) throw UndertowMessages.MESSAGES.invalidEscapeCharacter();
+                b.append(s.charAt(i));
+            } else if (c == '"')
+                b.append('\\').append('"');
+            else
+                b.append(c);
+        }
+
+        return b.toString();
+    }
+
+    public static int adjustedCookieVersion(Cookie cookie) {
+
+        /*
+         * The spec allows some latitude on when to send the version attribute
+         * with a Set-Cookie header. To be nice to clients, we'll make sure the
+         * version attribute is first. That means checking the various things
+         * that can cause us to switch to a v1 cookie first.
+         *_
+         * Note that by checking for tokens we will also throw an exception if a
+         * control character is encountered.
+         */
+
+        int version = cookie.getVersion();
+
+        String value = cookie.getValue();
+        String path = cookie.getPath();
+        String domain = cookie.getDomain();
+        String comment = cookie.getComment();
+
+        // If it is v0, check if we need to switch
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(value) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(value))) {
+            // HTTP token in value - need to use v1
+            version = 1;
+        }
+
+        if (version == 0 && comment != null) {
+            // Using a comment makes it a v1 cookie
+            version = 1;
+        }
+
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(path) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(path))) {
+            // HTTP token in path - need to use v1
+            version = 1;
+        }
+
+        if (version == 0 &&
+                (!ALLOW_HTTP_SEPARATORS_IN_V0 && isHttpToken(domain) ||
+                        ALLOW_HTTP_SEPARATORS_IN_V0 && isV0Token(domain))) {
+            // HTTP token in domain - need to use v1
+            version = 1;
+        }
+
+        return version;
+    }
+
+    // ------------------------------------------------------------- Constructor
+    private LegacyCookieSupport() {
+        // Utility class. Don't allow instances to be created.
+    }
+}

--- a/core/src/main/java/io/undertow/util/Rfc6265CookieSupport.java
+++ b/core/src/main/java/io/undertow/util/Rfc6265CookieSupport.java
@@ -1,0 +1,99 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.util;
+
+import io.undertow.UndertowMessages;
+import java.util.BitSet;
+
+/**
+ * Class that contains utility methods for dealing with RFC6265 Cookies.
+ *
+ */
+public final class Rfc6265CookieSupport {
+
+    private static final BitSet domainValid = new BitSet(128);
+
+    static {
+        for (char c = '0'; c <= '9'; c++) {
+            domainValid.set(c);
+        }
+        for (char c = 'a'; c <= 'z'; c++) {
+            domainValid.set(c);
+        }
+        for (char c = 'A'; c <= 'Z'; c++) {
+            domainValid.set(c);
+        }
+        domainValid.set('.');
+        domainValid.set('-');
+    }
+
+    public static void validateCookieValue(String value) {
+        int start = 0;
+        int end = value.length();
+
+        if (end > 1 && value.charAt(0) == '"' && value.charAt(end - 1) == '"') {
+            start = 1;
+            end--;
+        }
+
+        char[] chars = value.toCharArray();
+        for (int i = start; i < end; i++) {
+            char c = chars[i];
+            if (c < 0x21 || c == 0x22 || c == 0x2c || c == 0x3b || c == 0x5c || c == 0x7f) {
+                throw UndertowMessages.MESSAGES.invalidCookieValue(Integer.toString(c));
+            }
+        }
+    }
+
+    public static void validateDomain(String domain) {
+        int i = 0;
+        int prev = -1;
+        int cur = -1;
+        char[] chars = domain.toCharArray();
+        while (i < chars.length) {
+            prev = cur;
+            cur = chars[i];
+            if (!domainValid.get(cur)) {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            // labels must start with a letter or number
+            if ((prev == '.' || prev == -1) && (cur == '.' || cur == '-')) {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            // labels must end with a letter or number
+            if (prev == '-' && cur == '.') {
+                throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+            }
+            i++;
+        }
+        // domain must end with a label
+        if (cur == '.' || cur == '-') {
+            throw UndertowMessages.MESSAGES.invalidCookieDomain(domain);
+        }
+    }
+
+    public static void validatePath(String path) {
+        char[] chars = path.toCharArray();
+
+        for (int i = 0; i < chars.length; i++) {
+            char ch = chars[i];
+            if (ch < 0x20 || ch > 0x7E || ch == ';') {
+                throw UndertowMessages.MESSAGES.invalidCookiePath(path);
+            }
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -242,4 +242,62 @@ public class CookiesTestCase {
         Assert.assertEquals(1, cookie.getVersion());
         Assert.assertEquals("/", cookie.getPath());
     }
+
+    // RFC6265 allows US-ASCII characters excluding CTLs, whitespace,
+    // double quote, comma, semicolon and backslash as cookie value.
+    // This does not change even if value is quoted.
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue() {
+        // whitespace is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_ E_COYOTE; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue1() {
+        // whitespace is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_ E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue2() {
+        // double quote si not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_\\\"E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue3() {
+        // comma is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_,E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue4() {
+        // semicolon is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_;E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInValue5() {
+        /// backslash is not allowed
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=\"WILE_\\E_COYOTE\"; path=/example; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+    }
+
+    // RFC6265 allows any CHAR except CTLs or ";" as cookie path
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInPath() {
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_E_COYOTE; path=\"/ex;ample\"; domain=example.com");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        Rfc6265CookieSupport.validatePath(cookie.getPath());
+        Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidRfc6265CookieInDomain() {
+        Cookie cookie = Cookies.parseSetCookieHeader("CUSTOMER=WILE_E_COYOTE; path=/example; domain=\"ex;ample.com\"");
+        Rfc6265CookieSupport.validateCookieValue(cookie.getValue());
+        Rfc6265CookieSupport.validatePath(cookie.getPath());
+        Rfc6265CookieSupport.validateDomain(cookie.getDomain());
+    }
+
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletCachingTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletCachingTestCase.java
@@ -86,7 +86,7 @@ public class DefaultServletCachingTestCase {
                 .setClassLoader(ServletPathMappingTestCase.class.getClassLoader())
                 .setContextPath("/servletContext")
                 .setDeploymentName("servletContext.war")
-                .setResourceManager(new CachingResourceManager(100, 10000, dataCache, new PathResourceManager(tmpDir, 10485760), METADATA_MAX_AGE));
+                .setResourceManager(new CachingResourceManager(100, 10000, dataCache, new PathResourceManager(tmpDir, 10485760, false, false, false), METADATA_MAX_AGE));
 
         builder.addServlet(new ServletInfo("DefaultTestServlet", PathTestServlet.class)
                 .addMapping("/path/default"))


### PR DESCRIPTION
Please backport the master's commit 04ced07 to 1.3.x branch. 

In addition to the commit, I would like to add a new system property `io.undertow.cookie.DEFAULT_ENABLE_RFC6265_COOKIE_VALIDATION` for enabling RFC6265 cookie validation. 

I understand that Undertow does not go in for config via system properties but I think the feature is not albe to be enabled in EAP 7.0.z without this. (A new configurable parameter inside subsystem requires the management model change which does not happen during EAP 7.0.z release.)

