### PR TITLE
UNDERTOW-1368: SecureCookieHandler improvements

### DIFF
--- a/core/src/main/java/io/undertow/server/JvmRouteHandler.java
+++ b/core/src/main/java/io/undertow/server/JvmRouteHandler.java
@@ -67,12 +67,15 @@ public class JvmRouteHandler implements HttpHandler {
         @Override
         public StreamSinkConduit wrap(ConduitFactory<StreamSinkConduit> factory, HttpServerExchange exchange) {
 
-            Cookie sessionId = exchange.getResponseCookies().get(sessionCookieName);
-            if (sessionId != null) {
-                StringBuilder sb = new StringBuilder(sessionId.getValue());
-                sb.append('.');
-                sb.append(jvmRoute);
-                sessionId.setValue(sb.toString());
+            Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
+            if (cookies != null) {
+                Cookie sessionId = cookies.get(sessionCookieName);
+                if (sessionId != null) {
+                    StringBuilder sb = new StringBuilder(sessionId.getValue());
+                    sb.append('.');
+                    sb.append(jvmRoute);
+                    sessionId.setValue(sb.toString());
+                }
             }
             return factory.create();
         }

--- a/core/src/main/java/io/undertow/server/SecureCookieCommitListener.java
+++ b/core/src/main/java/io/undertow/server/SecureCookieCommitListener.java
@@ -1,0 +1,22 @@
+package io.undertow.server;
+
+import io.undertow.server.handlers.Cookie;
+
+import java.util.Map;
+
+/**
+ * Sets the <pre>secure</pre> attribute on all response cookies.
+ */
+public enum SecureCookieCommitListener implements ResponseCommitListener {
+    INSTANCE;
+
+    @Override
+    public void beforeCommit(HttpServerExchange exchange) {
+        Map<String, Cookie> cookies = exchange.getResponseCookiesInternal();
+        if (cookies != null) {
+            for (Map.Entry<String, Cookie> cookie : exchange.getResponseCookies().entrySet()) {
+                cookie.getValue().setSecure(true);
+            }
+        }
+    }
+}

--- a/core/src/main/java/io/undertow/server/handlers/SecureCookieHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SecureCookieHandler.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-import io.undertow.server.ResponseCommitListener;
+import io.undertow.server.SecureCookieCommitListener;
 import io.undertow.server.handlers.builder.HandlerBuilder;
 
 /**
@@ -49,14 +49,7 @@ public class SecureCookieHandler implements HttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
         if(exchange.isSecure()) {
-            exchange.addResponseCommitListener(new ResponseCommitListener() {
-                @Override
-                public void beforeCommit(HttpServerExchange exchange) {
-                    for(Map.Entry<String, Cookie> cookie : exchange.getResponseCookies().entrySet()) {
-                        cookie.getValue().setSecure(true);
-                    }
-                }
-            });
+            exchange.addResponseCommitListener(SecureCookieCommitListener.INSTANCE);
         }
         next.handleRequest(exchange);
     }


### PR DESCRIPTION
First commit is straightforward, the second attempts a bit more aggressively to avoid creating the mutable cookie map when we only need to read existing cookies.