### PR TITLE
[Proposal] Threadlocal cache on IO threads, use global queue by default

### DIFF
--- a/core/src/main/java/io/undertow/Undertow.java
+++ b/core/src/main/java/io/undertow/Undertow.java
@@ -146,7 +146,7 @@ public final class Undertow {
 
             ByteBufferPool buffers = this.byteBufferPool;
             if (buffers == null) {
-                buffers = new DefaultByteBufferPool(directBuffers, bufferSize, -1, 4);
+                buffers = new DefaultByteBufferPool(directBuffers, bufferSize, workerThreads, 12);
             }
 
             listenerInfo = new ArrayList<>();

--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -21,6 +21,7 @@ package io.undertow.server;
 import io.undertow.UndertowMessages;
 import io.undertow.connector.ByteBufferPool;
 import io.undertow.connector.PooledByteBuffer;
+import org.xnio.XnioIoThread;
 
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
@@ -125,7 +126,8 @@ public class DefaultByteBufferPool implements ByteBufferPool {
                 if (buffer != null) {
                     currentQueueLengthUpdater.decrementAndGet(this);
                 }
-            } else {
+            } else if (Thread.currentThread() instanceof XnioIoThread) {
+                // Only use a ThreadLocal cache on IO threads
                 local = new ThreadLocalData();
                 synchronized (threadLocalDataList) {
                     if (closed) {


### PR DESCRIPTION
In servlet applications pooled buffer instances tend to "migrate"
out from IO threads to worker threads, that is to say they are
allocated on an IO thread, but returned from a worker. Using the
default configuration from Undertow.Builder the global pool is
unused, forcing much higher re-allocation than should be necessary.

This commit makes two changes:
1. The ThreadLocal cache is only used on IO threads. This allows
the value to be safely modified to something much higher for faster
IO thread operations without the risk of significant memory bloat
as buffers "migrate" away.
2. The default buffer pool configuration from Undertow.Builder
has been updated to use a ThreadLocal cache size of 12 (the value
used by the default ssl buffer pool) up from 4, and a global
shared pool size matching the worker thread count.