### PR TITLE
UNDERTOW-1386 multibytes language in URL request to ajp-listener are …

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -253,13 +253,13 @@ public class AjpRequestParser {
                     int colon = result.value.indexOf(';');
                     if (colon == -1) {
                         String res = decode(result.value, result.containsUrlCharacters);
-                        exchange.setRequestURI(result.value);
+                        exchange.setRequestURI(res);
                         exchange.setRequestPath(res);
                         exchange.setRelativePath(res);
                     } else {
                         final String url = result.value.substring(0, colon);
                         String res = decode(url, result.containsUrlCharacters);
-                        exchange.setRequestURI(result.value);
+                        exchange.setRequestURI(res);
                         exchange.setRequestPath(res);
                         exchange.setRelativePath(res);
                         try {

--- a/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
@@ -111,13 +111,14 @@ public class AjpParsingUnitTestCase {
         AjpRequestParseState state = new AjpRequestParseState();
         AJP_REQUEST_PARSER.parse(data, state, result);
         Assert.assertEquals("/hi", result.getRequestPath());
+        Assert.assertEquals("/hi", result.getRequestURI());
 
         data = createAjpRequest("/한글이름".getBytes(StandardCharsets.UTF_8));
         result = new HttpServerExchange(null);
         state = new AjpRequestParseState();
         AJP_REQUEST_PARSER.parse(data, state, result);
         Assert.assertEquals("/한글이름", result.getRequestPath());
-
+        Assert.assertEquals("/한글이름", result.getRequestURI());
 
     }
 


### PR DESCRIPTION
…broken in EAP access log.

https://issues.jboss.org/browse/UNDERTOW-1386