### PR TITLE
Migrated from deprecated findbugs plugin to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
         <version.io.undertow.build.checkstyle-config>1.0.1.Final</version.io.undertow.build.checkstyle-config>
-        <version.org.codehaus.mojo.findbugs-maven-plugin>3.0.4</version.org.codehaus.mojo.findbugs-maven-plugin>
+        <version.com.github.spotbugs-maven-plugin>3.1.2</version.com.github.spotbugs-maven-plugin>
         <version.org.mortbay.jetty.alpn.jdk7>7.0.0.v20140317</version.org.mortbay.jetty.alpn.jdk7>
         <version.org.mortbay.jetty.alpn.jdk8>8.0.0.v20140317</version.org.mortbay.jetty.alpn.jdk8>
         <version.org.mortbay.jetty.alpn.jdk8.25>8.1.2.v20141202</version.org.mortbay.jetty.alpn.jdk8.25>
@@ -183,11 +183,11 @@
 
                 <!-- FindBugs -->
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>${version.org.codehaus.mojo.findbugs-maven-plugin}</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${version.com.github.spotbugs-maven-plugin}</version>
                     <configuration>
-                        <excludeFilterFile>../findbugs-exclude.xml</excludeFilterFile>
+                        <excludeFilterFile>../spotbugs-exclude.xml</excludeFilterFile>
                     </configuration>
                     <executions>
                         <execution>
@@ -479,17 +479,17 @@
 
     <profiles>
         <profile>
-            <id>findbugs</id>
+            <id>spotbugs</id>
             <activation>
                 <property>
-                    <name>findbugs</name>
+                    <name>findbugs</name> <!-- not modified just for compatibility reason -->
                 </property>
             </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,15 +1,15 @@
-<!-- This file specifies a findbugs filter for excluding reports that
+<!-- This file specifies a spotbugs filter for excluding reports that
      should not be considered errors.
 
      The format of this file is documented at:
 
-       http://findbugs.sourceforge.net/manual/filter.html
+       https://spotbugs.readthedocs.io/en/latest/filter.html
 
      When possible, please specify the full names of the bug codes,
      using the pattern attribute, to make it clearer what reports are
      being suppressed.  You can find a listing of codes at:
 
-       http://findbugs.sourceforge.net/bugDescriptions.html
+       https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html
   -->
 
 <FindBugsFilter>
@@ -22,7 +22,7 @@
         </Or>
     </Match>
 
-    <!-- Ignore findbugs reports from incomplete detectors -->
+    <!-- Ignore spotbugs reports from incomplete detectors -->
     <Match>
         <Bug pattern="TESTING"/>
     </Match>
@@ -54,6 +54,16 @@
             <And>
                 <Class name="io.undertow.server.protocol.ajp.AjpRequestParseState"/>
                 <Field name="dataSize"/>
+            </And>
+        </Or>
+    </Match>
+
+    <!-- False positives => ignoring, the field is regular boolean, no complex bitwise operation is in place here -->
+    <Match>
+        <Bug pattern="BIT_IOR"/>
+        <Or>
+            <And>
+                <Class name="io.undertow.conduits.AbstractFixedLengthStreamSinkConduit"/>
             </And>
         </Or>
     </Match>


### PR DESCRIPTION
As Findbugs project has been discontinued, we should now use Spotbugs which is a successor.