### PR TITLE
Use next handler if exists.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
@@ -159,7 +159,13 @@ public class ResourceHandler implements HttpHandler {
             } else {
                 exchange.setStatusCode(StatusCodes.NOT_IMPLEMENTED);
             }
-            exchange.endExchange();
+
+            if ( this.next != null ) {
+                next.handleRequest(exchange)
+            }
+            else {
+                exchange.endExchange(); 
+            }
         }
     }
 


### PR DESCRIPTION
When this handler serves a request verb which is not a GET, POST or HEAD
It ends the exchange.

This PR offers a different approach, before ending the exchange, use the next handler in case it is set.
I guess I should be adding a unit test for this — But before I do that, I'd like to know WDYT?

