### PR TITLE
Attempt to recover from Errors and RuntimeExceptions

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -117,7 +117,7 @@ public interface UndertowLogger extends BasicLogger {
 
     @LogMessage(level = DEBUG)
     @Message(id = 5014, value = "Failed to parse request")
-    void failedToParseRequest(@Cause Exception e);
+    void failedToParseRequest(@Cause Throwable e);
 
     @LogMessage(level = ERROR)
     @Message(id = 5015, value = "Error rotating access log")
@@ -412,4 +412,8 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 5089, value = "Method parameter '%s' cannot be null")
     IllegalArgumentException nullParameter(String name);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 5090, value = "Unexpected failure")
+    void handleUnexpectedFailure(@Cause Throwable t);
 }

--- a/core/src/main/java/io/undertow/client/ALPNClientSelector.java
+++ b/core/src/main/java/io/undertow/client/ALPNClientSelector.java
@@ -101,7 +101,8 @@ public class ALPNClientSelector {
                                 fallback.handleEvent(sslConnection);
                                 return;
                             }
-                        } catch (IOException e) {
+                        } catch (Throwable t) {
+                            IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
                             failedListener.failed(e);
                         }
                     }

--- a/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
@@ -271,8 +271,8 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
                 if (!sinkChannel.flush()) {
                     handleFailedFlush(sinkChannel);
                 }
-            } catch (IOException e) {
-                handleError(e);
+            } catch (Throwable t) {
+                handleError((t instanceof IOException) ? (IOException) t : new IOException(t));
             }
         }
     }
@@ -358,7 +358,7 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
                     Channels.drain(result, Long.MAX_VALUE);
                 }
 
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 UndertowLogger.CLIENT_LOGGER.exceptionProcessingRequest(e);
                 safeClose(connection);
                 if(currentRequest != null) {

--- a/core/src/main/java/io/undertow/client/http/HttpClientProvider.java
+++ b/core/src/main/java/io/undertow/client/http/HttpClientProvider.java
@@ -149,8 +149,8 @@ public class HttpClientProvider implements ClientProvider {
             if(connection instanceof SslConnection) {
                 try {
                     ((SslConnection) connection).startHandshake();
-                } catch (IOException e) {
-                    listener.failed(e);
+                } catch (Throwable t) {
+                    listener.failed((t instanceof IOException) ? (IOException) t : new IOException(t));
                 }
             }
             listener.completed(new HttpClientConnection(connection, options, bufferPool));

--- a/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
+++ b/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
@@ -530,7 +530,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                 return next.write(src) + alreadyWritten;
             }
             return alreadyWritten;
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             this.state |= FLAG_SHUTDOWN;
             if(pooledBuffer != null) {
                 pooledBuffer.close();
@@ -566,7 +566,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                 }
             }
             return length == 1 ? next.write(srcs[offset]) : next.write(srcs, offset, length);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             this.state |= FLAG_SHUTDOWN;
             if(pooledBuffer != null) {
                 pooledBuffer.close();
@@ -607,7 +607,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                 }
             }
             return next.transferFrom(src, position, count);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             this.state |= FLAG_SHUTDOWN;
             if(pooledBuffer != null) {
                 pooledBuffer.close();
@@ -639,7 +639,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                 }
             }
             return next.transferFrom(source, count, throughBuffer);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             this.state |= FLAG_SHUTDOWN;
             if(pooledBuffer != null) {
                 pooledBuffer.close();
@@ -670,7 +670,7 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
             }
             log.trace("Delegating flush");
             return next.flush();
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             this.state |= FLAG_SHUTDOWN;
             if(pooledBuffer != null) {
                 pooledBuffer.close();

--- a/core/src/main/java/io/undertow/client/http2/Http2ClientConnection.java
+++ b/core/src/main/java/io/undertow/client/http2/Http2ClientConnection.java
@@ -196,7 +196,8 @@ public class Http2ClientConnection implements ClientConnection {
         Http2HeadersStreamSinkChannel sinkChannel;
         try {
             sinkChannel = http2Channel.createStream(request.getRequestHeaders());
-        } catch (IOException e) {
+        } catch (Throwable t) {
+            IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
             clientCallback.failed(e);
             return;
         }
@@ -227,14 +228,14 @@ public class Http2ClientConnection implements ClientConnection {
                     }));
                     sinkChannel.resumeWrites();
                 }
-            } catch (IOException e) {
+            } catch (Throwable e) {
                 handleError(e);
             }
         }
     }
 
