### PR TITLE
UNDERTOW-1139 Not-accepted websocket extension will NPE connection

### DIFF
--- a/core/src/main/java/io/undertow/websockets/core/protocol/Handshake.java
+++ b/core/src/main/java/io/undertow/websockets/core/protocol/Handshake.java
@@ -199,7 +199,7 @@ public abstract class Handshake {
         for (WebSocketExtension ext : extensionList) {
             for (ExtensionHandshake extHandshake : availableExtensions) {
                 WebSocketExtension negotiated = extHandshake.accept(ext);
-                if (ext != null && !extHandshake.isIncompatible(configured)) {
+                if (negotiated != null && !extHandshake.isIncompatible(configured)) {
                     selected.add(negotiated);
                     configured.add(extHandshake);
                 }


### PR DESCRIPTION
If a websocket ExtensionHandshake is available but fails negotiation against the client-supplied extensions, the websocket connection will die with a null pointer exception.

The problem is that the Handshake class does not check the result of `ExtensionHandshake.accept(WebSocketExtension ext)` for null (which means the extension should not be used) before adding this extension to the list of selected and configured extensions on the connection. The null blows up later.

This commit checks whether the available extension was accepted by checking for a null return value from the extension's `accept` method. It stops checking for `ext != null` because this is unnecessary.