### PR TITLE
UNDERTOW-1404 Treat invalid query string via AJP as bad request

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -436,7 +436,7 @@ public class AjpRequestParser {
                         exchange.setQueryString(resultAsQueryString);
                         try {
                             URLUtils.parseQueryString(resultAsQueryString, exchange, encoding, doDecode && !decodingAlreadyDone, maxParameters);
-                        } catch (ParameterLimitException e) {
+                        } catch (ParameterLimitException | IllegalArgumentException e) {
                             UndertowLogger.REQUEST_IO_LOGGER.failedToParseRequest(e);
                             state.badRequest = true;
                         }

--- a/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/ajp/AjpParsingUnitTestCase.java
@@ -111,6 +111,7 @@ public class AjpParsingUnitTestCase {
         HttpServerExchange result = new HttpServerExchange(null);
         AjpRequestParseState state = new AjpRequestParseState();
         AJP_REQUEST_PARSER.parse(data, state, result);
+        Assert.assertFalse(state.badRequest);
         Assert.assertEquals("/hi", result.getRequestPath());
         Assert.assertEquals("/hi", result.getRequestURI());
         Assert.assertEquals("param=value", result.getQueryString());
@@ -120,9 +121,20 @@ public class AjpParsingUnitTestCase {
         result = new HttpServerExchange(null);
         state = new AjpRequestParseState();
         AJP_REQUEST_PARSER.parse(data, state, result);
+        Assert.assertFalse(state.badRequest);
         Assert.assertEquals("/한글이름", result.getRequestPath());
         Assert.assertEquals("/한글이름", result.getRequestURI());
         Assert.assertEquals("param=한글이름", result.getQueryString());
+    }
+
+    @Test
+    public void testInvalidQueryString() throws Exception {
+        ByteBuffer data = createAjpRequest("/hi".getBytes(StandardCharsets.UTF_8),
+                "param=value%http".getBytes(StandardCharsets.UTF_8));
+        HttpServerExchange result = new HttpServerExchange(null);
+        AjpRequestParseState state = new AjpRequestParseState();
+        AJP_REQUEST_PARSER.parse(data, state, result);
+        Assert.assertTrue(state.badRequest);
     }
 
     protected ByteBuffer createAjpRequest(byte[] path, byte[] query) {


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-1404
https://issues.jboss.org/browse/JBEAP-15134