-    private void handleError(IOException e) {
-
+    private void handleError(Throwable t) {
+        IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
         UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
         IoUtils.safeClose(Http2ClientConnection.this);
         for (Map.Entry<Integer, Http2ClientExchange> entry : currentExchanges.entrySet()) {
@@ -448,13 +449,14 @@ public class Http2ClientConnection implements ClientConnection {
                     Channels.drain(result, Long.MAX_VALUE);
                 }
 
-            } catch (IOException e) {
+            } catch (Throwable t) {
+                IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
                 UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
                 IoUtils.safeClose(Http2ClientConnection.this);
                 for (Map.Entry<Integer, Http2ClientExchange> entry : currentExchanges.entrySet()) {
                     try {
                         entry.getValue().failed(e);
-                    } catch (Exception ex) {
+                    } catch (Throwable ex) {
                         UndertowLogger.REQUEST_IO_LOGGER.ioException(new IOException(ex));
                     }
                 }

--- a/core/src/main/java/io/undertow/client/http2/Http2PriorKnowledgeClientProvider.java
+++ b/core/src/main/java/io/undertow/client/http2/Http2PriorKnowledgeClientProvider.java
@@ -145,7 +145,8 @@ public class Http2PriorKnowledgeClientProvider implements ClientProvider {
                                 return;
                             }
                             listener.completed(new Http2ClientConnection(new Http2Channel(connection, null, bufferPool, null, true, false, options), false, defaultHost, clientStatistics, false));
-                        } catch (IOException e) {
+                        } catch (Throwable t) {
+                            IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
                             listener.failed(e);
                         }
                     }
@@ -153,7 +154,8 @@ public class Http2PriorKnowledgeClientProvider implements ClientProvider {
                 return;
             }
             listener.completed(new Http2ClientConnection(new Http2Channel(connection, null, bufferPool, null, true, false, options), false, defaultHost, clientStatistics, false));
-        } catch (IOException e) {
+        } catch (Throwable t) {
+            IOException e = t instanceof IOException ? (IOException) t : new IOException(t);
             listener.failed(e);
         }
     }

