### PR TITLE
UNDERTOW-1387: Implement configurable executor shutdown timeout

### DIFF
--- a/core/src/main/java/io/undertow/Undertow.java
+++ b/core/src/main/java/io/undertow/Undertow.java
@@ -53,6 +53,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Convenience class used to build an Undertow server.
@@ -261,10 +262,18 @@ public final class Undertow {
          * Only shutdown the worker if it was created during start()
          */
         if (internalWorker && worker != null) {
+            Integer shutdownTimeoutMillis = serverOptions.get(UndertowOptions.SHUTDOWN_TIMEOUT);
             worker.shutdown();
             try {
-                worker.awaitTermination();
+                if (shutdownTimeoutMillis == null) {
+                    worker.awaitTermination();
+                } else {
+                    if (!worker.awaitTermination(shutdownTimeoutMillis, TimeUnit.MILLISECONDS)) {
+                        worker.shutdownNow();
+                    }
+                }
             } catch (InterruptedException e) {
+                worker.shutdownNow();
                 throw new RuntimeException(e);
             }
             worker = null;

--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -276,7 +276,7 @@ public class UndertowOptions {
     /**
      * The maximum number of concurrent requests that will be processed at a time. This differs from max concurrent streams in that it is not sent to the remote client.
      *
-     * If the number of pending requests exceeds this number then requests will be queued, the difference between this and max concurrent streams determins
+     * If the number of pending requests exceeds this number then requests will be queued, the difference between this and max concurrent streams determines
      * the maximum number of requests that will be queued.
      *
      * Queued requests are processed by a priority queue, rather than a FIFO based queue, using HTTP2 stream priority.
@@ -323,6 +323,14 @@ public class UndertowOptions {
 
 
     public static final Option<Boolean> ALLOW_UNESCAPED_CHARACTERS_IN_URL = Option.simple(UndertowOptions.class,"ALLOW_UNESCAPED_CHARACTERS_IN_URL", Boolean.class);
+
+    /**
+     * The server shutdown timeout in milliseconds after which the executor will be forcefully shut down interrupting
+     * tasks which are still executing.
+     *
+     * There is no timeout by default.
+     */
+    public static final Option<Integer> SHUTDOWN_TIMEOUT = Option.simple(UndertowOptions.class, "SHUTDOWN_TIMEOUT", Integer.class);
 
     private UndertowOptions() {
 


### PR DESCRIPTION
Cherry picked fix as this bug affects all spring relases from 1.5.12 and 2.0.2 onwards. 