### PR TITLE
[master branch] UNDERTOW-1016 Fix potential NPE while dealing with unresolved InetSocketAddress

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPConfig.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPConfig.java
@@ -43,11 +43,11 @@ public class MCMPConfig {
 
     public MCMPConfig(Builder builder) {
         this.managementSocketAddress = new InetSocketAddress(builder.managementHost, builder.managementPort);
-        if (managementSocketAddress.getAddress().isAnyLocalAddress()) {
-            throw UndertowLogger.PROXY_REQUEST_LOGGER.cannotUseWildcardAddressAsModClusterManagementHost(builder.managementHost);
-        }
         if (managementSocketAddress.isUnresolved()) {
             throw UndertowLogger.PROXY_REQUEST_LOGGER.unableToResolveModClusterManagementHost(builder.managementHost);
+        }
+        if (managementSocketAddress.getAddress().isAnyLocalAddress()) {
+            throw UndertowLogger.PROXY_REQUEST_LOGGER.cannotUseWildcardAddressAsModClusterManagementHost(builder.managementHost);
         }
         if (builder.advertiseBuilder != null) {
             this.advertiseConfig = new AdvertiseConfig(builder.advertiseBuilder, this);


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/UNDERTOW-1016.

The commit just reorders the if blocks which check whether an address is unresolved and whether it is a "any" local address, such that it first checks whether the address is unresolved. This prevents the NPE while checking `isAnyLocalAddress()` since the `managementSocketAddress.getAddress()`, as per its API contract can return null for unresolved address.
