### PR TITLE
Update URLDecodingHandler javadoc

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
@@ -36,7 +36,7 @@ import io.undertow.util.URLUtils;
 /**
  * A handler that will decode the URL and query parameters to the specified charset.
  * <p>
- * If you are using this handler you must set the {@link io.undertow.UndertowOptions#DECODE_URL} parameter to false.
+ * This handler will not have any effect unless the {@link io.undertow.UndertowOptions#DECODE_URL} parameter is set to false.
  * <p>
  * This is not as efficient as using the parsers built in UTF-8 decoder. Unless you need to decode to something other
  * than UTF-8 you should rely on the parsers decoding instead.


### PR DESCRIPTION
If DECODE_URL is set to the default value, the URLDecodingHandler
will not cause problems, it jut won't do additional decoding.