### PR TITLE
Added an example on WebSocketProtocolHandshakeHandler usage

### DIFF
--- a/examples/src/main/java/io/undertow/examples/websockets_extension/WebSocketServer.java
+++ b/examples/src/main/java/io/undertow/examples/websockets_extension/WebSocketServer.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.examples.websockets_extension;
+
+import io.undertow.Undertow;
+import io.undertow.examples.UndertowExample;
+import io.undertow.server.handlers.resource.ClassPathResourceManager;
+import io.undertow.websockets.WebSocketConnectionCallback;
+import io.undertow.websockets.WebSocketProtocolHandshakeHandler;
+import io.undertow.websockets.core.AbstractReceiveListener;
+import io.undertow.websockets.core.BufferedTextMessage;
+import io.undertow.websockets.core.WebSocketChannel;
+import io.undertow.websockets.core.WebSockets;
+import io.undertow.websockets.extensions.PerMessageDeflateHandshake;
+import io.undertow.websockets.spi.WebSocketHttpExchange;
+
+import static io.undertow.Handlers.path;
+import static io.undertow.Handlers.resource;
+
+/**
+ * @author Stuart Douglas
+ */
+@UndertowExample("Web Sockets")
+public class WebSocketServer {
+
+    public static void main(final String[] args) {
+        // Demonstrates how to use Websocket Protocol Handshake to enable Per-message deflate
+        Undertow server = Undertow.builder()
+                .addHttpListener(8080, "localhost")
+                .setHandler(path()
+                        .addPrefixPath("/myapp",
+                            new WebSocketProtocolHandshakeHandler(new WebSocketConnectionCallback() {
+
+                              @Override
+                              public void onConnect(WebSocketHttpExchange exchange, WebSocketChannel channel) {
+                                channel.getReceiveSetter().set(new AbstractReceiveListener() {
+
+                                  @Override
+                                  protected void onFullTextMessage(WebSocketChannel channel, BufferedTextMessage message) {
+                                    WebSockets.sendText(message.getData(), channel, null);
+                                  }
+                                });
+                                channel.resumeReceives();
+                              }
+                            }).addExtension(new PerMessageDeflateHandshake(false, 6)))
+                        .addPrefixPath("/", resource(new ClassPathResourceManager(WebSocketServer.class.getClassLoader(), WebSocketServer.class.getPackage())).addWelcomeFiles("index.html")))
+                .build();
+        server.start();
+    }
+
+}

--- a/examples/src/main/java/io/undertow/examples/websockets_extension/index.html
+++ b/examples/src/main/java/io/undertow/examples/websockets_extension/index.html
@@ -1,0 +1,57 @@
+<!--
+
+  This example adapted from Netty project
+
+ * Copyright 2010 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ -->
+
+<html>
+<head><title>Web Socket Test</title></head>
+<body>
+<script>
+    var socket;
+    if (window.WebSocket) {
+        socket = new WebSocket("ws://localhost:8080/myapp");
+        socket.onmessage = function(event) {
+            alert("Received data from websocket: " + event.data);
+        };
+        socket.onopen = function(event) {
+            alert("Web Socket opened!");
+        };
+        socket.onclose = function(event) {
+            alert("Web Socket closed.");
+        };
+    } else {
+        alert("Your browser does not support Websockets. (Use Chrome)");
+    }
+
+    function send(message) {
+        if (!window.WebSocket) {
+            return;
+        }
+        if (socket.readyState == WebSocket.OPEN) {
+            socket.send(message);
+        } else {
+            alert("The socket is not open.");
+        }
+    }
+</script>
+<form onsubmit="return false;">
+    <input type="text" name="message" value="Hello, World!"/>
+    <input type="button" value="Send Web Socket Data" onclick="send(this.form.message.value)"/>
+</form>
+</body>
+</html>


### PR DESCRIPTION
I had some hard times finding an example on how to enable websocket per-message deflate.
I've added an extra example highliting usage of WebSocketProtocolHandshakeHandler and PerMessageDeflateHandshake in this PR.