### PR TITLE
[UNDERTOW-1144] URL session tracking - sessionid is appended if there is old sessionid in the URL

### DIFF
--- a/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
+++ b/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
@@ -103,7 +103,7 @@ public class PathParameterSessionConfig implements SessionConfig {
 
         StringBuilder sb = new StringBuilder(path);
         if (sb.length() > 0) { // jsessionid can't be first.
-            if(fragmentIndex > 0) {
+            if(fragmentIndex > 0 && !fragment.toLowerCase(Locale.ENGLISH).contains(name)) {
                 sb.append(fragment);
                 sb.append("&");
             } else {


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/UNDERTOW-1144