### PR TITLE
UNDERTOW-1415: Cross-context calls (forward/include) do not update al…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/RequestDispatcherImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/RequestDispatcherImpl.java
@@ -140,8 +140,10 @@ public class RequestDispatcherImpl implements RequestDispatcher {
                 });
 
             } finally {
-                    servletRequestContext.setSession(oldSession);
-                    servletRequestContext.setCurrentServletContext(oldServletContext);
+                servletRequestContext.setSession(oldSession);
+                servletRequestContext.setCurrentServletContext(oldServletContext);
+                // update time in old context and run the requestDone for the session
+                servletRequestContext.getCurrentServletContext().updateSessionAccessTime(servletRequestContext.getExchange());
             }
         } else {
             forwardImpl(request, response, servletRequestContext);
@@ -304,6 +306,8 @@ public class RequestDispatcherImpl implements RequestDispatcher {
                     }
                 });
             } finally {
+                // update time in new context and run the requestDone for the session
+                servletRequestContext.getCurrentServletContext().updateSessionAccessTime(servletRequestContext.getExchange());
                 servletRequestContext.setSession(oldSession);
                 servletRequestContext.setCurrentServletContext(oldServletContext);
             }

--- a/servlet/src/test/java/io/undertow/servlet/test/session/LastAccessTimeSessionServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/session/LastAccessTimeSessionServlet.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.session;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+/**
+ * @author rmartinc
+ */
+public class LastAccessTimeSessionServlet extends HttpServlet {
+
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession();
+        resp.addHeader("url", resp.encodeURL(req.getRequestURL().toString()));
+        Integer value = (Integer)session.getAttribute("key");
+        if(value == null) {
+            value = 1;
+        }
+        session.setAttribute("key", value+1);
+        resp.getWriter().write("" + value + " " + session.getLastAccessedTime());
+        resp.getWriter().close();
+    }
+}


### PR DESCRIPTION
…l the session access times

I have added two tests to check that the accessed time is updated in both sessions (included/forwarded session and the outer one).