### PR TITLE
UNDERTOW-1308 Fix incomplete recognition of absolute URL for redirects

### DIFF
--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -18,15 +18,18 @@
 
 package io.undertow.util;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import io.undertow.UndertowMessages;
 import io.undertow.server.HttpServerExchange;
-
-import java.io.UnsupportedEncodingException;
 
 /**
  * Utilities for dealing with URLs
  *
  * @author Stuart Douglas
+ * @author Andre Schaefer
  */
 public class URLUtils {
 
@@ -310,4 +313,23 @@ public class URLUtils {
 
         return path;
     }
+
+
+	/**
+	 * Test if provided location is an absolute URI or not.
+	 *
+	 * @param location location to check, null = relative, having scheme = absolute
+	 * @return true if location is considered absolute
+	 */
+	public static boolean isAbsoluteUrl(String location) {
+		if (location != null && location.length() > 0 && location.contains(":")){
+			try {
+				URI uri = new URI(location);
+				return uri.getScheme() != null;
+			} catch (URISyntaxException e) {
+				// ignore invalid locations and consider not absolute
+			}
+		}
+		return false;
+	}
 }

--- a/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
@@ -26,9 +26,10 @@ import org.junit.runners.Parameterized;
 
 import java.nio.charset.Charset;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 /**
  * @author Oleksandr Radchykov
+ * @author Andre Schaefer
  */
 @RunWith(Parameterized.class)
 @Category(UnitTest.class)
@@ -58,4 +59,35 @@ public class URLUtilsTestCase {
         assertEquals(url, result);
     }
 
+	@Test
+	public void testIsAbsoluteUrlRecognizingAbsolutUrls() {
+		assertTrue(URLUtils.isAbsoluteUrl("https://some.valid.url:8080/path?query=val"));
+		assertTrue(URLUtils.isAbsoluteUrl("http://some.valid.url:8080/path?query=val"));
+		assertTrue(URLUtils.isAbsoluteUrl("http://some.valid.url"));
+	}
+
+	@Test
+	public void testIsAbsoluteUrlRecognizingAppUrls() {
+		assertTrue(URLUtils.isAbsoluteUrl("com.example.app:/oauth2redirect/example-provider"));
+		assertTrue(URLUtils.isAbsoluteUrl("com.example.app:/oauth2redirect/example-provider?query=val"));
+	}
+
+	@Test
+	public void testIsAbsoluteUrlRecognizingRelativeUrls() {
+		assertFalse(URLUtils.isAbsoluteUrl("relative"));
+		assertFalse(URLUtils.isAbsoluteUrl("relative/path"));
+		assertFalse(URLUtils.isAbsoluteUrl("relative/path?query=val"));
+		assertFalse(URLUtils.isAbsoluteUrl("/root/relative/path"));
+	}
+
+	@Test
+	public void testIsAbsoluteUrlRecognizingEmptyOrNullAsRelative() {
+		assertFalse(URLUtils.isAbsoluteUrl(null));
+		assertFalse(URLUtils.isAbsoluteUrl(""));
+	}
+
+	@Test
+	public void testIsAbsoluteUrlIgnoresSyntaxErrorsAreNotAbsolute() {
+		assertFalse(URLUtils.isAbsoluteUrl(":"));
+	}
 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
@@ -51,6 +51,8 @@ import io.undertow.util.HttpString;
 import io.undertow.util.RedirectBuilder;
 import io.undertow.util.StatusCodes;
 
+import static io.undertow.util.URLUtils.isAbsoluteUrl;
+
 
 /**
  * @author Stuart Douglas
@@ -184,7 +186,7 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
         resetBuffer();
         setStatus(StatusCodes.FOUND);
         String realPath;
-        if (location.contains("://")) {//absolute url
+        if (isAbsoluteUrl(location)) {//absolute url
             exchange.getResponseHeaders().put(Headers.LOCATION, location);
         } else {
             if (location.startsWith("/")) {


### PR DESCRIPTION
- previous recognition based on literal "://" was incomplete
- especially it should be possible to redirect to native oauth2 clients
  using 7.1.  Private-Use URI Scheme Redirection
  e.g. com.example.app:/oauth2redirect/example-provider