### PR TITLE
add %o: obfuscated remote IP address

### DIFF
--- a/core/src/main/java/io/undertow/attribute/ExchangeAttributes.java
+++ b/core/src/main/java/io/undertow/attribute/ExchangeAttributes.java
@@ -75,6 +75,10 @@ public class ExchangeAttributes {
         return RemoteIPAttribute.INSTANCE;
     }
 
+    public static ExchangeAttribute remoteObfuscatedIp() {
+        return RemoteObfuscatedIPAttribute.INSTANCE;
+    }
+
     public static ExchangeAttribute remoteUser() {
         return RemoteUserAttribute.INSTANCE;
     }

--- a/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2019 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/RemoteObfuscatedIPAttribute.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.attribute;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.NetworkUtils;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+/**
+ * The remote IP address
+ *
+ * @author Stuart Douglas
+ */
+public class RemoteObfuscatedIPAttribute implements ExchangeAttribute {
+
+    public static final String REMOTE_OBFUSCATED_IP_SHORT = "%o";
+    public static final String REMOTE_OBFUSCATED_IP = "%{REMOTE_OBFUSCATED_IP}";
+
+    public static final ExchangeAttribute INSTANCE = new RemoteObfuscatedIPAttribute();
+
+    private RemoteObfuscatedIPAttribute() {
+
+    }
+
+    @Override
+    public String readAttribute(final HttpServerExchange exchange) {
+        final InetSocketAddress sourceAddress = exchange.getSourceAddress();
+        InetAddress address = sourceAddress.getAddress();
+        if (address == null) {
+            //this can happen when we have an unresolved X-forwarded-for address
+            //in this case we just return the IP of the balancer
+            address = ((InetSocketAddress) exchange.getConnection().getPeerAddress()).getAddress();
+        }
+        if(address == null) {
+            return null;
+        }
+        return NetworkUtils.toObfuscatedString(address);
+    }
+
+    @Override
+    public void writeAttribute(final HttpServerExchange exchange, final String newValue) throws ReadOnlyAttributeException {
+        throw new ReadOnlyAttributeException("Remote Obfuscated IP", newValue);
+    }
+
+    public static final class Builder implements ExchangeAttributeBuilder {
+
+        @Override
+        public String name() {
+            return "Remote Obfuscated IP";
+        }
+
+        @Override
+        public ExchangeAttribute build(final String token) {
+            if (token.equals(REMOTE_OBFUSCATED_IP) || token.equals(REMOTE_OBFUSCATED_IP_SHORT)) {
+                return RemoteObfuscatedIPAttribute.INSTANCE;
+            }
+            return null;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+    }
+}

--- a/core/src/main/java/io/undertow/server/handlers/accesslog/AccessLogHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/accesslog/AccessLogHandler.java
@@ -54,6 +54,8 @@ import io.undertow.server.handlers.builder.HandlerBuilder;
  * <li><b>%H</b> - Request protocol
  * <li><b>%l</b> - Remote logical username from identd (always returns '-')
  * <li><b>%m</b> - Request method
+ * <li><b>%o</b> - Obfuscated remote IP address (IPv4: last byte removed,
+ * IPv6: cut off after second colon, ie. '1.2.3.' or 'fe08:44:')
  * <li><b>%p</b> - Local port
  * <li><b>%q</b> - Query string (excluding the '?' character)
  * <li><b>%r</b> - First line of the request
@@ -72,6 +74,9 @@ import io.undertow.server.handlers.builder.HandlerBuilder;
  * <li><b>common</b> - <code>%h %l %u %t "%r" %s %b</code>
  * <li><b>combined</b> -
  * <code>%h %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"</code>
+ * <li><b>commonobf</b> - <code>%o %l %u %t "%r" %s %b</code>
+ * <li><b>combinedobf</b> -
+ * <code>%o %l %u %t "%r" %s %b "%{i,Referer}" "%{i,User-Agent}"</code>
  * </ul>
  * <p>
  * <p>
@@ -128,6 +133,10 @@ public class AccessLogHandler implements HttpHandler {
             return "%h %l %u %t \"%r\" %s %b";
         } else if (formatString.equals("combined")) {
             return "%h %l %u %t \"%r\" %s %b \"%{i,Referer}\" \"%{i,User-Agent}\"";
+        } else if(formatString.equals("commonobf")) {
+            return "%o %l %u %t \"%r\" %s %b";
+        } else if (formatString.equals("combinedobf")) {
+            return "%o %l %u %t \"%r\" %s %b \"%{i,Referer}\" \"%{i,User-Agent}\"";
         }
         return formatString;
     }

