### PR TITLE
UNDERTOW 1219 ProxyConnectionPool closes too many idle connections when they reach their ttl

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyConnectionPool.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyConnectionPool.java
@@ -419,7 +419,7 @@ public class ProxyConnectionPool implements Closeable {
         int idleConnections = data.availableConnections.size();
         for (;;) {
             ConnectionHolder holder;
-            if (idleConnections > 0 && idleConnections >= coreCachedConnections && (holder = data.availableConnections.peek()) != null) {
+            if (idleConnections > 0 && idleConnections > coreCachedConnections && (holder = data.availableConnections.peek()) != null) {
                 if (!holder.clientConnection.isOpen()) {
                     // Already closed connections decrease the available connections
                     idleConnections--;


### PR DESCRIPTION
The number of idle connections should not drop below coreCachedConnections.