### PR TITLE
Improve RequestDumpingHandler logging of request & response body

### DIFF
--- a/core/src/main/java/io/undertow/conduits/StoredRequestStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/StoredRequestStreamSinkConduit.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.conduits;
+
+import io.undertow.UndertowMessages;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
+import org.xnio.IoUtils;
+import org.xnio.channels.StreamSinkChannel;
+import org.xnio.conduits.AbstractStreamSourceConduit;
+import org.xnio.conduits.ConduitReadableByteChannel;
+import org.xnio.conduits.StreamSourceConduit;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * @author Farid Zakaria
+ */
+public class StoredRequestStreamSinkConduit extends AbstractStreamSourceConduit<StreamSourceConduit> {
+
+    public static final AttachmentKey<byte[]> REQUEST = AttachmentKey.create(byte[].class);
+
+    private final HttpServerExchange exchange;
+
+    private ByteArrayOutputStream outputStream;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param next the delegate conduit to set
+     */
+    public StoredRequestStreamSinkConduit(StreamSourceConduit next, HttpServerExchange exchange) {
+        super(next);
+        this.exchange = exchange;
+        long length = exchange.getResponseContentLength();
+        //Could be -1 if it is chunked transfer encoding
+        if (length <= 0L) {
+            outputStream = new ByteArrayOutputStream();
+        } else {
+            if (length > Integer.MAX_VALUE) {
+                throw UndertowMessages.MESSAGES.responseTooLargeToBuffer(length);
+            }
+            outputStream = new ByteArrayOutputStream((int) length);
+        }
+    }
+
+    @Override
+    public long transferTo(long position, long count, FileChannel target) throws IOException {
+        return target.transferFrom(new ConduitReadableByteChannel(this), position, count);
+    }
+
+    @Override
+    public long transferTo(long count, ByteBuffer throughBuffer, StreamSinkChannel target) throws IOException {
+        return IoUtils.transfer(new ConduitReadableByteChannel(this), count, throughBuffer, target);
+    }
+
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        int pos = dst.position();
+        int res = super.read(dst);
+        if (res > 0) {
+            byte[] d = new byte[res];
+            for (int i = 0; i < res; ++i) {
+                d[i] = dst.get(i + pos);
+            }
+            outputStream.write(d);
+        }
+
+        //Attach the request body once finished
+        if (res == -1) {
+            exchange.putAttachment(REQUEST, outputStream.toByteArray());
+            outputStream = null;
+        }
+
+        return res;
+    }
+
+    @Override
+    public long read(ByteBuffer[] dsts, int offs, int len) throws IOException {
+        for (int i = offs; i < len; ++i) {
+            if (dsts[i].hasRemaining()) {
+                return read(dsts[i]);
+            }
+        }
+        return 0;
+    }
+
+}

--- a/core/src/main/java/io/undertow/server/handlers/StoredRequestHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/StoredRequestHandler.java
@@ -1,0 +1,38 @@
+package io.undertow.server.handlers;
+
+import io.undertow.conduits.StoredRequestStreamSinkConduit;
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.ConduitFactory;
+import org.xnio.conduits.StreamSourceConduit;
+
+/**
+ * A handler that buffers the full response and attaches it to the exchange. This makes use of
+ * {@link io.undertow.conduits.StoredRequestStreamSinkConduit}
+ * <p>
+ * This will be made available once the request is fully complete, so should generally
+ * be read in an {@link io.undertow.server.ExchangeCompletionListener}
+ *
+ * @author Farid Zakaria
+ */
+public class StoredRequestHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    public StoredRequestHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        exchange.addRequestWrapper(new ConduitWrapper<StreamSourceConduit>() {
+            @Override
+            public StreamSourceConduit wrap(ConduitFactory<StreamSourceConduit> factory, HttpServerExchange exchange) {
+                return new StoredRequestStreamSinkConduit(factory.create(), exchange);
+            }
+        });
+        next.handleRequest(exchange);
+    }
+
+}

--- a/core/src/test/java/io/undertow/server/handlers/RequestDumpingTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RequestDumpingTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.util.DateUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Farid Zakaria
+ */
+@RunWith(DefaultServer.class)
+public class RequestDumpingTestCase {
+
+    private static class EchoHandler implements HttpHandler {
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            exchange.getRequestReceiver().receiveFullBytes((ex, body) -> {
+                //Just echo back the response as 200
+                ex.getResponseSender().send(ByteBuffer.wrap(body));
+            });
+        }
+    }
+
+    @BeforeClass
+    public static void setup() {
+        DefaultServer.setRootHandler(new RequestDumpingHandler(new EchoHandler(), true));
+    }
+
+    @Test
+    public void testDateHandler() throws IOException {
+        HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL() + "/path");
+        post.setEntity(new StringEntity("Hello world!"));
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpResponse result = client.execute(post);
+            String responseBody = HttpClientUtils.readResponse(result);
+            Assert.assertEquals("Hello world!", responseBody);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+
+}


### PR DESCRIPTION
Add the ability for RequestDumpingHandler to log the body of the request
& response.

Previous implementation relied on other handlers being set and would
only log the request body if it was a form. This commit makes the logic
work in all cases.