--- a/core/src/main/java/io/undertow/conduits/AbstractFixedLengthStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/AbstractFixedLengthStreamSinkConduit.java
@@ -104,7 +104,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
         int res = 0;
         try {
             return res = next.write(src);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         } finally {
@@ -146,7 +146,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
         long res = 0L;
         try {
             return res = next.write(srcs, offset, length);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         } finally {
@@ -163,7 +163,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
     public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
         try {
             return Conduits.writeFinalBasic(this, srcs, offset, length);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         }
@@ -173,7 +173,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
     public int writeFinal(ByteBuffer src) throws IOException {
         try {
             return Conduits.writeFinalBasic(this, src);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         }
@@ -191,7 +191,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
         long res = 0L;
         try {
             return res = next.transferFrom(src, position, min(count, (val & MASK_COUNT)));
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         } finally {
@@ -211,7 +211,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
         long res = 0L;
         try {
             return res = next.transferFrom(source, min(count, (val & MASK_COUNT)), throughBuffer);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         } finally {
@@ -227,7 +227,7 @@ public abstract class AbstractFixedLengthStreamSinkConduit extends AbstractStrea
         boolean flushed = false;
         try {
             return flushed = next.flush();
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             broken = true;
             throw e;
         } finally {

--- a/core/src/main/java/io/undertow/conduits/AbstractFramedStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/AbstractFramedStreamSinkConduit.java
@@ -161,13 +161,14 @@ public class AbstractFramedStreamSinkConduit extends AbstractStreamSinkConduit<S
             }
             return toAllocate;
 
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
+            IOException ioe = e instanceof IOException ? (IOException) e : new IOException(e);
             //on exception we fail every item in the frame queue
             try {
                 for (Frame frame : frameQueue) {
                     FrameCallBack cb = frame.callback;
                     if (cb != null) {
-                        cb.failed(e);
+                        cb.failed(ioe);
                     }
                 }
                 frameQueue.clear();

--- a/core/src/main/java/io/undertow/conduits/ChunkedStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/ChunkedStreamSourceConduit.java
@@ -19,6 +19,8 @@
 package io.undertow.conduits;
 
 import io.undertow.UndertowMessages;
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.connector.PooledByteBuffer;
 import io.undertow.server.Connectors;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.protocol.http.HttpAttachments;
@@ -28,8 +30,6 @@ import io.undertow.util.AttachmentKey;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.PooledAdaptor;
 import org.xnio.IoUtils;
-import io.undertow.connector.ByteBufferPool;
-import io.undertow.connector.PooledByteBuffer;
 import org.xnio.channels.StreamSinkChannel;
 import org.xnio.conduits.AbstractStreamSourceConduit;
 import org.xnio.conduits.ConduitReadableByteChannel;
@@ -107,7 +107,7 @@ public class ChunkedStreamSourceConduit extends AbstractStreamSourceConduit<Stre
     public long transferTo(final long position, final long count, final FileChannel target) throws IOException {
         try {
             return target.transferFrom(new ConduitReadableByteChannel(this), position, count);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(closeable);
             throw e;
         }
@@ -140,7 +140,7 @@ public class ChunkedStreamSourceConduit extends AbstractStreamSourceConduit<Stre
     public long transferTo(final long count, final ByteBuffer throughBuffer, final StreamSinkChannel target) throws IOException {
         try {
             return IoUtils.transfer(new ConduitReadableByteChannel(this), count, throughBuffer, target);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(closeable);
             throw e;
         }
@@ -281,7 +281,7 @@ public class ChunkedStreamSourceConduit extends AbstractStreamSourceConduit<Stre
                     pooled.close();
                 }
             }
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(closeable);
             throw e;
         } finally {

--- a/core/src/main/java/io/undertow/conduits/DeflatingStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/DeflatingStreamSinkConduit.java
@@ -136,7 +136,7 @@ public class DeflatingStreamSinkConduit implements StreamSinkConduit {
             Connectors.updateResponseBytesSent(exchange, 0 - data.length);
             deflateData(false);
             return data.length;
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             freeBuffer();
             throw e;
         }
@@ -163,7 +163,7 @@ public class DeflatingStreamSinkConduit implements StreamSinkConduit {
                 }
             }
             return total;
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             freeBuffer();
             throw e;
         }
@@ -400,13 +400,13 @@ public class DeflatingStreamSinkConduit implements StreamSinkConduit {
                     if (anyAreSet(state, WRITES_RESUMED) && !anyAreSet(state ,NEXT_SHUTDOWN)) {
                         try {
                             next.resumeWrites();
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             UndertowLogger.REQUEST_LOGGER.debug("Failed to resume", e);
                         }
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException | Error e) {
             freeBuffer();
             throw e;
         }

--- a/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
@@ -123,7 +123,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
         long res = 0L;
         try {
             return res = next.transferTo(position, min(count, val & MASK_COUNT), target);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         } finally {
@@ -146,7 +146,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
         long res = 0L;
         try {
             return res = next.transferTo(min(count, val & MASK_COUNT), throughBuffer, target);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         } finally {
@@ -212,7 +212,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
             }
             // the total buffer space is less than the remaining count.
             return res = next.read(dsts, offset, length);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         } finally {
@@ -248,7 +248,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
             } else {
                 return res = next.read(dst);
             }
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         }  finally {
@@ -292,7 +292,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
         }
         try {
             next.awaitReadable(time, timeUnit);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         }

--- a/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
@@ -199,7 +199,7 @@ public class InflatingStreamSourceConduit extends AbstractStreamSourceConduit<St
     public long transferTo(final long position, final long count, final FileChannel target) throws IOException {
         try {
             return target.transferFrom(new ConduitReadableByteChannel(this), position, count);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         }
@@ -209,7 +209,7 @@ public class InflatingStreamSourceConduit extends AbstractStreamSourceConduit<St
     public long transferTo(final long count, final ByteBuffer throughBuffer, final StreamSinkChannel target) throws IOException {
         try {
             return IoUtils.transfer(new ConduitReadableByteChannel(this), count, throughBuffer, target);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;
         }

--- a/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
@@ -240,7 +240,7 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
                 headerParser.length = initialOtherSideSettings.remaining();
                 parser.parse(initialOtherSideSettings, headerParser);
                 updateSettings(parser.getSettings());
-            } catch (IOException e) {
+            } catch (Throwable e) {
                 IoUtils.safeClose(connectedStreamChannel);
                 //should never happen
                 throw new RuntimeException(e);
@@ -303,6 +303,8 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
             flushChannel(stream);
         } catch (IOException e) {
             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+        } catch (Throwable t) {
+            UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
         }
     }
 
@@ -745,6 +747,8 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
             }
         } catch (IOException e) {
             exceptionHandler.handleException(ping, e);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(ping, new IOException(t));
         }
     }
 
@@ -776,6 +780,8 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
             }
         } catch (IOException e) {
             exceptionHandler.handleException(goAway, e);
+        } catch (Throwable t) {
+            exceptionHandler.handleException(goAway, new IOException(t));
         }
     }
 

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -1586,7 +1586,7 @@ public final class HttpServerExchange extends AbstractAttachable {
                         if (listener.handleDefaultResponse(this)) {
                             return this;
                         }
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         UndertowLogger.REQUEST_LOGGER.debug("Exception running default response listener", e);
                     }
                 }
