### PR TITLE
UNDERTOW-1237 Added multiline header parsing (1.1.x)

### DIFF
--- a/core/src/main/java/io/undertow/util/MultipartParser.java
+++ b/core/src/main/java/io/undertow/util/MultipartParser.java
@@ -32,6 +32,12 @@ import org.xnio.Pooled;
 public class MultipartParser {
 
     /**
+     * The Horizontal Tab ASCII character value;
+     */
+    public static final byte HTAB = 0x09;
+
+
+    /**
      * The Carriage Return ASCII character value.
      */
     public static final byte CR = 0x0D;
@@ -41,6 +47,12 @@ public class MultipartParser {
      * The Line Feed ASCII character value.
      */
     public static final byte LF = 0x0A;
+
+
+    /**
+     * The Space ASCII character value;
+     */
+    public static final byte SP = 0x20;
 
 
     /**
@@ -218,17 +230,34 @@ public class MultipartParser {
         private void headerValue(final ByteBuffer buffer) throws MalformedMessageException, UnsupportedEncodingException {
             while (buffer.hasRemaining()) {
                 final byte b = buffer.get();
-                if (b == CR) {
+                if(subState == 2) {
+                    if (b == CR) { //end of headers section
+                        headers.put(new HttpString(currentHeaderName.trim()), new String(currentString.toByteArray(), requestCharset).trim());
+                        //set state for headerName to verify end of headers section
+                        state = 1;
+                        subState = 1; //CR already encountered
+                        currentString = null;
+                        return;
+                    } else if (b == SP || b == HTAB) { //multi-line header
+                        currentString.write(b);
+                        subState = 0;
+                    } else { //next header name
+                        headers.put(new HttpString(currentHeaderName.trim()), new String(currentString.toByteArray(), requestCharset).trim());
+                        //set state for headerName to collect next header's name
+                        state = 1;
+                        subState = 0;
+                        //start name collection for headerName to finish
+                        currentString = new ByteArrayOutputStream();
+                        currentString.write(b);
+                        return;
+                    }
+                } else if (b == CR) {
                     subState = 1;
                 } else if (b == LF) {
                     if (subState != 1) {
                         throw new MalformedMessageException();
                     }
-                    headers.put(new HttpString(currentHeaderName.trim()), new String(currentString.toByteArray(), requestCharset).trim());
-                    state = 1;
-                    subState = 0;
-                    currentString = null;
-                    return;
+                    subState = 2;
                 } else {
                     if (subState != 0) {
                         throw new MalformedMessageException();

--- a/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
+++ b/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
@@ -135,9 +135,9 @@ public class MimeDecodingTestCase {
     public void testMultilineHeader() throws IOException {
         final String data =  fixLineEndings(FileUtils.readFile(MimeDecodingTestCase.class, "mime-multiline.txt"));
         TestPartHandler handler = new TestPartHandler();
-        MultipartParser.ParseState parser = MultipartParser.beginParse(DefaultServer.getBufferPool(), handler, "unique-boundary-1".getBytes(), "ISO-8859-1");
+        MultipartParser.ParseState parser = MultipartParser.beginParse(bufferPool, handler, "unique-boundary-1".getBytes(), "ISO-8859-1");
 
-        ByteBuffer buf = ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer buf = ByteBuffer.wrap(data.getBytes());
         parser.parse(buf);
         Assert.assertTrue(parser.isComplete());
         Assert.assertEquals(2, handler.parts.size());

--- a/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
+++ b/core/src/test/java/io/undertow/util/MimeDecodingTestCase.java
@@ -131,6 +131,22 @@ public class MimeDecodingTestCase {
         Assert.assertEquals("text/plain", handler.parts.get(0).map.getFirst(Headers.CONTENT_TYPE));
     }
 
+    @Test
+    public void testMultilineHeader() throws IOException {
+        final String data =  fixLineEndings(FileUtils.readFile(MimeDecodingTestCase.class, "mime-multiline.txt"));
+        TestPartHandler handler = new TestPartHandler();
+        MultipartParser.ParseState parser = MultipartParser.beginParse(DefaultServer.getBufferPool(), handler, "unique-boundary-1".getBytes(), "ISO-8859-1");
+
+        ByteBuffer buf = ByteBuffer.wrap(data.getBytes(StandardCharsets.UTF_8));
+        parser.parse(buf);
+        Assert.assertTrue(parser.isComplete());
+        Assert.assertEquals(2, handler.parts.size());
+        Assert.assertEquals("Here is some text.", handler.parts.get(0).data.toString());
+        Assert.assertEquals("Here is some more text.", handler.parts.get(1).data.toString());
+
+        Assert.assertEquals("text/plain; charset=\"ascii\"", handler.parts.get(0).map.getFirst(Headers.CONTENT_TYPE));
+    }
+
     private static class TestPartHandler implements MultipartParser.PartHandler {
 
         private final List<Part> parts = new ArrayList<>();

--- a/core/src/test/java/io/undertow/util/mime-multiline.txt
+++ b/core/src/test/java/io/undertow/util/mime-multiline.txt
@@ -1,0 +1,9 @@
+--unique-boundary-1
+Content-type: text/plain;
+ charset="ascii"
+
+Here is some text.
+--unique-boundary-1
+
+Here is some more text.
+--unique-boundary-1--


### PR DESCRIPTION
Modified multipart header parsing to allow for headers that span multiple lines per section 2.2.3 of RFC2822.