### PR TITLE
HttpClientConnection catches failures more broadly

### DIFF
--- a/core/src/main/java/io/undertow/util/ConnectionUtils.java
+++ b/core/src/main/java/io/undertow/util/ConnectionUtils.java
@@ -74,7 +74,7 @@ public class ConnectionUtils {
                 doDrain(connection, additional);
             }
 
-        } catch (Exception e) {
+        } catch (Throwable e) {
             if (e instanceof IOException) {
                 UndertowLogger.REQUEST_IO_LOGGER.ioException((IOException) e);
             } else {
@@ -130,7 +130,7 @@ public class ConnectionUtils {
                 IoUtils.safeClose(connection);
                 IoUtils.safeClose(additional);
             }
-        } catch (Exception e) {
+        } catch (Throwable e) {
             if (e instanceof IOException) {
                 UndertowLogger.REQUEST_IO_LOGGER.ioException((IOException) e);
             } else {


### PR DESCRIPTION
In some (likely failure) cases I've noticed the undertow client
fails to execute any ClientCallback methods.

I've noticed NPEs in the the logs from SslConduit.doUnwrap, so
it's possible this is caused by UNDERTOW-1156.