--- a/core/src/main/java/io/undertow/util/NetworkUtils.java
+++ b/core/src/main/java/io/undertow/util/NetworkUtils.java
@@ -21,6 +21,7 @@ package io.undertow.util;
 import io.undertow.UndertowMessages;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 
 /**
@@ -100,6 +101,19 @@ public class NetworkUtils {
             throw UndertowMessages.MESSAGES.invalidIpAddress(addressString);
         }
         return InetAddress.getByAddress(data);
+    }
+
+    public static String toObfuscatedString(InetAddress address) {
+        if (address == null) {
+            return null;
+        }
+        String s = address.getHostAddress();
+        if (address instanceof Inet4Address) {
+            // IPv4 addresses: cut off last byte
+            return s.substring(0, s.lastIndexOf(".")+1);
+        }
+        // IPv6 addresses: cut off at second colon
+        return s.substring(0, s.indexOf(":", s.indexOf(":")+1)+1);
     }
 
     private NetworkUtils() {

--- a/core/src/main/resources/META-INF/services/io.undertow.attribute.ExchangeAttributeBuilder
+++ b/core/src/main/resources/META-INF/services/io.undertow.attribute.ExchangeAttributeBuilder
@@ -35,3 +35,4 @@ io.undertow.attribute.ResolvedPathAttribute$Builder
 io.undertow.attribute.NullAttribute$Builder
 io.undertow.attribute.StoredResponse$Builder
 io.undertow.attribute.ResponseReasonPhraseAttribute$Builder
+io.undertow.attribute.RemoteObfuscatedIPAttribute$Builder

--- a/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
+++ b/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
@@ -1,0 +1,35 @@
+package io.undertow.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * verifies that the proxy protocol ip address parser correctly parses IP addresses as per the additional requirements
+ * in the proxy protocol spec
+ *
+ * @author Stuart Douglas
+ */
+public class NetworkUtilsAddressObfuscationTestCase {
+
+    private static String cvt(String input) throws UnknownHostException {
+        return NetworkUtils.toObfuscatedString(InetAddress.getByName(input));
+    }
+
+    @Test
+    public void testIpV4Address() throws IOException {
+        Assert.assertEquals("1.123.255.", cvt("1.123.255.2"));
+        Assert.assertEquals("127.0.0.", cvt("127.0.0.1"));
+        Assert.assertEquals("0.0.0.", cvt("0.0.0.0"));
+    }
+
+    @Test
+    public void testIpv6Address() throws IOException {
+        Assert.assertEquals("2001:1db8:", cvt("2001:1db8:100:3:6:ff00:42:8329"));
+        Assert.assertEquals("2001:1db8:", cvt("2001:1db8:100::6:ff00:42:8329"));
+        Assert.assertEquals("0:0:", cvt("::1"));
+    }
+}

--- a/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
+++ b/core/src/test/java/io/undertow/util/NetworkUtilsAddressObfuscationTestCase.java
@@ -1,3 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package io.undertow.util;
 
 import org.junit.Assert;


### PR DESCRIPTION
add %o: obfuscated remote IP address, removing the
last IPv4 byte or anything after the second colon (IPv6),
ie. "1.2.3." or "fe08:2:"

Also added the log patterns commonobf and combinedobf where instead of the remote host the obfuscated remote IP gets logged.

Purpose: better support for data privacy laws in the EU.

Tested against WildFly 15.0.1.