### PR TITLE
[UNDERTOW-1149] Move CachedAuthenticatedSessionMechanism before than NegotiationMechanism to avoid kerberos negotiation on each request in IE

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -321,6 +321,9 @@ public class DeploymentManagerImpl implements DeploymentManager {
         }
         List<AuthenticationMechanism> authenticationMechanisms = new LinkedList<>();
 
+        if(deploymentInfo.isUseCachedAuthenticationMechanism()) {
+            authenticationMechanisms.add(new CachedAuthenticatedSessionMechanism(identityManager));
+        }
         String mechName = null;
         if (loginConfig != null || deploymentInfo.getJaspiAuthenticationMechanism() != null) {
 
@@ -360,9 +363,6 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
                 authenticationMechanisms.add(factory.create(name, parser, properties));
             }
-        }
-        if(deploymentInfo.isUseCachedAuthenticationMechanism()) {
-            authenticationMechanisms.add(new CachedAuthenticatedSessionMechanism(identityManager));
         }
         deployment.setAuthenticationMechanisms(authenticationMechanisms);
         //if the JASPI auth mechanism is set then it takes over


### PR DESCRIPTION
IE (at least IE8, IE9 and IE10) sends the negotiation token in every request for kerberos authentication. This is only reproducible in undertow-1.3, because in undertow-1.4 CachedAuthenticatedSessionMechanism is being called before than NegotiationMechanism. This patch fixes the order of those mechanisms in undertow-1.3 as they are in undertow-1.4. 

Issue: https://issues.jboss.org/browse/UNDERTOW-1149
EAP 7.0.x Issue: https://issues.jboss.org/browse/JBEAP-12407
Upstream Issue: Upstream not required