### PR TITLE
UNDERTOW-1474 Fix file descriptor leaks while writing FormData

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/FormData.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/FormData.java
@@ -256,11 +256,14 @@ public final class FormData implements Iterable<String> {
             if (file != null) {
                 try {
                     Files.move(file, target);
+                    return;
                 } catch (IOException e) {
-                    Files.copy(getInputStream(), target);
+                    // ignore and let the Files.copy, outside
+                    // this if block, take over and attempt to copy it
                 }
-            } else {
-                Files.copy(getInputStream(), target);
+            }
+            try (InputStream is = getInputStream()) {
+                Files.copy(is, target);
             }
         }
     }


### PR DESCRIPTION
The commit here fixes a file descriptor leak in FormData while writing out the data to target file as noted in https://issues.jboss.org/browse/UNDERTOW-1474.

This either is the sole reason why the users are running into such leaks as noted in the linked forum thread https://developer.jboss.org/thread/278816 or at least one of the reasons.