### PR TITLE
UNDERTOW-1205 move NodeConfig queueNewRequests and ttl defaults to ModCluster

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
@@ -206,7 +206,7 @@ public class ModCluster {
         private boolean queueNewRequests = false;
 
         private int maxRequestTime = -1;
-        private long ttl;
+        private long ttl = TimeUnit.SECONDS.toMillis(60);
         private boolean useAlias = false;
 
         private NodeHealthChecker healthChecker = NodeHealthChecker.NO_CHECK;

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/NodeConfig.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/NodeConfig.java
@@ -243,9 +243,9 @@ public class NodeConfig {
         private int maxConnections;
         private int cacheConnections;
         private int requestQueueSize;
-        private boolean queueNewRequests = false;
+        private boolean queueNewRequests;
 
-        private long ttl = 60000;
+        private long ttl;
         private int timeout = 0;
         private int waitWorker = -1;
 


### PR DESCRIPTION
The NodeConfig defaults for queueNewRequests and ttl are always overridden in the
constructor. It is better to have the defaults specified in ModCluster.

This also solves the issue where the ttl is set to 0 instead of 60000.