### PR TITLE
UNDERTOW-1147 Fix based on RFC 2231

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -238,6 +238,9 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                 if (disposition.startsWith("form-data")) {
                     currentName = Headers.extractQuotedValueFromHeader(disposition, "name");
                     fileName = Headers.extractQuotedValueFromHeader(disposition, "filename");
+					if(fileName == null){
+						fileName = Headers.extractQuotedValueFromHeaderFollowingIncludedEncoding(disposition, "filename*");
+					}
                     if (fileName != null) {
                         try {
                             if (tempFileLocation != null) {

--- a/core/src/main/java/io/undertow/util/Headers.java
+++ b/core/src/main/java/io/undertow/util/Headers.java
@@ -18,8 +18,10 @@
 
 package io.undertow.util;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.net.URLDecoder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
@@ -379,4 +381,32 @@ public final class Headers {
             return header.substring(start, end);
         }
     }
+
+	/**
+	 * Extracts a quoted value from a header that has a given key. For instance if the header is
+	 * <p>
+	 * content-disposition=form-data; filename*="utf-8''test.txt"
+	 * and the key is filename* then "test.txt" will be returned after extracting character set and language
+	 * (following RFC 2231) and performing URL decoding to the value using the specified encoding
+	 *
+	 * @param header The header
+	 * @param key    The key that identifies the token to extract
+	 * @return The token, or null if it was not found
+	 */
+	public static String extractQuotedValueFromHeaderFollowingIncludedEncoding(final String header, final String key) {
+		String value = extractQuotedValueFromHeader(header, key);
+		if (value == null) {
+			return null;
+		}
+
+		int characterSetDelimiter = value.indexOf('\'');
+		int languageDelimiter = value.lastIndexOf('\'');
+		String characterSet = value.substring(0, characterSetDelimiter);
+		try {
+			String fileNameURLEncoded = value.substring(languageDelimiter + 1);
+			return URLDecoder.decode(fileNameURLEncoded, characterSet);
+		} catch (UnsupportedEncodingException e) {
+			throw new RuntimeException(e);
+		}
+	}
 }


### PR DESCRIPTION
Added a unit test that exposes this issue. Implemented the fix in the MultiPartParseDefinition, so the unit test succeeds if executed on the patched version.

The unit test could be improved by enforcing the http client to include the "filename*" value in the content-disposition header, but I could not make it. However, this header format is valid based on
RFC 2231.