### PR TITLE
ExchangeAttribute may be read directly to a StringBuilder

### DIFF
--- a/core/src/main/java/io/undertow/attribute/BytesSentAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/BytesSentAttribute.java
@@ -40,11 +40,25 @@ public class BytesSentAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final HttpServerExchange exchange) {
-        if (dashIfZero )  {
+        if (dashIfZero)  {
             long bytesSent = exchange.getResponseBytesSent();
             return bytesSent == 0 ? "-" : Long.toString(bytesSent);
         } else {
             return Long.toString(exchange.getResponseBytesSent());
+        }
+    }
+
+    @Override
+    public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+        if (dashIfZero)  {
+            long bytesSent = exchange.getResponseBytesSent();
+            if (bytesSent == 0) {
+                destination.append('-');
+            } else {
+                destination.append(bytesSent);
+            }
+        } else {
+            destination.append(exchange.getResponseBytesSent());
         }
     }
 

--- a/core/src/main/java/io/undertow/attribute/CompositeExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/CompositeExchangeAttribute.java
@@ -38,13 +38,15 @@ public class CompositeExchangeAttribute implements ExchangeAttribute {
     @Override
     public String readAttribute(HttpServerExchange exchange) {
         final StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < attributes.length; ++i) {
-            final String val = attributes[i].readAttribute(exchange);
-            if(val != null) {
-                sb.append(val);
-            }
-        }
+        readAttribute(exchange, sb);
         return sb.toString();
+    }
+
+    @Override
+    public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+        for (int i = 0; i < attributes.length; ++i) {
+            attributes[i].readAttribute(exchange, destination);
+        }
     }
 
     @Override

--- a/core/src/main/java/io/undertow/attribute/ExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/ExchangeAttribute.java
@@ -35,6 +35,13 @@ public interface ExchangeAttribute {
      */
     String readAttribute(final HttpServerExchange exchange);
 
+    default void readAttribute(final HttpServerExchange exchange, final StringBuilder destination) {
+        final String value = readAttribute(exchange);
+        if (value != null) {
+            destination.append(value);
+        }
+    }
+
     /**
      * Sets a new value for the attribute. Not all attributes are writable.
      * @param exchange The exchange

--- a/core/src/main/java/io/undertow/attribute/PathParameterAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/PathParameterAttribute.java
@@ -61,6 +61,26 @@ public class PathParameterAttribute implements ExchangeAttribute {
     }
 
     @Override
+    public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+        Deque<String> res = exchange.getPathParameters().get(parameter);
+        if(res != null && !res.isEmpty()) {
+            if (res.size() == 1) {
+                destination.append(res.getFirst());
+            } else {
+                destination.append('[');
+                int i = 0;
+                for (String s : res) {
+                    destination.append(s);
+                    if (++i != res.size()) {
+                        destination.append(", ");
+                    }
+                }
+                destination.append(']');
+            }
+        }
+    }
+
+    @Override
     public void writeAttribute(final HttpServerExchange exchange, final String newValue) throws ReadOnlyAttributeException {
         final ArrayDeque<String> value = new ArrayDeque<>();
         value.add(newValue);

--- a/core/src/main/java/io/undertow/attribute/QuotingExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/QuotingExchangeAttribute.java
@@ -47,22 +47,33 @@ public class QuotingExchangeAttribute implements ExchangeAttribute {
 
         /* Wrap all quotes in double quotes. */
         StringBuilder buffer = new StringBuilder(svalue.length() + 2);
-        buffer.append('\'');
-        int i = 0;
-        while (i < svalue.length()) {
-            int j = svalue.indexOf('\'', i);
-            if (j == -1) {
-                buffer.append(svalue.substring(i));
-                i = svalue.length();
-            } else {
-                buffer.append(svalue.substring(i, j + 1));
-                buffer.append('"');
-                i = j + 2;
-            }
+        readAttribute(exchange, buffer);
+        return buffer.toString();
+    }
+
+    @Override
+    public void readAttribute(HttpServerExchange exchange, StringBuilder buffer) {
+        int start = buffer.length();
+        exchangeAttribute.readAttribute(exchange, buffer);
+        int end = buffer.length();
+        // Does the value contain a " ? If so must encode it
+        if (buffer.length() == start) {
+            buffer.append('-');
+            return;
+        } else if (end == start + 1 && buffer.charAt(start) == '-') {
+            return;
         }
 
+        /* Wrap all quotes in double quotes. */
+        buffer.insert(start, '\'');
+        for (int i = start + 1; i < buffer.length(); i++) {
+            if (buffer.charAt(i) == '\'') {
+                buffer.insert(i, '"');
+                buffer.insert(i + 2, '"');
+                i += 2;
+            }
+        }
         buffer.append('\'');
-        return buffer.toString();
     }
 
     @Override

--- a/core/src/main/java/io/undertow/attribute/RequestLineAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/RequestLineAttribute.java
@@ -38,8 +38,14 @@ public class RequestLineAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(final HttpServerExchange exchange) {
-        StringBuilder sb = new StringBuilder()
-                .append(exchange.getRequestMethod().toString())
+        StringBuilder sb = new StringBuilder();
+        readAttribute(exchange, sb);
+        return sb.toString();
+    }
+
+    @Override
+    public void readAttribute(HttpServerExchange exchange, StringBuilder sb) {
+        sb.append(exchange.getRequestMethod().toString())
                 .append(' ')
                 .append(exchange.getRequestURI());
         if (!exchange.getQueryString().isEmpty()) {
@@ -47,8 +53,7 @@ public class RequestLineAttribute implements ExchangeAttribute {
             sb.append(exchange.getQueryString());
         }
         sb.append(' ')
-                .append(exchange.getProtocol().toString()).toString();
-        return sb.toString();
+                .append(exchange.getProtocol().toString());
     }
 
     @Override

--- a/core/src/main/java/io/undertow/attribute/SubstituteEmptyWrapper.java
+++ b/core/src/main/java/io/undertow/attribute/SubstituteEmptyWrapper.java
@@ -37,6 +37,15 @@ public class SubstituteEmptyWrapper implements ExchangeAttributeWrapper {
         }
 
         @Override
+        public void readAttribute(final HttpServerExchange exchange, final StringBuilder destination) {
+            int start = destination.length();
+            attribute.readAttribute(exchange, destination);
+            if(start == destination.length() && substitute != null) {
+                destination.append(substitute);
+            }
+        }
+
+        @Override
         public void writeAttribute(HttpServerExchange exchange, String newValue) throws ReadOnlyAttributeException {
             attribute.writeAttribute(exchange, newValue);
         }

--- a/core/src/main/java/io/undertow/server/handlers/accesslog/ExtendedAccessLogParser.java
+++ b/core/src/main/java/io/undertow/server/handlers/accesslog/ExtendedAccessLogParser.java
@@ -270,6 +270,17 @@ public class ExtendedAccessLogParser {
                     }
 
                     @Override
+                    public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+                        final InetSocketAddress peerAddress = exchange.getConnection().getPeerAddress(InetSocketAddress.class);
+
+                        try {
+                            destination.append(peerAddress.getHostName());
+                        } catch (Throwable e) {
+                            destination.append(peerAddress.getHostString());
+                        }
+                    }
+
+                    @Override
                     public void writeAttribute(HttpServerExchange exchange, String newValue) throws ReadOnlyAttributeException {
                         throw new ReadOnlyAttributeException();
                     }
@@ -338,6 +349,19 @@ public class ExtendedAccessLogParser {
                                 buf.append('?');
                                 buf.append(exchange.getQueryString());
                                 return buf.toString();
+                            }
+                        }
+
+                        @Override
+                        public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+                            String query = exchange.getQueryString();
+
+                            if (query.isEmpty()) {
+                                destination.append(exchange.getRequestURI());
+                            } else {
+                                destination.append(exchange.getRequestURI());
+                                destination.append('?');
+                                destination.append(exchange.getQueryString());
                             }
                         }
 
