### PR TITLE
Implement DefaultByteBufferPool allocationDepth ceiling

### DIFF
--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -148,7 +148,9 @@ public class DefaultByteBufferPool implements ByteBufferPool {
                 buffer = ByteBuffer.allocate(bufferSize);
             }
         }
-        if(local != null) {
+        // limit allocationDepth runaway in scenarios where buffers flow from I/O threads to workers.
+        // Without an upper bound, allocationDepth may overflow and disable the threadLocal cache.
+        if (local != null && local.allocationDepth < 100) {
             local.allocationDepth++;
         }
         buffer.clear();


### PR DESCRIPTION
Prevents excessive buffer flow between I/O and worker threads from
overflowing the allocationDepth value.
Once allocationDepth wraps to a negative value, the thread local
cache will never be used.