### PR TITLE
UNDERTOW-1182 Update SecureCookieHandler to check secure attribute

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -97,6 +97,7 @@ public final class HttpServerExchange extends AbstractAttachable {
 
     private static final RuntimePermission SET_SECURITY_CONTEXT = new RuntimePermission("io.undertow.SET_SECURITY_CONTEXT");
     private static final String ISO_8859_1 = "ISO-8859-1";
+    private static final String HTTPS = "https";
 
     /**
      * The HTTP reason phrase to send. This is an attachment rather than a field as it is rarely used. If this is not set
@@ -113,6 +114,11 @@ public final class HttpServerExchange extends AbstractAttachable {
      * Attachment key that can be used to hold additional request attributes
      */
     public static final AttachmentKey<Map<String, String>> REQUEST_ATTRIBUTES = AttachmentKey.create(Map.class);
+
+    /**
+     * Attachment key that can be used as a flag of secure attribute
+     */
+    public static final AttachmentKey<Boolean> SECURE_REQUEST = AttachmentKey.create(Boolean.class);
 
     private final ServerConnection connection;
     private final HeaderMap requestHeaders;
@@ -375,6 +381,18 @@ public final class HttpServerExchange extends AbstractAttachable {
      */
     public boolean isHttp11() {
         return protocol.equals(Protocols.HTTP_1_1);
+    }
+
+    public boolean isSecure() {
+        Boolean secure = getAttachment(SECURE_REQUEST);
+        if(secure != null && secure) {
+            return true;
+        }
+        String scheme = getRequestScheme();
+        if (scheme != null && scheme.equalsIgnoreCase(HTTPS)) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/core/src/main/java/io/undertow/server/handlers/SecureCookieHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SecureCookieHandler.java
@@ -45,7 +45,7 @@ public class SecureCookieHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        if(exchange.getRequestScheme().equals("https")) {
+        if(exchange.isSecure()) {
             exchange.addResponseCommitListener(new ResponseCommitListener() {
                 @Override
                 public void beforeCommit(HttpServerExchange exchange) {

--- a/servlet/src/main/java/io/undertow/servlet/handlers/MarkSecureHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/MarkSecureHandler.java
@@ -22,7 +22,6 @@ import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.builder.HandlerBuilder;
-import io.undertow.servlet.spec.HttpServletRequestImpl;
 
 import java.util.Collections;
 import java.util.Map;
@@ -45,7 +44,7 @@ public class MarkSecureHandler implements HttpHandler  {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        exchange.putAttachment(HttpServletRequestImpl.SECURE_REQUEST, Boolean.TRUE);
+        exchange.putAttachment(HttpServerExchange.SECURE_REQUEST, Boolean.TRUE);
         next.handleRequest(exchange);
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -39,7 +39,6 @@ import io.undertow.servlet.handlers.ServletPathMatch;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.servlet.util.EmptyEnumeration;
 import io.undertow.servlet.util.IteratorEnumeration;
-import io.undertow.util.AttachmentKey;
 import io.undertow.util.CanonicalPathUtils;
 import io.undertow.util.DateUtils;
 import io.undertow.util.HeaderMap;
@@ -99,8 +98,6 @@ import javax.servlet.http.PushBuilder;
  */
 public final class HttpServletRequestImpl implements HttpServletRequest {
 
-    private static final String HTTPS = "https";
-
     private final HttpServerExchange exchange;
     private final ServletContextImpl originalServletContext;
     private ServletContextImpl servletContext;
@@ -119,8 +116,6 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
     private Charset characterEncoding;
     private boolean readStarted;
     private SessionConfig.SessionCookieSource sessionCookieSource;
-
-    public static final AttachmentKey<Boolean> SECURE_REQUEST = AttachmentKey.create(Boolean.class);
 
     public HttpServletRequestImpl(final HttpServerExchange exchange, final ServletContextImpl servletContext) {
         this.exchange = exchange;
@@ -924,11 +919,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
 
     @Override
     public boolean isSecure() {
-        Boolean secure = exchange.getAttachment(SECURE_REQUEST);
-        if(secure != null && secure) {
-            return true;
-        }
-        return getScheme().equalsIgnoreCase(HTTPS);
+        return exchange.isSecure();
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/handlers/IsSecureFilter.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/handlers/IsSecureFilter.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.handlers;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Stuart Douglas
+ */
+public class IsSecureFilter implements Filter {
+
+    @Override
+    public void init(final FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain) throws IOException, ServletException {
+
+        ((HttpServletResponse) response).setHeader("issecure", Boolean.toString(request.isSecure()));
+
+        Cookie cookie = new Cookie("foo","bar");
+        ((HttpServletResponse) response).addCookie(cookie);
+
+        chain.doFilter(request,response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/handlers/MarkSecureHandlerTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/handlers/MarkSecureHandlerTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.handlers;
+
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.SecureCookieHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.FilterInfo;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.handlers.MarkSecureHandler;
+import io.undertow.servlet.test.util.MessageServlet;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+/**
+ * @author Stuart Douglas
+ */
+@RunWith(DefaultServer.class)
+public class MarkSecureHandlerTestCase {
+
+    public static final String HELLO_WORLD = "Hello World";
+
+    @Test
+    public void testMarkSecureHandler() throws IOException, GeneralSecurityException, ServletException {
+
+        final PathHandler root = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        ServletInfo s = new ServletInfo("servlet", MessageServlet.class)
+                .addInitParam(MessageServlet.MESSAGE, HELLO_WORLD)
+                .addMapping("/issecure");
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(MarkSecureHandlerTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName("servletContext.war")
+                .addServlet(s);
+
+        builder.addFilter(new FilterInfo("issecure-filter", IsSecureFilter.class));
+        builder.addFilterUrlMapping("issecure-filter", "/*", DispatcherType.REQUEST);
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(new MarkSecureHandler(root));
+
+        TestHttpClient client = new TestHttpClient();
+
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/issecure");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            // When MarkSecureHandler is enabled, req.isSecure() should be true
+            Assert.assertEquals("true", result.getHeaders("issecure")[0].getValue());
+            // When SecureCookieHandler is not enabled, secure cookie is not automatically enabled.
+            Header header = result.getFirstHeader("set-cookie");
+            Assert.assertEquals("foo=bar", header.getValue());
+            final String response = HttpClientUtils.readResponse(result);
+            Assert.assertEquals(HELLO_WORLD, response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testMarkSecureHandlerWithSecureCookieHandler() throws IOException, GeneralSecurityException, ServletException {
+
+        final PathHandler root = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        ServletInfo s = new ServletInfo("servlet", MessageServlet.class)
+                .addInitParam(MessageServlet.MESSAGE, HELLO_WORLD)
+                .addMapping("/issecure");
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(MarkSecureHandlerTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName("servletContext.war")
+                .addServlet(s);
+
+        builder.addFilter(new FilterInfo("issecure-filter", IsSecureFilter.class));
+        builder.addFilterUrlMapping("issecure-filter", "/*", DispatcherType.REQUEST);
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(new MarkSecureHandler(new SecureCookieHandler(root)));
+
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/issecure");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            // When MarkSecureHandler is enabled, req.isSecure() should be true
+            Assert.assertEquals("true", result.getHeaders("issecure")[0].getValue());
+            // When SecureCookieHandler is enabled with MarkSecureHandler, secure cookie is enabled as this channel is treated as secure
+            Header header = result.getFirstHeader("set-cookie");
+            Assert.assertEquals("foo=bar; secure", header.getValue());
+            final String response = HttpClientUtils.readResponse(result);
+            Assert.assertEquals(HELLO_WORLD, response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/undertow-io/undertow/commit/806dac3f591489600c06cfccdd45a205a8c74d37 added the partial feature for the RFE [UNDERTOW-1182](https://issues.jboss.org/browse/UNDERTOW-1182). However, it checks only request scheme but it does not check secure attribute setting on listener in undertow subsytem (which invokes MarkSecureHandler internally). So, the current implementation does not provide same feature to EAP 6.

I would like to propose this complement patch. This PR will changes the followings:

 - Add `HttpServerExchange#isSecure()` method (actually move `isSecure()` method from `HttpServletRequestImpl` to `HttpServerExchange`)
 - Update `SecureCookieHandler` to use the `HttpServerExchange#isSecure()` method to check secure attribute set by `MarkSecureHandler` and request scheme, instead of just checking request scheme.
 - Add a test case which uses `MarkSecureHandler` with `SecureCookieHandler`