### PR TITLE
UndertowOutputStream.write IoThread check uses exchange.isInIoThread

### DIFF
--- a/core/src/main/java/io/undertow/io/UndertowOutputStream.java
+++ b/core/src/main/java/io/undertow/io/UndertowOutputStream.java
@@ -112,7 +112,7 @@ public class UndertowOutputStream extends OutputStream implements BufferWritable
         if (len < 1) {
             return;
         }
-        if(Thread.currentThread() == exchange.getIoThread()) {
+        if (exchange.isInIoThread()) {
             throw UndertowMessages.MESSAGES.blockingIoFromIOThread();
         }
         if (anyAreSet(state, FLAG_CLOSED)) {


### PR DESCRIPTION
No need to re-implement the check inline.