### PR TITLE
Add new rule to spotbugs-exclude.xml

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -186,6 +186,12 @@
                 <Class name="io.undertow.util.FlexBase64$Encoder"/>
                 <Method name="encodeString"/>
             </And>
+
+            <!-- Intentional not throwing exception -->
+            <And>
+                <Class name="io.undertow.protocols.alpn.JDK9AlpnProvider$1"/>
+                <Method name="run"/>
+            </And>
         </Or>
     </Match>
 


### PR DESCRIPTION
Commit 9ad4689ca756aef6bea8447559febc4496084c3e caused spotbugs failing with REC_CATCH_EXCEPTION.
Although introduced change is intentional, this commit adds an exclude rule to spotbugs to ignore this.
