### PR TITLE
Add option to enable default websocket deployment info.

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -126,6 +126,7 @@ public class DeploymentInfo implements Cloneable {
     private final Map<String, AuthenticationMechanismFactory> authenticationMechanisms = new HashMap<>();
     private final List<LifecycleInterceptor> lifecycleInterceptors = new ArrayList<>();
     private final List<SessionListener> sessionListeners = new ArrayList<>();
+    private final boolean defaultWebSocketEnabled = false;
 
     /**
      * additional servlet extensions
@@ -1327,6 +1328,14 @@ public class DeploymentInfo implements Cloneable {
     public Map<String, String> getPreCompressedResources() {
         return Collections.unmodifiableMap(preCompressedResources);
     }
+    
+    public DeploymentInfo enableDefaultWebsocket(boolean defaultWebSocketEnabled) {
+        WebSocketDeploymentInfo webSocketDeploymentInfo = new WebSocketDeploymentInfo();
+        addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME, webSocketDeploymentInfo);
+        this.defaultWebSocketEnabled = defaultWebSocketEnabled;
+        return this;
+        
+    }
 
     @Override
     public DeploymentInfo clone() {
@@ -1418,6 +1427,7 @@ public class DeploymentInfo implements Cloneable {
         info.defaultRequestEncoding = defaultRequestEncoding;
         info.defaultResponseEncoding = defaultResponseEncoding;
         info.preCompressedResources.putAll(preCompressedResources);
+        info.enableDefaultWebsocket(defaultWebSocketEnabled);
         return info;
     }
 


### PR DESCRIPTION
This would be helpful if using undertow to serve a vaadin application with atmosphere.

So in the server definition you could say:
```
           DeploymentInfo servletBuilder = deployment()
              .setClassLoader(Main.class.getClassLoader())
              .setContextPath(MYAPP)
              .setDeploymentName("vaadin.war")
              .setResourceManager(new FileResourceManager(new File("src/main/webapp"), 1024))
              .enableDefaultWebsocket(true)
              .addServlets(
                servlet("MyUIServlet", MyUI.MyUIServlet.class)
                  .setAsyncSupported(true)
                  .addMapping("/*"));
```

instead of this adding boilerplate like so:

```
            DeploymentInfo servletBuilder = deployment()
              .setClassLoader(Main.class.getClassLoader())
              .setContextPath(MYAPP)
              .setDeploymentName("vaadin.war")
              .setResourceManager(new FileResourceManager(new File("src/main/webapp"), 1024))
              .addServlets(
                servlet("MyUIServlet", MyUI.MyUIServlet.class)
                  .setAsyncSupported(true)
                  .addMapping("/*"));

            WebSocketDeploymentInfo webSocketDeploymentInfo = new WebSocketDeploymentInfo();
            servletBuilder.addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME, webSocketDeploymentInfo);
```
