### PR TITLE
UNDERTOW-1204 mod_cluster proxy: set default value of cacheConnections (smax) to 1

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
@@ -201,7 +201,7 @@ public class ModCluster {
 
         // Fairly restrictive connection pool defaults
         private int maxConnections = 16;
-        private int cacheConnections = 8;
+        private int cacheConnections = 1;
         private int requestQueueSize = 0;
         private boolean queueNewRequests = false;
 


### PR DESCRIPTION
The default value of cacheConnections (smax) is currently set to 8. This is the number of idle connections that will be kept alive per IO thread. ioThreads is set to the number of available processors with a minimum of 2 (Undertow.java).

These idle connections unnecessarily consume cpu, memory and network resources. This becomes a big issue in large scale environments with over 4100 backend servers (4100 (backend servers) * 8 (conns) * 2 (iothreads) = 65600 idle connections, TCP stack only supports up to 65535 ports).

By setting the default value of cacheConnections (smax) to 1, idle connections timeout when they reach their ttl, not before. There is no performance impact. The default value can still be overriden client-side by setting smax in the mod_cluster configuration.