### PR TITLE
add %o: obfuscated remote IP address, removing the

### DIFF
--- a/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.attribute;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.NetworkUtils;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * The remote IP address
+ *
+ * @author Stuart Douglas
+ */
+public class RemoteObfuscatedIPAttribute implements ExchangeAttribute {
+
+    public static final String REMOTE_OBFUSCATED_IP_SHORT = "%o";
+    public static final String REMOTE_OBFUSCATED_IP = "%{REMOTE_OBFUSCATED_IP}";
+
+    public static final ExchangeAttribute INSTANCE = new RemoteObfuscatedIPAttribute();
+
+    private RemoteObfuscatedIPAttribute() {
+
+    }
+
+    @Override
+    public String readAttribute(final HttpServerExchange exchange) {
+        final InetSocketAddress sourceAddress = exchange.getSourceAddress();
+        InetAddress address = sourceAddress.getAddress();
+        if (address == null) {
+            //this can happen when we have an unresolved X-forwarded-for address
+            //in this case we just return the IP of the balancer
+            address = ((InetSocketAddress) exchange.getConnection().getPeerAddress()).getAddress();
+        }
+        if(address == null) {
+            return null;
+        }
+        return NetworkUtils.toObfuscatedString(address);
+    }
+
+    @Override
+    public void writeAttribute(final HttpServerExchange exchange, final String newValue) throws ReadOnlyAttributeException {
+        throw new ReadOnlyAttributeException("Remote Obfuscated IP", newValue);
+    }
+
+    public static final class Builder implements ExchangeAttributeBuilder {
+
+        @Override
+        public String name() {
+            return "Remote Obfuscated IP";
+        }
+
+        @Override
+        public ExchangeAttribute build(final String token) {
+            if (token.equals(REMOTE_OBFUSCATED_IP) || token.equals(REMOTE_OBFUSCATED_IP_SHORT)) {
+                return RemoteObfuscatedIPAttribute.INSTANCE;
+            }
+            return null;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+    }
+}

--- a/core/src/main/java/io/undertow/util/NetworkUtils.java
+++ b/core/src/main/java/io/undertow/util/NetworkUtils.java
@@ -21,6 +21,7 @@ package io.undertow.util;
 import io.undertow.UndertowMessages;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 
 /**
@@ -102,6 +103,19 @@ public class NetworkUtils {
         return InetAddress.getByAddress(data);
     }
 
+    public static String toObfuscatedString(InetAddress address) {
+        if (address == null) {
+            return null;
+        }
+        String s = address.getHostAddress();
+        if (address instanceof Inet4Address) {
+            // IPv4 addresses: cut off last byte 
+            return s.substring(0, s.lastIndexOf(".")+1);
+        }
+        // IPv6 addresses: cut off at second colon
+        return s.substring(0, s.indexOf(":", s.indexOf(":")+1)+1);
+    }
+    
     private NetworkUtils() {
 
     }

--- a/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
+++ b/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
@@ -1,0 +1,37 @@
+package io.undertow.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * verifies that the proxy protocol ip address parser correctly parses IP addresses as per the additional requirements
+ * in the proxy protocol spec
+ *
+ * @author Stuart Douglas
+ */
+public class NetworkUtilsAddressObfuscationTestCase {
+
+    private static String cvt(String input) throws UnknownHostException {
+        return NetworkUtils.toObfuscatedString(InetAddress.getByName(input));
+    }
+    
+    @Test
+    public void testIpV4Address() throws IOException {
+        Assert.assertEquals("1.123.255.", cvt("1.123.255.2"));
+        Assert.assertEquals("127.0.0.", cvt("127.0.0.1"));
+        Assert.assertEquals("0.0.0.", cvt("0.0.0.0"));
+    }
+
+    @Test
+    public void testIpv6Address() throws IOException {
+        Assert.assertEquals("2001:1db8:", cvt("2001:1db8:100:3:6:ff00:42:8329"));
+        Assert.assertEquals("2001:1db8:", cvt("2001:1db8:100::6:ff00:42:8329"));
+        Assert.assertEquals("0:0:", cvt("::1"));
+    }
+}


### PR DESCRIPTION
add %o: obfuscated remote IP address, removing the
last IPv4 byte or anything after the second colon (IPv6),
ie. "1.2.3." or "fe08:2:"

Needed for data privacy laws in the EU.

Tell me if I should change the @author tags. I dont care about copyright/license.