### PR TITLE
UNDERTOW-1196 match DUMP and INFO output of apache httpd mod_cluster

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
@@ -26,81 +26,79 @@ class MCMPInfoUtil {
     private static final String NEWLINE = "\n";
 
     static void printDump(final Balancer balancer, final StringBuilder builder) {
-        builder.append("balancer: [").append(balancer.getId()).append("],")
+        builder.append("balancer: [").append(balancer.getId()).append("]")
                 .append(" Name: ").append(balancer.getName())
-                .append(" Sticky: ").append(formatBoolean(balancer.isStickySession()))
+                .append(" Sticky: ").append(toStringOneZero(balancer.isStickySession()))
                 .append(" [").append(balancer.getStickySessionCookie()).append("]/[").append(balancer.getStickySessionPath()).append("]")
-                .append(" remove: ").append(formatBoolean(balancer.isStickySessionRemove()))
-                .append("force: ").append(formatBoolean(balancer.isStickySessionForce()))
-                .append("Timeout: ").append(balancer.getWaitWorker())
-                .append("maxAttempts: ").append(balancer.getMaxattempts())
+                .append(" remove: ").append(toStringOneZero(balancer.isStickySessionRemove()))
+                .append(" force: ").append(toStringOneZero(balancer.isStickySessionForce()))
+                .append(" Timeout: ").append(balancer.getWaitWorker())
+                .append(" maxAttempts: ").append(balancer.getMaxattempts())
                 .append(NEWLINE);
     }
 
     static void printInfo(final Node.VHostMapping host, final StringBuilder builder) {
-        builder.append("Vhost: [")
-                // .append(host.getNode().getBalancer().getId()).append(":") // apparently no balancer
-                .append(host.getNode().getId()).append(":")
-                .append(host.getId()).append(":")
-                .append(-1) // id[i] id in the table!? does not exist
-                .append("], Alias: ").append(host.getAliases())
-                .append(NEWLINE);
+        // node id is not unique?
+        for (final String alias : host.getAliases()) {
+            builder.append("Vhost: [")
+                    .append(host.getNode().getId()).append(":")
+                    .append(host.getId()).append(":")
+                    .append(-1) // id[i] id in the table!? does not exist
+                    .append("], Alias: ").append(alias)
+                    .append(NEWLINE);
+        }
     }
 
     static void printDump(final Node.VHostMapping host, final StringBuilder builder) {
-        final int hostID = host.getId();
-        final int nodeID  = host.getNode().getId();
+        // node id is not unique?
         for (final String alias : host.getAliases()) {
-            builder.append("host: ").append(hostID).append(" [")
-                    .append(alias).append("] vhost: ").append(host.getId())
-                    .append(" node: ").append(nodeID)
+            builder.append("host: ").append(host.getId())
+                    .append(" [").append(alias).append("]")
+                    .append(" vhost: ").append(host.getId())
+                    .append(" node: ").append(host.getNode().getId())
                     .append(NEWLINE);
         }
     }
 
     static void printInfo(final Context context, final StringBuilder builder) {
-        builder.append("Context: ").append("[")
+        builder.append("Context: [")
                 .append(context.getNode().getId()).append(":")
                 .append(context.getVhost().getId()).append(":")
-                .append(context.getId()).append("]")
-                .append("],Context: ").append(context.getPath())
-                .append(",Status: ").append(context.getStatus())
+                .append(context.getId())
+                .append("]")
+                .append(", Context: ").append(context.getPath())
+                .append(", Status: ").append(context.getStatus())
                 .append(NEWLINE);
     }
 
     static void printDump(final Context context, final StringBuilder builder) {
-        builder.append("context: ").append("[").append(context.getId()).append("]")
-                .append(" [").append(context.getPath())
-                .append("] vhost: ").append(context.getVhost().getId())
-                .append("node: ").append(context.getNode().getId())
-                .append("status: ").append(context.getStatus())
+        builder.append("context: ").append(context.getId())
+                .append(" [").append(context.getPath()).append("]")
+                .append(" vhost: ").append(context.getVhost().getId())
+                .append(" node: ").append(context.getNode().getId())
+                .append(" status: ").append(formatStatus(context.getStatus()))
                 .append(NEWLINE);
     }
 
     static void printInfo(final Node node, final StringBuilder builder) {
-        builder.append("Node: [")
-                // .append(node.getBalancer().getId()).append(":")
-                .append(node.getId()).append("]")
+        builder.append("Node: ")
+                .append("[").append(node.getId()).append("]")
                 .append(",Name: ").append(node.getJvmRoute())
                 .append(",Balancer: ").append(node.getNodeConfig().getBalancer())
-                .append(",JVMRoute: ").append(node.getJvmRoute())
-                .append(",LBGroup: ").append(node.getNodeConfig().getDomain())
+                .append(",LBGroup: ").append(formatString(node.getNodeConfig().getDomain()))
                 .append(",Host: ").append(node.getNodeConfig().getConnectionURI().getHost())
                 .append(",Port: ").append(node.getNodeConfig().getConnectionURI().getPort())
                 .append(",Type: ").append(node.getNodeConfig().getConnectionURI().getScheme())
-                .append(",flushpackets: ").append(formatBoolean(node.getNodeConfig().isFlushPackets()))
-                .append(",flushwait: ").append(node.getNodeConfig().getFlushwait())
-                .append(",ping: ").append(node.getNodeConfig().getPing())
-                .append(",smax: ").append(node.getNodeConfig().getSmax())
-                .append(",ttl: ").append(node.getNodeConfig().getTtl())
-                .append(",timeout: ").append(node.getNodeConfig().getTimeout())
-                //
+                .append(",Flushpackets: ").append(toStringOnOff(node.getNodeConfig().isFlushPackets()))
+                .append(",Flushwait: ").append(node.getNodeConfig().getFlushwait())
+                .append(",Ping: ").append(node.getNodeConfig().getPing())
+                .append(",Smax: ").append(node.getNodeConfig().getSmax())
+                .append(",Ttl: ").append(node.getNodeConfig().getTtl())
                 .append(",Elected: ").append(node.getElected())
                 .append(",Read: ").append(node.getConnectionPool().getClientStatistics().getRead())
-                .append(",Transferred: ").append(node.getConnectionPool().getClientStatistics().getWritten())
+                .append(",Transfered: ").append(node.getConnectionPool().getClientStatistics().getWritten())
                 .append(",Connected: ").append(node.getConnectionPool().getOpenConnections())
                 .append(",Load: ").append(node.getLoad())
-
                 .append(NEWLINE);
     }
 
@@ -110,11 +108,11 @@ class MCMPInfoUtil {
                 .append(node.getId()).append("]")
                 .append(",Balancer: ").append(node.getNodeConfig().getBalancer())
                 .append(",JVMRoute: ").append(node.getJvmRoute())
-                .append(",LBGroup: ").append(node.getNodeConfig().getDomain())
+                .append(",LBGroup: [").append(formatString(node.getNodeConfig().getDomain())).append("]")
                 .append(",Host: ").append(node.getNodeConfig().getConnectionURI().getHost())
                 .append(",Port: ").append(node.getNodeConfig().getConnectionURI().getPort())
                 .append(",Type: ").append(node.getNodeConfig().getConnectionURI().getScheme())
-                .append(",flushpackets: ").append(formatBoolean(node.getNodeConfig().isFlushPackets()))
+                .append(",flushpackets: ").append(toStringOneZero(node.getNodeConfig().isFlushPackets()))
                 .append(",flushwait: ").append(node.getNodeConfig().getFlushwait())
                 .append(",ping: ").append(node.getNodeConfig().getPing())
                 .append(",smax: ").append(node.getNodeConfig().getSmax())
@@ -123,8 +121,24 @@ class MCMPInfoUtil {
                 .append(NEWLINE);
     }
 
-    static String formatBoolean(boolean value) {
-        return value ? "1" : "0";
+    static String toStringOneZero(boolean bool) {
+        return bool ? "1" : "0";
+    }
+
+    static String toStringOnOff(boolean bool) {
+        return bool ? "On" : "Off";
+    }
+
+    static String formatString(String str) {
+        return str == null ? "" : str;
+    }
+
+    /* matches constants defined in mod_cluster-1.3.7.Final/native/include/context.h */
+    static int formatStatus(Context.Status status) {
+        return status == Context.Status.ENABLED ? 1 :
+               status == Context.Status.DISABLED ? 2 :
+               status == Context.Status.STOPPED ? 3 :
+               -1;
     }
 
 }


### PR DESCRIPTION
The DUMP and INFO output of the undertow mod_cluster implementation contains formatting errors. This fix updates dump and info functions so that the output matches that of apache httpd mod_cluster.