### PR TITLE
UNDERTOW-1322 use exchange's sourceAddress instead of getConnection().getPeerAddress() inside ProxyHandler so that it can be used together with ProxyPeerAddressHandler

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
@@ -447,8 +447,8 @@ public final class ProxyHandler implements HttpHandler {
                 }
             }
             final String remoteHost;
-            final SocketAddress address = exchange.getConnection().getPeerAddress();
-            if (address != null && address instanceof InetSocketAddress) {
+            final SocketAddress address = exchange.getSourceAddress();
+            if (address != null) {
                 remoteHost = ((InetSocketAddress) address).getHostString();
                 if(!((InetSocketAddress) address).isUnresolved()) {
                     request.putAttachment(ProxiedRequestAttachments.REMOTE_ADDRESS, ((InetSocketAddress) address).getAddress().getHostAddress());


### PR DESCRIPTION
Fix proposal for https://issues.jboss.org/browse/UNDERTOW-1322