### PR TITLE
Catch and log Error on deployment.stop()

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -67,7 +67,7 @@ public interface UndertowServletLogger extends BasicLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 15005, value = "Error invoking method %s on listener %s")
-    void errorInvokingListener(final String method, Class<?> listenerClass, @Cause Exception e);
+    void errorInvokingListener(final String method, Class<?> listenerClass, @Cause Throwable t);
 
     @LogMessage(level = ERROR)
     @Message(id = 15006, value = "IOException dispatching async event")

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -119,7 +119,7 @@ public interface UndertowServletLogger extends BasicLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 15019, value = "Failed to destroy %s")
-    void failedToDestroy(Object object, @Cause Exception e);
+    void failedToDestroy(Object object, @Cause Throwable t);
 
     @LogMessage(level = WARN)
     @Message(id = 15020, value = "Path %s is secured for some HTTP methods, however it is not secured for %s")

--- a/servlet/src/main/java/io/undertow/servlet/core/ApplicationListeners.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ApplicationListeners.java
@@ -200,8 +200,8 @@ public class ApplicationListeners implements Lifecycle {
             ManagedListener listener = servletContextListeners[i];
             try {
                 this.<ServletContextListener>get(listener).contextDestroyed(event);
-            } catch (Exception e) {
-                UndertowServletLogger.REQUEST_LOGGER.errorInvokingListener("contextDestroyed", listener.getListenerInfo().getListenerClass(), e);
+            } catch (Throwable t) {
+                UndertowServletLogger.REQUEST_LOGGER.errorInvokingListener("contextDestroyed", listener.getListenerInfo().getListenerClass(), t);
             }
         }
     }

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -611,8 +611,8 @@ public class DeploymentManagerImpl implements DeploymentManager {
                     for (Lifecycle object : deployment.getLifecycleObjects()) {
                         try {
                             object.stop();
-                        } catch (Exception e) {
-                            UndertowServletLogger.ROOT_LOGGER.failedToDestroy(object, e);
+                        } catch (Throwable t) {
+                            UndertowServletLogger.ROOT_LOGGER.failedToDestroy(object, t);
                         }
                     }
                     deployment.getSessionManager().stop();

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -93,7 +93,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
-
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -666,7 +665,11 @@ public class DeploymentManagerImpl implements DeploymentManager {
                 @Override
                 public Void call(HttpServerExchange exchange, Object ignore) throws ServletException {
                     for(ServletContextListener listener : deployment.getDeploymentInfo().getDeploymentCompleteListeners()) {
-                        listener.contextDestroyed(new ServletContextEvent(deployment.getServletContext()));
+                        try {
+                            listener.contextDestroyed(new ServletContextEvent(deployment.getServletContext()));
+                        } catch (Throwable t) {
+                            UndertowServletLogger.REQUEST_LOGGER.failedToDestroy(listener, t);
+                        }
                     }
                     deployment.destroy();
                     deployment = null;

--- a/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
@@ -381,7 +381,11 @@ public class ManagedServlet implements Lifecycle {
 
                 @Override
                 public void release() {
-                    instance.destroy();
+                    try {
+                        instance.destroy();
+                    } catch (Throwable t) {
+                        UndertowServletLogger.REQUEST_LOGGER.failedToDestroy(instance, t);
+                    }
                     instanceHandle.release();
                 }
             };


### PR DESCRIPTION
Otherwise ClassNotFound and Linker errors prevent the server from
removing a deployment.