### PR TITLE
 UNDERTOW-1315 Undertow mod_cluster balancer retries one less time

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Balancer.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Balancer.java
@@ -70,7 +70,7 @@ public class Balancer {
     /**
      * Maximum number of failover attempts to send the request to the backend server. Default: "1"
      */
-    private final int maxattempts;
+    private final int maxRetries;
 
     private final int id;
     private static final AtomicInteger idGen = new AtomicInteger();
@@ -84,85 +84,50 @@ public class Balancer {
         this.stickySessionRemove = b.isStickySessionRemove();
         this.stickySessionForce = b.isStickySessionForce();
         this.waitWorker = b.getWaitWorker();
-        this.maxattempts = b.getMaxattempts();
+        this.maxRetries = b.getMaxRetries();
         UndertowLogger.ROOT_LOGGER.balancerCreated(this.id, this.name, this.stickySession, this.stickySessionCookie, this.stickySessionPath,
-                this.stickySessionRemove,  this.stickySessionForce, this.waitWorker, this.maxattempts);
+                this.stickySessionRemove,  this.stickySessionForce, this.waitWorker, this.maxRetries);
     }
 
     public int getId() {
         return id;
     }
 
-    /**
-     * Getter for name
-     *
-     * @return the name
-     */
     public String getName() {
         return this.name;
     }
 
-    /**
-     * Getter for stickySession
-     *
-     * @return the stickySession
-     */
     public boolean isStickySession() {
         return this.stickySession;
     }
 
-    /**
-     * Getter for stickySessionCookie
-     *
-     * @return the stickySessionCookie
-     */
     public String getStickySessionCookie() {
         return this.stickySessionCookie;
     }
 
-    /**
-     * Getter for stickySessionPath
-     *
-     * @return the stickySessionPath
-     */
     public String getStickySessionPath() {
         return this.stickySessionPath;
     }
 
-    /**
-     * Getter for stickySessionRemove
-     *
-     * @return the stickySessionRemove
-     */
     public boolean isStickySessionRemove() {
         return this.stickySessionRemove;
     }
 
-    /**
-     * Getter for stickySessionForce
-     *
-     * @return the stickySessionForce
-     */
     public boolean isStickySessionForce() {
         return this.stickySessionForce;
     }
 
-    /**
-     * Getter for waitWorker
-     *
-     * @return the waitWorker
-     */
     public int getWaitWorker() {
         return this.waitWorker;
     }
 
-    /**
-     * Getter for maxattempts
-     *
-     * @return the maxattempts
-     */
+    public int getMaxRetries() {
+        return this.maxRetries;
+    }
+
+    @Deprecated
     public int getMaxattempts() {
-        return this.maxattempts;
+        return this.maxRetries;
     }
 
     @Override
@@ -173,10 +138,10 @@ public class Balancer {
                 .append(this.stickySessionPath).append("], remove: ")
                 .append(this.stickySessionRemove ? 1 : 0).append(", force: ")
                 .append(this.stickySessionForce ? 1 : 0).append(", Timeout: ")
-                .append(this.waitWorker).append(", Maxtry: ").append(this.maxattempts).toString();
+                .append(this.waitWorker).append(", Maxtry: ").append(this.maxRetries).toString();
     }
 
