### PR TITLE
UNDERTOW-1195 correct value of FLUSH_PACKET_STRING in the mod_cluster MCMP implementation

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPConstants.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPConstants.java
@@ -29,7 +29,7 @@ interface MCMPConstants {
     String BALANCER_STRING = "Balancer";
     String CONTEXT_STRING = "Context";
     String DOMAIN_STRING = "Domain";
-    String FLUSH_PACKET_STRING = "flushpacket";
+    String FLUSH_PACKET_STRING = "flushpackets";
     String FLUSH_WAIT_STRING = "flushwait";
     String HOST_STRING = "Host";
     String JVMROUTE_STRING = "JVMRoute";


### PR DESCRIPTION
The value of FLUSH_PACKET_STRING in the mod_cluster MCMP implementation
should be set to "flushpackets", not "flushpacket".

The error can be reproduced by configuring the mod_cluster subsystem with property flush-packets set to true.

Apache httpd mod_cluster-1.3.7 accepts the node. Undertow mod_cluster implementation produces an error:
ERROR: UT005043: Error in processing MCMP commands: Type:SYNTAX, Mess: SYNTAX: Invalid field flushpackets in message

This fix should be applied to all active branches.