### PR TITLE
Avoid mandatory dependency to java.sql module

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -39,7 +39,6 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.nio.file.Path;
-import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 
@@ -140,7 +139,7 @@ public interface UndertowLogger extends BasicLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 5020, value = "Error writing JDBC log")
-    void errorWritingJDBCLog(@Cause SQLException e);
+    void errorWritingJDBCLog(@Cause Exception e);
 
 //    @LogMessage(level = Logger.Level.ERROR)
 //    @Message(id = 5021, value = "Proxy request to %s timed out")
@@ -335,7 +334,7 @@ public interface UndertowLogger extends BasicLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 5069, value = "Failed to write JDBC access log")
-    void failedToWriteJdbcAccessLog(@Cause SQLException e);
+    void failedToWriteJdbcAccessLog(@Cause Exception e);
 
     @LogMessage(level = ERROR)
     @Message(id = 5070, value = "Failed to write pre-cached file")


### PR DESCRIPTION
Hey, I was experimenting with [using Undertow as a module on Java 9](https://github.com/moditect/moditect#example) (explicit module, not automatic) and creating a modular runtime image with it.

In that course I noticed that there currently is a mandatory dependence to the _java.sql_ module due to a specific log handler and exposure of `SQLException` in a few signatures of `UndertowLogger`. This proposed change allows to make that dependence optional (`requires static java.sql` in terms of the module descriptor), which reduces size of a runtime image with an Undertow Hello World from 29 MB to 25 MB. The price is a slightly less explicit signature of these methods. An alternative would be to create a separate logger interface just for the methods with a `SQLException` parameter.

I thought I'd first propose this change here quickly and see whether you'd be willing to apply it. Happy to file a JIRA issue if you think it's good. Thanks!