### PR TITLE
[UNDERTOW-1426] Update of the spotbugs-maven-plugin to support checks…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
         <version.io.undertow.build.checkstyle-config>1.0.1.Final</version.io.undertow.build.checkstyle-config>
-        <version.com.github.spotbugs-maven-plugin>3.1.5</version.com.github.spotbugs-maven-plugin>
+        <version.com.github.spotbugs-maven-plugin>3.1.7</version.com.github.spotbugs-maven-plugin>
         <version.org.eclipse.jetty.alpn>1.1.3.v20160715</version.org.eclipse.jetty.alpn>
 
         <version.com.twitter.hpack>1.0.2</version.com.twitter.hpack>
@@ -350,7 +350,7 @@
                 <artifactId>apacheds-all</artifactId>
                 <version>${version.org.apache.directory.server}</version>
                 <scope>test</scope>
-            </dependency>            
+            </dependency>
 
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
@@ -483,6 +483,27 @@
                     <plugin>
                         <groupId>com.github.spotbugs</groupId>
                         <artifactId>spotbugs-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- Temporary profile to workaround issue described here https://github.com/spotbugs/spotbugs/issues/756. -->
+            <id>spotbugs-jdk11</id>
+            <activation>
+                <jdk>11</jdk>
+                <property>
+                    <name>findbugs</name> <!-- not modified just for compatibility reason -->
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
… with JDK11+.

 - update of the spotbugs-maven-plugin
 - introduced spotbugs profile not to fail on jdk11 as there are some false-positive
   errors, see https://github.com/spotbugs/spotbugs/issues/756

https://issues.jboss.org/browse/UNDERTOW-1426