### PR TITLE
Revert jboss-logmanager version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.org.jboss.classfilewriter>1.0.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.logging>3.3.0.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.1.0.Final</version.org.jboss.logging.processor>
-        <version.org.jboss.logmanager>2.0.1.Final-SNAPSHOT</version.org.jboss.logmanager>
+        <version.org.jboss.logmanager>2.0.0.Final</version.org.jboss.logmanager>
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.2.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.jboss.spec.javax.servlet.jsp>1.0.3.Final</version.org.jboss.spec.javax.servlet.jsp>


### PR DESCRIPTION
A version bump from 2.0.0.Final to 2.0.1.Final-SNAPSHOT accidentally
updated the version of jboss-logmanager dependency.