### PR TITLE
UNDERTOW-1274 Cross context session creation should not set a cookie,…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -740,7 +740,7 @@ public class ServletContextImpl implements ServletContext {
                     c = new SessionConfig() {
                         @Override
                         public void setSessionId(HttpServerExchange exchange, String sessionId) {
-                            getSessionConfig().setSessionId(exchange, sessionId);
+                            //noop
                         }
 
                         @Override


### PR DESCRIPTION
… but rely on the original contexts cookie