### PR TITLE
UNDERTOW-1205 only set NodeConfig ttl if ModCluster ttl is greater than 0

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/NodeConfig.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/NodeConfig.java
@@ -254,7 +254,7 @@ public class NodeConfig {
             this.cacheConnections = modCluster.getCacheConnections();
             this.requestQueueSize = modCluster.getRequestQueueSize();
             this.queueNewRequests = modCluster.isQueueNewRequests();
-            this.ttl = modCluster.getTtl();
+            if (modCluster.getTtl() > 0) { this.ttl = modCluster.getTtl(); }
         }
 
         public NodeBuilder setHostname(String hostname) {


### PR DESCRIPTION
In ModCluster.java, ttl is not set and thus defaults to 0.
In NodeConfig.java, NodeBuilder constructor, the ttl value is always set.
This should not happen, the default value of 60000 should be kept.