### PR TITLE
Proposal to add Handler for Curl format request including body data

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/CurlRequestDumpingConduit.java
+++ b/core/src/main/java/io/undertow/server/handlers/CurlRequestDumpingConduit.java
@@ -1,0 +1,80 @@
+package io.undertow.server.handlers;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.xnio.IoUtils;
+import org.xnio.channels.StreamSinkChannel;
+import org.xnio.conduits.AbstractStreamSourceConduit;
+import org.xnio.conduits.ConduitReadableByteChannel;
+import org.xnio.conduits.StreamSourceConduit;
+
+public class CurlRequestDumpingConduit extends AbstractStreamSourceConduit<StreamSourceConduit>
+{
+
+    private final List<byte[]> data = new CopyOnWriteArrayList<>();
+
+    /**
+     * Construct a new instance.
+     *
+     * @param next the delegate conduit to set
+     */
+    public CurlRequestDumpingConduit(StreamSourceConduit next)
+    {
+        super(next);
+    }
+
+    public long transferTo(final long position, final long count, final FileChannel target) throws IOException
+    {
+        return target.transferFrom(new ConduitReadableByteChannel(this), position, count);
+    }
+
+    public long transferTo(final long count, final ByteBuffer throughBuffer, final StreamSinkChannel target)
+            throws IOException
+    {
+        return IoUtils.transfer(new ConduitReadableByteChannel(this), count, throughBuffer, target);
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException
+    {
+        int pos = dst.position();
+        int res = super.read(dst);
+        if (res > 0)
+        {
+            byte[] d = new byte[res];
+            for(int i = 0; i < res; ++i)
+            {
+                d[i] = dst.get(i + pos);
+            }
+            data.add(d);
+        }
+        return res;
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offs, int len) throws IOException
+    {
+        for(int i = offs; i < len; ++i)
+        {
+            if (dsts[i].hasRemaining())
+            {
+                return read(dsts[i]);
+            }
+        }
+        return 0;
+    }
+
+    public String fullRequestDump()
+    {
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < data.size(); ++i)
+        {
+            sb.append(new String(data.get(i)));
+        }
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/io/undertow/server/handlers/CurlRequestDumpingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/CurlRequestDumpingHandler.java
@@ -1,0 +1,114 @@
+package io.undertow.server.handlers;
+
+import java.util.Map;
+
+import org.xnio.conduits.ConduitStreamSourceChannel;
+import org.xnio.conduits.StreamSourceConduit;
+
+import io.undertow.UndertowLogger;
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.protocol.http.HttpServerConnection;
+import io.undertow.util.ConduitFactory;
+import io.undertow.util.HeaderValues;
+import io.undertow.util.Methods;
+
+/**
+ * Handler that dumps a exchange to a log in curl format.
+ *
+ * @author Venkat Desu
+ */
+public class CurlRequestDumpingHandler implements HttpHandler
+{
+    private final HttpHandler next;
+    private CurlRequestDumpingConduit dumpConduit;
+
+    public RequestDumpInCurlFormatHandler(final HttpHandler next)
+    {
+        this.next = next;
+    }
+
+    public static boolean isPostOrPutMethod(HttpServerExchange exchange)
+    {
+        return (Methods.POST).equals(exchange.getRequestMethod()) || (Methods.PUT).equals(exchange.getRequestMethod());
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception
+    {
+
+        CURL_REQUEST_DUMP:
+        {
+            if (!UndertowLogger.REQUEST_DUMPER_LOGGER.isDebugEnabled() || !isPostOrPutMethod(exchange))
+            {
+                break CURL_REQUEST_DUMP;
+            }
+
+            final StringBuilder sb = new StringBuilder(2000);
+            sb.append("curl '" + exchange.getRequestScheme() + ":/" + exchange.getDestinationAddress()
+                    + exchange.getRequestURI());
+            String queryString = exchange.getQueryString();
+            if (exchange.getQueryString() != null && exchange.getQueryString().length() > 0)
+            {
+                sb.append("?" + queryString + "'");
+            }
+            else
+            {
+                sb.append("'");
+            }
+
+            Map<String, Cookie> cookies = exchange.getRequestCookies();
+            if (cookies != null)
+            {
+                for(Map.Entry<String, Cookie> entry : cookies.entrySet())
+                {
+                    Cookie cookie = entry.getValue();
+                    sb.append(" --cookie '" + cookie.getName() + "=" + cookie.getValue() + "'\n");
+                }
+            }
+            for(HeaderValues header : exchange.getRequestHeaders())
+            {
+                for(String value : header)
+                {
+                    sb.append(" -H '" + header.getHeaderName() + ": " + value + "'");
+                }
+            }
+
+            exchange.addRequestWrapper(new ConduitWrapper<StreamSourceConduit>()
+            {
+                @Override
+                public StreamSourceConduit wrap(final ConduitFactory<StreamSourceConduit> factory,
+                        final HttpServerExchange exchange)
+                {
+                    if (exchange.isRequestChannelAvailable() && !exchange.isResponseStarted())
+                    {
+                        ConduitStreamSourceChannel sourceChannel = ((HttpServerConnection) exchange.getConnection())
+                                .getChannel().getSourceChannel();
+                        dumpConduit = new CurlRequestDumpingConduit(sourceChannel.getConduit());
+                        return dumpConduit;
+                    }
+                    return factory.create();
+                }
+            });
+
+            exchange.addExchangeCompleteListener(new ExchangeCompletionListener()
+            {
+                @Override
+                public void exchangeEvent(final HttpServerExchange exchange, final NextListener nextListener)
+                {
+                    sb.append(" --data-binary '" + new String(dumpConduit.fullRequestDump()) + "'");
+
+                    UndertowLogger.REQUEST_DUMPER_LOGGER.info(" CURL Request Format --> " + sb.toString());
+                    nextListener.proceed();
+                }
+            });
+
+        }// CURL_REQUEST_DUMP ends
+
+        // Perform the exchange
+        next.handleRequest(exchange);
+    }
+
+}


### PR DESCRIPTION
Two enhancements on top of existing RequestDumpHandler

#1) able to handle request body, Proposed one would handle it.
#2) Current one prints in regular format, which cannot be copied and replicate same request in bash/terminal. We try to print in curl acceptable format, so it should be quick copy/paste.

Here is sample Log line:

CURL Request Format --> curl 'http://127.0.0.1:8080/testcontextpath/test' --cookie '_ga=GA1.1.16270314.1505902496' -H 'Accept: application/json' -H 'Accept-Language: en-US,en;q=0.8' -H 'Accept-Encoding: gzip, deflate, br' -H 'Origin: http://127.0.0.1:8080' -H 'User-Agent: Mozilla/5.0' -H 'Connection: keep-alive' -H 'Content-Length: 17' -H 'Content-Type: application/json;charset=UTF-8' -H 'Referer: http://127.0.0.1:8080/testcontextpath/' -H 'Host: 127.0.0.1:8080' --data-binary '{"someDatId":"1"}'