### PR TITLE
[UNDERTOW-1277] Clear XnioByteBufferPool.PooledByteBuffer pool when close() to avoid direct memory leaking

### DIFF
--- a/core/src/main/java/io/undertow/server/XnioByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/XnioByteBufferPool.java
@@ -20,6 +20,7 @@ package io.undertow.server;
 
 import io.undertow.connector.ByteBufferPool;
 import io.undertow.connector.PooledByteBuffer;
+import org.xnio.ByteBufferSlicePool;
 import org.xnio.Pool;
 import org.xnio.Pooled;
 
@@ -64,6 +65,7 @@ public class XnioByteBufferPool implements ByteBufferPool {
             public void close() {
                 open = false;
                 buf.free();
+                ((ByteBufferSlicePool) pool).clean();
             }
 
             @Override

--- a/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateTestCase.java
@@ -99,12 +99,12 @@ public class PathTemplateTestCase {
     @Test
     public void testTrailingSlash() {
         PathTemplate template = PathTemplate.create("/bob/");
-        Assert.assertFalse(template.matches("/bob", new HashMap<>()));
-        Assert.assertTrue(template.matches("/bob/", new HashMap<>()));
+        Assert.assertFalse(template.matches("/bob", new HashMap<String, String>()));
+        Assert.assertTrue(template.matches("/bob/", new HashMap<String, String>()));
 
         template = PathTemplate.create("/bob/{id}/");
-        Assert.assertFalse(template.matches("/bob/1", new HashMap<>()));
-        Assert.assertTrue(template.matches("/bob/1/", new HashMap<>()));
+        Assert.assertFalse(template.matches("/bob/1", new HashMap<String, String>()));
+        Assert.assertTrue(template.matches("/bob/1/", new HashMap<String, String>()));
 
     }
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/UNDERTOW-1277

DO NOT MERGE. This fix requires https://github.com/xnio/xnio/pull/142 to be merged first.