### PR TITLE
Reduce DirectByteBuffer pressure on the finalizer queue

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -416,4 +416,12 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 5090, value = "Unexpected failure")
     void handleUnexpectedFailure(@Cause Throwable t);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 5091, value = "Failed to initialize DirectByteBufferDeallocator")
+    void directBufferDeallocatorInitializationFailed(@Cause Throwable t);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 5092, value = "Failed to free direct buffer")
+    void directBufferDeallocationFailed(@Cause Throwable t);
 }

--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -183,6 +183,7 @@ public class DefaultByteBufferPool implements ByteBufferPool {
 
     private void freeInternal(ByteBuffer buffer) {
         if (closed) {
+            DirectByteBufferDeallocator.free(buffer);
             return; //GC will take care of it
         }
         ThreadLocalData local = threadLocalCache.get();
@@ -203,6 +204,7 @@ public class DefaultByteBufferPool implements ByteBufferPool {
         do {
             size = currentQueueLength;
             if(size > maximumPoolSize) {
+                DirectByteBufferDeallocator.free(buffer);
                 return;
             }
         } while (!currentQueueLengthUpdater.compareAndSet(this, size, currentQueueLength + 1));

--- a/core/src/main/java/io/undertow/server/DirectByteBufferDeallocator.java
+++ b/core/src/main/java/io/undertow/server/DirectByteBufferDeallocator.java
@@ -1,0 +1,55 @@
+package io.undertow.server;
+
+import io.undertow.UndertowLogger;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+/**
+ * {@link DirectByteBufferDeallocator} Utility class used to free direct buffer memory.
+ */
+public final class DirectByteBufferDeallocator {
+    private static final boolean SUPPORTED;
+    private static final Method cleaner;
+    private static final Method cleanerClean;
+
+    static {
+        Method tmpCleaner = null;
+        Method tmpCleanerClean = null;
+        boolean supported;
+        try {
+            tmpCleaner = Class.forName("java.nio.DirectByteBuffer").getMethod("cleaner");
+            tmpCleaner.setAccessible(true);
+            tmpCleanerClean = Class.forName("sun.misc.Cleaner").getMethod("clean");
+            tmpCleanerClean.setAccessible(true);
+            supported = true;
+        } catch (Throwable t) {
+            UndertowLogger.ROOT_LOGGER.directBufferDeallocatorInitializationFailed(t);
+            supported = false;
+        }
+        SUPPORTED = supported;
+        cleaner = tmpCleaner;
+        cleanerClean = tmpCleanerClean;
+    }
+
+    private DirectByteBufferDeallocator() {
+        // Utility Class
+    }
+
+    /**
+     * Attempts to deallocate the underlying direct memory.
+     * This is a no-op for buffers where {@link ByteBuffer#isDirect()} returns false.
+     *
+     * @param buffer to deallocate
+     */
+    public static void free(ByteBuffer buffer) {
+        if (SUPPORTED && buffer != null && buffer.isDirect()) {
+            try {
+                Object cleaner = DirectByteBufferDeallocator.cleaner.invoke(buffer);
+                cleanerClean.invoke(cleaner);
+            } catch (Throwable t) {
+                UndertowLogger.ROOT_LOGGER.directBufferDeallocationFailed(t);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is generally a problem when the ByteBuffer cache
is configured suboptimally.
It can cause direct memory OMEs that pull down the stack server.