### PR TITLE
Add new rule to spotbugs-exclude.xml

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -254,6 +254,7 @@
             <Class name="io.undertow.servlet.api.LoginConfig"/>
             <Class name="io.undertow.servlet.api.FilterInfo"/>
             <Class name="io.undertow.servlet.api.ServletInfo"/>
+            <Class name="io.undertow.websockets.jsr.WebSocketDeploymentInfo"/>
         </Or>
     </Match>
 


### PR DESCRIPTION
Commit df65c01 caused spotbugs failing with CN_IDIOM_NO_SUPER_CALL.
Although introduced change is intentional, this commit adds an exclude rule to spotbugs to ignore this.