### PR TITLE
Add a test + fix for adding an annotated Websocket endpoint programmatically

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/ServerWebSocketContainer.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/ServerWebSocketContainer.java
@@ -758,7 +758,13 @@ public class ServerWebSocketContainer implements ServerContainer, Closeable {
         }
         seenPaths.add(template);
         EncodingFactory encodingFactory = EncodingFactory.createFactory(classIntrospecter, endpoint.getDecoders(), endpoint.getEncoders());
-        ConfiguredServerEndpoint confguredServerEndpoint = new ConfiguredServerEndpoint(endpoint, null, template, encodingFactory);
+
+        AnnotatedEndpointFactory annotatedEndpointFactory = null;
+        if(!Endpoint.class.isAssignableFrom(endpoint.getEndpointClass())) {
+            // We may want to check that the path in @ServerEndpoint matches the specified path, and throw if they are not equivalent
+            annotatedEndpointFactory = AnnotatedEndpointFactory.create(endpoint.getEndpointClass(), encodingFactory, template.getParameterNames());
+        }
+        ConfiguredServerEndpoint confguredServerEndpoint = new ConfiguredServerEndpoint(endpoint, null, template, encodingFactory, annotatedEndpointFactory, endpoint.getExtensions());
         configuredServerEndpoints.add(confguredServerEndpoint);
         handleAddingFilterMapping();
     }

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedAddedProgrammaticallyEndpoint.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedAddedProgrammaticallyEndpoint.java
@@ -1,0 +1,19 @@
+package io.undertow.websockets.jsr.test.annotated;
+
+
+import javax.websocket.OnMessage;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+
+@ServerEndpoint(AnnotatedAddedProgrammaticallyEndpoint.PATH)
+public class AnnotatedAddedProgrammaticallyEndpoint {
+
+    static final String PATH = "/programmatic";
+
+    @OnMessage
+    public String handleMessage(String message, Session session) {
+        StringBuilder reversed = new StringBuilder(message);
+        reversed.reverse();
+        return reversed.toString();
+    }
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedEndpointTest.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/annotated/AnnotatedEndpointTest.java
@@ -25,6 +25,7 @@ import javax.websocket.ClientEndpoint;
 import javax.websocket.CloseReason;
 import javax.websocket.OnClose;
 import javax.websocket.Session;
+import javax.websocket.server.ServerEndpointConfig;
 
 import java.io.IOException;
 import java.net.URI;
@@ -38,7 +39,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.FutureResult;
-
 
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
@@ -100,6 +100,10 @@ public class AnnotatedEndpointTest {
                                         deployment = container;
                                     }
                                 })
+                                .addEndpoint(ServerEndpointConfig.Builder.create(
+                                        AnnotatedAddedProgrammaticallyEndpoint.class,
+                                        AnnotatedAddedProgrammaticallyEndpoint.PATH)
+                                        .build())
                 )
                 .addServlet(new ServletInfo("redirect", RedirectServlet.class)
                 .addMapping("/redirect"))
@@ -126,6 +130,18 @@ public class AnnotatedEndpointTest {
         WebSocketTestClient client = new WebSocketTestClient(WebSocketVersion.V13, new URI("ws://" + DefaultServer.getHostAddress("default") + ":" + DefaultServer.getHostPort("default") + "/ws/chat/Stuart"));
         client.connect();
         client.send(new TextWebSocketFrame(Unpooled.wrappedBuffer(payload)), new FrameChecker(TextWebSocketFrame.class, "hello Stuart".getBytes(), latch));
+        latch.getIoFuture().get();
+        client.destroy();
+    }
+
+    @Test
+    public void testStringOnMessageAddedProgramatically() throws Exception {
+        final byte[] payload = "foo".getBytes();
+        final FutureResult latch = new FutureResult();
+
+        WebSocketTestClient client = new WebSocketTestClient(WebSocketVersion.V13, new URI("ws://" + DefaultServer.getHostAddress("default") + ":" + DefaultServer.getHostPort("default") + "/ws/programmatic"));
+        client.connect();
+        client.send(new TextWebSocketFrame(Unpooled.wrappedBuffer(payload)), new FrameChecker(TextWebSocketFrame.class, "oof".getBytes(), latch));
         latch.getIoFuture().get();
         client.destroy();
     }
@@ -350,6 +366,7 @@ public class AnnotatedEndpointTest {
         session.close();
         Assert.assertEquals(0, expected.size());
     }
+
 
 
     @ClientEndpoint


### PR DESCRIPTION
The Javadoc for `ServerEndpointConfig` states that both Annotated + programmatic endpoints should be supported, though it doesn't seem to work with Undertow's implementation. The fix was fairly straightforward - if the endpoint does not extend from `Endpoint` then add the `AnnotatedEndpointFactory` to the final configuration, similar to when provided as the class-specifying method.