-    static final BalancerBuilder builder() {
+    static BalancerBuilder builder() {
         return new BalancerBuilder();
     }
 
@@ -189,7 +154,7 @@ public class Balancer {
         private boolean stickySessionRemove = false;
         private boolean stickySessionForce = true;
         private int waitWorker = 0;
-        private int maxattempts = 1;
+        private int maxRetries = 1;
 
         public String getName() {
             return name;
@@ -259,12 +224,34 @@ public class Balancer {
             return this;
         }
 
-        public int getMaxattempts() {
-            return maxattempts;
+        public int getMaxRetries() {
+            return this.maxRetries;
         }
 
+        /**
+         * Maximum number of failover attempts to send the request to the backend server.
+         *
+         * @param maxRetries number of failover attempts
+         */
+        public BalancerBuilder setMaxRetries(int maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        /**
+         * @deprecated Use {@link BalancerBuilder#getMaxRetries()}.
+         */
+        @Deprecated
+        public int getMaxattempts() {
+            return maxRetries;
+        }
+
+        /**
+         * @deprecated Use {@link BalancerBuilder#setMaxRetries(int)}.
+         */
+        @Deprecated
         public BalancerBuilder setMaxattempts(int maxattempts) {
-            this.maxattempts = maxattempts;
+            this.maxRetries = maxattempts;
             return this;
         }
 

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Balancer.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/Balancer.java
@@ -68,7 +68,7 @@ public class Balancer {
     private final int waitWorker;
 
     /**
-     * value: number of attempts to send the request to the backend server. Default: "1"
+     * Maximum number of failover attempts to send the request to the backend server. Default: "1"
      */
     private final int maxattempts;
 

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
@@ -212,9 +212,8 @@ class MCMPHandler implements HttpHandler {
      *
      * @param exchange the http server exchange
      * @param requestData the request data
-     * @throws IOException
      */
-    private void processConfig(final HttpServerExchange exchange, final RequestData requestData) throws IOException {
+    private void processConfig(final HttpServerExchange exchange, final RequestData requestData) {
 
         // Get the node builder
         List<String> hosts = null;
@@ -236,7 +235,7 @@ class MCMPHandler implements HttpHandler {
                 node.setBalancer(value);
                 balancer.setName(value);
             } else if (MAXATTEMPTS.equals(name)) {
-                balancer.setMaxattempts(Integer.parseInt(value));
+                balancer.setMaxRetries(Integer.parseInt(value));
             } else if (STICKYSESSION.equals(name)) {
                 if ("No".equalsIgnoreCase(value)) {
                     balancer.setStickySession(false);

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPInfoUtil.java
@@ -35,7 +35,7 @@ class MCMPInfoUtil {
                 .append(" remove: ").append(toStringOneZero(balancer.isStickySessionRemove()))
                 .append(" force: ").append(toStringOneZero(balancer.isStickySessionForce()))
                 .append(" Timeout: ").append(balancer.getWaitWorker())
-                .append(" maxAttempts: ").append(balancer.getMaxattempts())
+                .append(" maxAttempts: ").append(balancer.getMaxRetries())
                 .append(NEWLINE);
     }
 

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterContainer.java
@@ -742,8 +742,14 @@ class ModClusterContainer implements ModClusterController {
         }
 
         @Override
+        public int getMaxRetries() {
+            return balancer.getMaxRetries();
+        }
+
+        @Override
+        @Deprecated
         public int getMaxAttempts() {
-            return balancer.getMaxattempts();
+            return balancer.getMaxRetries();
         }
     }
 

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
@@ -84,7 +84,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
             if(balancer == null) {
                 return 0;
             }
-            return balancer.getMaxattempts();
+            return balancer.getMaxRetries();
         }
     }
 
@@ -111,7 +111,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
             if(balancer == null) {
                 return 0;
             }
-            return balancer.getMaxattempts();
+            return balancer.getMaxRetries();
         }
 
         @Override

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyTarget.java
@@ -84,7 +84,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
             if(balancer == null) {
                 return 0;
             }
-            return balancer.getMaxattempts() - 1;
+            return balancer.getMaxattempts();
         }
     }
 
@@ -111,7 +111,7 @@ public interface ModClusterProxyTarget extends ProxyClient.ProxyTarget, ProxyCli
             if(balancer == null) {
                 return 0;
             }
-            return balancer.getMaxattempts() - 1;
+            return balancer.getMaxattempts();
         }
 
         @Override

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterStatus.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterStatus.java
@@ -40,52 +40,29 @@ public interface ModClusterStatus {
 
         Node getNode(String name);
 
-        /**
-         * Getter for stickySession
-         *
-         * @return the stickySession
-         */
         boolean isStickySession();
 
-        /**
-         * Getter for stickySessionCookie
-         *
-         * @return the stickySessionCookie
-         */
         String getStickySessionCookie();
-        /**
-         * Getter for stickySessionPath
-         *
-         * @return the stickySessionPath
-         */
+
         String getStickySessionPath();
 
-        /**
-         * Getter for stickySessionRemove
-         *
-         * @return the stickySessionRemove
-         */
         boolean isStickySessionRemove();
 
-        /**
-         * Getter for stickySessionForce
-         *
-         * @return the stickySessionForce
-         */
         boolean isStickySessionForce();
 
-        /**
-         * Getter for waitWorker
-         *
-         * @return the waitWorker
-         */
         int getWaitWorker();
 
         /**
-         * Getter for maxattempts
+         * Returns maximum number of failover attempts to send the request to the backend server.
          *
-         * @return the maxattempts
+         * @return number of failover attempts
          */
+        int getMaxRetries();
+
+        /**
+         * @deprecated Use {@link LoadBalancer#getMaxRetries()}.
+         */
+        @Deprecated
         int getMaxAttempts();
     }
 


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/UNDERTOW-1315

This is very easy to overlook because the attribute is extremely poorly named and missing from MCMP definition [1] completely. This is because mod_cluster aligned nomenclature with httpd mod_proxy's [2] which defines maxattempts as:

Maximum number of failover attempts before giving up.

[1] https://developer.jboss.org/docs/DOC-11425

[2] https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass

The first commit fixes the issue.

Second commit cleans up the API with proper deprecation. I don't think we need to keep the mod_proxy nomenclature and use proper one in our APIs.