@@ -1604,6 +1604,9 @@ public final class HttpServerExchange extends AbstractAttachable {
                 blockingHttpExchange.close();
             } catch (IOException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+                IoUtils.safeClose(connection);
+            } catch (Throwable t) {
+                UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
                 IoUtils.safeClose(connection);
             }
         }
@@ -1657,8 +1660,12 @@ public final class HttpServerExchange extends AbstractAttachable {
                     } else if (read == -1) {
                         break;
                     }
-                } catch (IOException e) {
-                    UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+                } catch (Throwable t) {
+                    if (t instanceof IOException) {
+                        UndertowLogger.REQUEST_IO_LOGGER.ioException((IOException) t);
+                    } else {
+                        UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+                    }
                     invokeExchangeCompleteListeners();
                     IoUtils.safeClose(connection);
                     return this;
@@ -1720,8 +1727,12 @@ public final class HttpServerExchange extends AbstractAttachable {
                     IoUtils.safeClose(connection);
                 }
             }
-        } catch (IOException e) {
-            UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+        } catch (Throwable t) {
+            if (t instanceof IOException) {
+                UndertowLogger.REQUEST_IO_LOGGER.ioException((IOException) t);
+            } else {
+                UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+            }
             invokeExchangeCompleteListeners();
 
             IoUtils.safeClose(connection);

--- a/core/src/main/java/io/undertow/server/handlers/RequestBufferingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/RequestBufferingHandler.java
@@ -112,8 +112,12 @@ public class RequestBufferingHandler implements HttpHandler {
                                         buffer = exchange.getConnection().getByteBufferPool().allocate();
                                     }
                                 } while (true);
-                            } catch (IOException e) {
-                                UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+                            } catch (Throwable t) {
+                                if (t instanceof IOException) {
+                                    UndertowLogger.REQUEST_IO_LOGGER.ioException((IOException) t);
+                                } else {
+                                    UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+                                }
                                 for(int i = 0; i < bufferedData.length; ++i) {
                                     IoUtils.safeClose(bufferedData[i]);
                                 }

--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
@@ -166,7 +166,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
                     stream.getReadSetter().set(ChannelListeners.drainListener(Long.MAX_VALUE, null, null));
                     stream.wakeupReads();
                 }
-            } catch (IOException e) {
+            } catch (IOException | RuntimeException | Error e) {
                 IoUtils.safeClose(channel);
             }
         }
@@ -468,7 +468,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
                 }
             }
             return null;
-        } catch (IOException|RuntimeException e) {
+        } catch (IOException|RuntimeException|Error e) {
             //something has code wrong with parsing, close the read side
             //we don't close the write side, as the underlying implementation will most likely want to send an error
             markReadsBroken(e);
@@ -607,7 +607,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
                     if(channel.getSinkChannel().flush()) {
                         channel.getSinkChannel().suspendWrites();
                     }
-                } catch (IOException e) {
+                } catch (Throwable e) {
                     safeClose(channel);
                     markWritesBroken(e);
                 }
@@ -665,7 +665,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
                     }
                 }
 
-            } catch (IOException|RuntimeException e) {
+            } catch (IOException|RuntimeException|Error e) {
                 safeClose(channel);
                 markWritesBroken(e);
             }

--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
@@ -529,7 +529,7 @@ public abstract class AbstractFramedStreamSourceChannel<C extends AbstractFramed
         } finally {
             try {
                 exitRead();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 markStreamBroken();
             }
         }
