### PR TITLE
[UNDERTOW-1301] Web Socket sessions are not closed when session is in…

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketFilter.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/JsrWebSocketFilter.java
@@ -196,6 +196,10 @@ public class JsrWebSocketFilter implements Filter {
                 }
             }
         }
+
+        @Override
+        public void sessionCreated(HttpSessionEvent se) {
+        }
     }
 
 }


### PR DESCRIPTION
…validated

 - follow-up after cherry-pick that caused compilation error due to the Servlet 3.1
   and Servlet 4.0 difference in javax.servlet.http.HttpSessionListener interface