### PR TITLE
UNDERTOW-1200 AjpClientConnection should handle a closed connection like HttpClientConnection

### DIFF
--- a/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.undertow.client.ClientStatistics;
+import org.jboss.logging.Logger;
 import org.xnio.ChannelExceptionHandler;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
@@ -81,6 +82,8 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
         }
     };
 
+    private static final Logger log = Logger.getLogger(AjpClientConnection.class);
+
     private final Deque<AjpClientExchange> pendingQueue = new ArrayDeque<>();
     private AjpClientExchange currentRequest;
 
@@ -109,6 +112,8 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
         connection.addCloseTask(new ChannelListener<AjpClientChannel>() {
             @Override
             public void handleEvent(AjpClientChannel channel) {
+                log.debugf("connection to %s closed", getPeerAddress());
+                AjpClientConnection.this.state |= CLOSED;
                 ChannelListeners.invokeChannelListener(AjpClientConnection.this, closeSetter.get());
                 for(ChannelListener<ClientConnection> listener : closeListeners) {
                     listener.handleEvent(AjpClientConnection.this);
@@ -120,6 +125,7 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
                 }
                 if(currentRequest != null) {
                     currentRequest.setFailed(new ClosedChannelException());
+                    currentRequest = null;
                 }
             }
         });
@@ -297,6 +303,7 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
     }
 
     public void close() throws IOException {
+        log.debugf("close called on connection to %s", getPeerAddress());
         if (anyAreSet(state, CLOSED)) {
             return;
         }

--- a/core/src/main/java/io/undertow/protocols/ajp/AjpClientChannel.java
+++ b/core/src/main/java/io/undertow/protocols/ajp/AjpClientChannel.java
@@ -158,16 +158,10 @@ public class AjpClientChannel extends AbstractFramedChannel<AjpClientChannel, Ab
 
     @Override
     protected void handleBrokenSourceChannel(Throwable e) {
-        IoUtils.safeClose(source, sink);
-        UndertowLogger.REQUEST_IO_LOGGER.ioException(new IOException(e));
-        IoUtils.safeClose(this);
     }
 
     @Override
     protected void handleBrokenSinkChannel(Throwable e) {
-        IoUtils.safeClose(source, sink);
-        UndertowLogger.REQUEST_IO_LOGGER.ioException(new IOException(e));
-        IoUtils.safeClose(this);
     }
 
     @Override


### PR DESCRIPTION
Added a few debug log calls similar to those defined in HttpClientConnection.
Set currentRequest to null after it is set to failed, similar to HttpClientConnection.

Emptied AjpClientChannel#handleBrokenSourceChannel, because:
- IoUtils.safeClose(source, sink) is already called in AjpClientChannel#closeSubChannels
- Debug log entry already sent in AbstractFramedChannel#markReadsBroken
- IoUtils.safeClose(this) is already called in AjpClientChannel#lastDataRead

Emptied AjpClientChannel#handleBrokenSinkChannel, because:
- IoUtils.safeClose(source, sink) is already called via AjpClientChannel#closeSubChannels
- Debug log entry already sent in AbstractFramedChannel#markWritesBroken
- IoUtils.safeClose(this) is already called in AjpClientChannel#lastDataRead