@@ -440,6 +464,20 @@ public class ExtendedAccessLogParser {
                         return buffer.toString();
                     }
                     return null;
+                }
+
+                @Override
+                public void readAttribute(HttpServerExchange exchange, StringBuilder destination) {
+                    HeaderValues values = exchange.getResponseHeaders().get(parameter);
+                    if (values != null && values.size() > 0) {
+                        for (int i = 0; i < values.size(); i++) {
+                            String string = values.get(i);
+                            destination.append(string);
+                            if (i + 1 < values.size()) {
+                                destination.append(",");
+                            }
+                        }
+                    }
                 }
 
                 @Override

--- a/core/src/test/java/io/undertow/attribute/QuotingExchangeAttributeTest.java
+++ b/core/src/test/java/io/undertow/attribute/QuotingExchangeAttributeTest.java
@@ -1,0 +1,39 @@
+package io.undertow.attribute;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QuotingExchangeAttributeTest {
+
+    @Test
+    public void testQuoting() {
+        ExchangeAttribute delegate = new ConstantExchangeAttribute("test 'value'");
+        ExchangeAttribute attribute = new QuotingExchangeAttribute(delegate);
+        String value = attribute.readAttribute(null);
+        Assert.assertEquals("'test \"'\"value\"'\"'", value);
+    }
+
+    @Test
+    public void testNull() {
+        ExchangeAttribute delegate = new ConstantExchangeAttribute(null);
+        ExchangeAttribute attribute = new QuotingExchangeAttribute(delegate);
+        String value = attribute.readAttribute(null);
+        Assert.assertEquals("-", value);
+    }
+
+    @Test
+    public void testEmpty() {
+        ExchangeAttribute delegate = new ConstantExchangeAttribute("");
+        ExchangeAttribute attribute = new QuotingExchangeAttribute(delegate);
+        String value = attribute.readAttribute(null);
+        Assert.assertEquals("-", value);
+    }
+
+    @Test
+    public void testSingleQuote() {
+        ExchangeAttribute delegate = new ConstantExchangeAttribute("'");
+        ExchangeAttribute attribute = new QuotingExchangeAttribute(delegate);
+        String value = attribute.readAttribute(null);
+        Assert.assertEquals("'\"'\"'", value);
+    }
+}


### PR DESCRIPTION
Goal is to reduce String and StringBuilder allocation around
access logging.

Note: This changes (fixes?) behavior of `QuotingExchangeAttribute` where previously the string `you're` would be encoded to to `'you'"re'` instead of `'you"'"re'`. I'm not totally certain how QuotingExchangeAttribute is expected to work though, so my interperetation may be incorrect.

I'm not certain that adding a StringBuilder method to ExchangeAttribute is the best way to write this feature, so feel free to close out if you're worried about API bloat.