### PR TITLE
Compilation issue fix - Map types required for java 1.7

### DIFF
--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -99,12 +99,12 @@ public class PathTemplateTestCase {
     @Test
     public void testTrailingSlash() {
         PathTemplate template = PathTemplate.create("/bob/");
-        Assert.assertFalse(template.matches("/bob", new HashMap<>()));
-        Assert.assertTrue(template.matches("/bob/", new HashMap<>()));
+        Assert.assertFalse(template.matches("/bob", new HashMap<String, String>()));
+        Assert.assertTrue(template.matches("/bob/", new HashMap<String, String>()));
 
         template = PathTemplate.create("/bob/{id}/");
-        Assert.assertFalse(template.matches("/bob/1", new HashMap<>()));
-        Assert.assertTrue(template.matches("/bob/1/", new HashMap<>()));
+        Assert.assertFalse(template.matches("/bob/1", new HashMap<String, String>()));
+        Assert.assertTrue(template.matches("/bob/1/", new HashMap<String, String>()));
 
     }
 

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -129,6 +129,10 @@
                 <Class name="io.undertow.util.Cookies"/>
                 <Method name="parseCookie"/>
             </And>
+            <And>
+                <Class name="io.undertow.util.PathTemplate"/>
+                <Method name="create"/>
+            </And>
         </Or>
     </Match>
 


### PR DESCRIPTION
This fix is needed only for 1.4.x branches, which are still java 1.7 compatible.