### PR TITLE
FIX: Only send path (part after hostname) to upstream for HTTP proxy requests

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
@@ -380,8 +380,10 @@ public final class ProxyHandler implements HttpHandler {
             if(exchange.isHostIncludedInRequestURI()) {
                 int uriPart = targetURI.indexOf("//");
                 if(uriPart != -1) {
-                    uriPart = targetURI.indexOf("/", uriPart);
-                    targetURI = targetURI.substring(uriPart);
+                    uriPart = targetURI.indexOf("/", uriPart + 2);
+                    if(uriPart != -1) {
+                        targetURI = targetURI.substring(uriPart);
+                    }
                 }
             }
 


### PR DESCRIPTION
When using `ProxyHandler` to build a forward proxy, the request path forwarded to the upstream is incorrect. It does not correctly strip-out the `scheme://hostname` prefix. Instead, it only strips-out the `scheme:` prefix.

For example, the following request to the Undertow server:
```
GET http://github.com/undertow-io HTTP/1.1
...
```

Incorrectly produces the following request to the upstream:
```
GET //github.com/undertow-io HTTP/1.1
...
```

The fix in the PR corrects this to:
```
GET /undertow-io HTTP/1.1
...
```