### PR TITLE
fix active requests metric collecting

### DIFF
--- a/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
+++ b/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
@@ -143,7 +143,7 @@ public class ConnectorStatisticsImpl implements ConnectorStatistics {
         do {
             maxActiveRequests = this.maxActiveRequests;
             if(current <= maxActiveRequests) {
-                return;
+                break;
             }
         } while (!maxActiveRequestsUpdater.compareAndSet(this, maxActiveRequests, current));
         exchange.addExchangeCompleteListener(completionListener);


### PR DESCRIPTION
setting complete listener is unreachable when a current value less than max