@@ -558,7 +558,7 @@ public abstract class AbstractFramedStreamSourceChannel<C extends AbstractFramed
                         this.currentDataOriginalSize = frameData.getBuffer().remaining();
                         try {
                             this.data = processFrameData(frameData, frameDataRemaining - currentDataOriginalSize == 0);
-                        } catch (Exception e) {
+                        } catch (Throwable e) {
                             frameData.close();
                             UndertowLogger.REQUEST_IO_LOGGER.ioException(new IOException(e));
                             markStreamBroken();
@@ -660,7 +660,7 @@ public abstract class AbstractFramedStreamSourceChannel<C extends AbstractFramed
             if(data != null) {
                 try {
                     data.close(); //may have been closed by the read thread
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     //ignore
                 }
                 this.data = null;

--- a/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
@@ -366,6 +366,9 @@ public class AlpnOpenListener implements ChannelListener<StreamConnection>, Open
             } catch (IOException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
                 IoUtils.safeClose(channel);
+            } catch (Throwable t) {
+                UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+                IoUtils.safeClose(channel);
             } finally {
                 if (free) {
                     buffer.close();

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
@@ -121,6 +121,9 @@ public final class HttpOpenListener implements ChannelListener<StreamConnection>
         } catch (IOException e) {
             IoUtils.safeClose(channel);
             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+        } catch (Throwable t) {
+            IoUtils.safeClose(channel);
+            UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
         }
         if(statisticsEnabled) {
             channel.getSinkChannel().setConduit(new BytesSentStreamSinkConduit(channel.getSinkChannel().getConduit(), connectorStatistics.sentAccumulator()));

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
@@ -263,7 +263,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             } while (buffer.hasRemaining());
             bufferDone();
             return STATE_BODY;
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             //WFLY-4696, just to be safe
             if (pooledBuffer != null) {
                 pooledBuffer.close();
@@ -610,7 +610,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             } finally {
                 this.state = oldState & ~MASK_STATE | state;
             }
-        } catch(IOException|RuntimeException e) {
+        } catch(IOException|RuntimeException|Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -643,7 +643,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
                 return ret;
             }
             return length == 1 ? next.write(srcs[offset]) : next.write(srcs, offset, length);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         } finally {
@@ -656,7 +656,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             if (pooledFileTransferBuffer != null) {
                 try {
                     return write(pooledFileTransferBuffer.getBuffer());
-                } catch (IOException | RuntimeException e) {
+                } catch (IOException | RuntimeException | Error e) {
                     if (pooledFileTransferBuffer != null) {
                         pooledFileTransferBuffer.close();
                         pooledFileTransferBuffer = null;
@@ -692,7 +692,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             } else {
                 return next.transferFrom(src, position, count);
             }
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -705,7 +705,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             } else {
                 return next.transferFrom(source, count, throughBuffer);
             }
-        } catch (IOException| RuntimeException e) {
+        } catch (IOException| RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -715,7 +715,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
     public int writeFinal(ByteBuffer src) throws IOException {
         try {
             return Conduits.writeFinalBasic(this, src);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -725,7 +725,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
     public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
         try {
             return Conduits.writeFinalBasic(this, srcs, offset, length);
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -746,7 +746,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
                 }
             }
             return next.flush();
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         } finally {
@@ -763,7 +763,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
                 return;
             }
             this.state = oldVal | FLAG_SHUTDOWN;
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         }
@@ -772,7 +772,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
     public void truncateWrites() throws IOException {
         try {
             next.truncateWrites();
-        } catch (IOException | RuntimeException e) {
+        } catch (IOException | RuntimeException | Error e) {
             IoUtils.safeClose(connection);
             throw e;
         } finally {

--- a/core/src/main/java/io/undertow/server/protocol/http/PipeliningBufferingStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/PipeliningBufferingStreamSinkConduit.java
@@ -323,6 +323,9 @@ public class PipeliningBufferingStreamSinkConduit extends AbstractStreamSinkCond
                         } catch (IOException e) {
                             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
                             IoUtils.safeClose(channel);
+                        } catch (Throwable t) {
+                            UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+                            IoUtils.safeClose(channel);
                         }
                     }
                 });
@@ -334,6 +337,9 @@ public class PipeliningBufferingStreamSinkConduit extends AbstractStreamSinkCond
             }
         } catch (IOException e) {
             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
+            IoUtils.safeClose(connection.getChannel());
+        } catch (Throwable t) {
+            UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
             IoUtils.safeClose(connection.getChannel());
         }
     }

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -119,6 +119,9 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         } catch (IOException e) {
             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
             IoUtils.safeClose(channel);
+        } catch (Throwable t) {
+            UndertowLogger.REQUEST_IO_LOGGER.handleUnexpectedFailure(t);
+            IoUtils.safeClose(channel);
         }
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
@@ -309,7 +309,7 @@ public class ServletInputStreamImpl extends ServletInputStream {
                 } else {
                     channel.resumeReads();
                 }
-            } catch (final RuntimeException|IOException e) {
+            } catch (final Throwable e) {
                 request.getServletContext().invokeRunnable(request.getExchange(), new Runnable() {
                     @Override
                     public void run() {


### PR DESCRIPTION
There are several places where errors (OutOfMemoryError, for
instance) cause us not to return pooled buffers, and continue
a memory death spiral.