### PR TITLE
UNDERTOW-1206 MCMPHandler must convert ttl from seconds to milliseconds

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
@@ -51,6 +51,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static io.undertow.server.handlers.proxy.mod_cluster.MCMPConstants.ALIAS;
 import static io.undertow.server.handlers.proxy.mod_cluster.MCMPConstants.BALANCER;
@@ -277,7 +278,7 @@ class MCMPHandler implements HttpHandler {
             } else if (SMAX.equals(name)) {
                 node.setSmax(Integer.parseInt(value));
             } else if (TTL.equals(name)) {
-                node.setTtl(Integer.parseInt(value));
+                node.setTtl(TimeUnit.SECONDS.toMillis(Long.parseLong(value)));
             } else if (TIMEOUT.equals(name)) {
                 node.setTimeout(Integer.parseInt(value));
             } else if (CONTEXT.equals(name)) {

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
@@ -18,6 +18,8 @@
 
 package io.undertow.server.handlers.proxy.mod_cluster;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author Emanuel Muckenhuber
  */
@@ -93,7 +95,7 @@ class MCMPInfoUtil {
                 .append(",Flushwait: ").append(node.getNodeConfig().getFlushwait())
                 .append(",Ping: ").append(node.getNodeConfig().getPing())
                 .append(",Smax: ").append(node.getNodeConfig().getSmax())
-                .append(",Ttl: ").append(node.getNodeConfig().getTtl())
+                .append(",Ttl: ").append(TimeUnit.MILLISECONDS.toSeconds(node.getNodeConfig().getTtl()))
                 .append(",Elected: ").append(node.getElected())
                 .append(",Read: ").append(node.getConnectionPool().getClientStatistics().getRead())
                 .append(",Transfered: ").append(node.getConnectionPool().getClientStatistics().getWritten())
@@ -116,7 +118,7 @@ class MCMPInfoUtil {
                 .append(",flushwait: ").append(node.getNodeConfig().getFlushwait())
                 .append(",ping: ").append(node.getNodeConfig().getPing())
                 .append(",smax: ").append(node.getNodeConfig().getSmax())
-                .append(",ttl: ").append(node.getNodeConfig().getTtl())
+                .append(",ttl: ").append(TimeUnit.MILLISECONDS.toSeconds(node.getNodeConfig().getTtl()))
                 .append(",timeout: ").append(node.getNodeConfig().getTimeout())
                 .append(NEWLINE);
     }

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPWebManager.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPWebManager.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 /**
  * The mod cluster manager web frontend.
@@ -217,7 +218,7 @@ class MCMPWebManager extends MCMPHandler {
                     if (nodeConfig.isFlushPackets()) {
                         flushpackets = "Auto";
                     }
-                    buf.append(",Flushpackets: " + flushpackets + ",Flushwait: " + nodeConfig.getFlushwait() + ",Ping: " + nodeConfig.getPing() + " ,Smax: " + nodeConfig.getPing() + ",Ttl: " + nodeConfig.getTtl());
+                    buf.append(",Flushpackets: " + flushpackets + ",Flushwait: " + nodeConfig.getFlushwait() + ",Ping: " + nodeConfig.getPing() + " ,Smax: " + nodeConfig.getPing() + ",Ttl: " + TimeUnit.MILLISECONDS.toSeconds(nodeConfig.getTtl()));
                     printProxyStat(buf, node, reduceDisplay);
                 } else {
                     buf.append("<br/>\n");


### PR DESCRIPTION
ModCluster handles ttl in milliseconds. Client sends ttl in seconds, but MCMPHandler does not convert the incoming value to milliseconds. Setting the ttl to 600 - client-side - results in a ttl of 0.6 seconds in undertow. This is not as intended.

To keep DUMP and INFO output similar to that of apache httpd mod_cluster, MCMPInfoUtil should convert ttl from milliseconds to seconds. MCMPWebManager should match that behaviour.