### PR TITLE
[UNDERTOW-1287] Karaf update to 4.2.0.M2 version which supports Java 9.

### DIFF
--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -47,7 +47,7 @@
         <libraryPath></libraryPath>
         <java.library.path></java.library.path>
         <org.wildfly.openssl.path></org.wildfly.openssl.path>
-        <dependency.karaf.version>4.0.7</dependency.karaf.version>
+        <dependency.karaf.version>4.2.0.M2</dependency.karaf.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
 - This contains an update of Karaf module from 4.0.7 to 4.2.0.M2
   so we are able to build Undertow with JDK9.