### PR TITLE
[UNDERTOW-1290][UNDERTOW-1291] for SecureExchangeAttribute

### DIFF
--- a/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
@@ -30,7 +30,7 @@ public class SecureExchangeAttribute implements ExchangeAttribute {
 
     @Override
     public String readAttribute(HttpServerExchange exchange) {
-        return Boolean.toString(exchange.getRequestScheme().toLowerCase().equals("https"));
+        return Boolean.toString(exchange.isSecure());
     }
 
     @Override

--- a/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/SecureExchangeAttribute.java
@@ -25,7 +25,7 @@ import io.undertow.server.HttpServerExchange;
  */
 public class SecureExchangeAttribute implements ExchangeAttribute {
 
-    public static final String TOKEN = "${SECURE}";
+    public static final String TOKEN = "%{SECURE}";
     public static final ExchangeAttribute INSTANCE = new SecureExchangeAttribute();
 
     @Override


### PR DESCRIPTION
This PR contains two commits for SecureExchangeAttribute:
- [UNDERTOW-1290 Fix a typo for the token name of SecureExchangeAttribute](https://issues.jboss.org/browse/UNDERTOW-1290)
- [UNDERTOW-1291 Improve SecureExchangeAttribute to use HttpServerExchange#isSecure() instead of HttpServerExchange#getRequestScheme()](https://issues.jboss.org/browse/UNDERTOW-1291)