### PR TITLE
ConnectorStatisticsImpl reuses ByteActivityCallback instances

### DIFF
--- a/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
+++ b/core/src/main/java/io/undertow/server/ConnectorStatisticsImpl.java
@@ -77,6 +77,9 @@ public class ConnectorStatisticsImpl implements ConnectorStatistics {
         }
     };
 
+    private final ByteActivityCallback bytesSentAccumulator = new BytesSentAccumulator();
+    private final ByteActivityCallback bytesReceivedAccumulator = new BytesReceivedAccumulator();
+
     @Override
     public long getRequestCount() {
         return requestCountUpdater.get(this);
@@ -150,11 +153,11 @@ public class ConnectorStatisticsImpl implements ConnectorStatistics {
     }
 
     public ByteActivityCallback sentAccumulator() {
-        return new BytesSentAccumulator();
+        return bytesSentAccumulator;
     }
 
     public ByteActivityCallback receivedAccumulator() {
-        return new BytesReceivedAccumulator();
+        return bytesReceivedAccumulator;
     }
 
     //todo: we can do a way


### PR DESCRIPTION
It's unnecessary to create multiple instances because they
wrap state in the parent ConnectorStatisticsImpl.