### PR TITLE
[UNDERTOW-1282] HttpServletRequest.getLocalPort() returned value does…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -1005,11 +1005,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
 
     @Override
     public int getLocalPort() {
-        SocketAddress address = exchange.getConnection().getLocalAddress();
-        if (address instanceof InetSocketAddress) {
-            return ((InetSocketAddress) address).getPort();
-        }
-        return -1;
+        return exchange.getDestinationAddress().getPort();
     }
 
     @Override


### PR DESCRIPTION
… not reflect value specified by Forwarded~by header