### PR TITLE
RFC per cookie request limit handler

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/CookieRequestLimitingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/CookieRequestLimitingHandler.java
@@ -1,0 +1,71 @@
+package com.parallels.pa.reqlimit;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.Cookie;
+import io.undertow.server.handlers.RequestLimit;
+
+public class CookieRequestLimitingHandler implements HttpHandler {
+	private int maximumConcurrentRequests = 5;
+	private int queueSize = 10;
+	private String cookieName = "JSESSIONID";
+	private HttpHandler nextHandler;
+
+	public CookieRequestLimitingHandler(HttpHandler nextHandler) {
+		super();
+		this.nextHandler = nextHandler;
+	}
+
+	private LoadingCache<String, RequestLimit> limiters = CacheBuilder.newBuilder()
+			.maximumSize(1000)
+			.expireAfterAccess(1, TimeUnit.MINUTES)
+			.build(new CacheLoader<String, RequestLimit>() {
+				@Override
+				public RequestLimit load(String key) throws Exception {
+					return new RequestLimit(maximumConcurrentRequests, queueSize);
+				}
+			});
+
+	@Override
+	public void handleRequest(HttpServerExchange exchange) throws Exception {
+		Map<String, Cookie> cookies = Optional.ofNullable(exchange.getRequestCookies()).orElse(Collections.emptyMap());
+		if (cookies.containsKey(cookieName)) {
+			limiters.get(cookies.get(cookieName).getValue()).handleRequest(exchange, nextHandler);
+		} else {
+			nextHandler.handleRequest(exchange);
+		}
+	}
+
+	public int getMaximumConcurrentRequests() {
+		return maximumConcurrentRequests;
+	}
+
+	public void setMaximumConcurrentRequests(int maximumConcurrentRequests) {
+		this.maximumConcurrentRequests = maximumConcurrentRequests;
+	}
+
+	public int getQueueSize() {
+		return queueSize;
+	}
+
+	public void setQueueSize(int queueSize) {
+		this.queueSize = queueSize;
+	}
+
+	public String getCookieName() {
+		return cookieName;
+	}
+
+	public void setCookieName(String cookieName) {
+		this.cookieName = cookieName;
+	}
+}


### PR DESCRIPTION
IMHO RequestLimitingHandler undertow have now is pretty much useless. Same effect is easily achievable by limiting xnio thread pool. Maybe it make sense to add something more usefull: like per cookie limiter? 

I know I have to drop guava and maybe add builder/wrapper (btw wasn't able to figure out who use it). If comminuty is interested I can polish pull-request.