### PR TITLE
Make RequestLimit safer

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/RequestLimit.java
+++ b/core/src/main/java/io/undertow/server/handlers/RequestLimit.java
@@ -18,6 +18,7 @@
 
 package io.undertow.server.handlers;
 
+import io.undertow.UndertowLogger;
 import io.undertow.server.Connectors;
 import io.undertow.server.ExchangeCompletionListener;
 import io.undertow.server.HttpHandler;
@@ -62,19 +63,24 @@ public class RequestLimit {
 
         @Override
         public void exchangeEvent(final HttpServerExchange exchange, final NextListener nextListener) {
-            try {
-                synchronized (RequestLimit.this) {
-                    final SuspendedRequest task = queue.poll();
-                    if (task != null) {
-                        task.exchange.addExchangeCompleteListener(COMPLETION_LISTENER);
-                        task.exchange.dispatch(task.next);
-                    } else {
-                        decrementRequests();
-                    }
+            SuspendedRequest task = null;
+            boolean found = false;
+            while ((task = queue.poll()) != null) {
+                try {
+                    task.exchange.addExchangeCompleteListener(COMPLETION_LISTENER);
+                    task.exchange.dispatch(task.next);
+                    found = true;
+                    break;
+                } catch (Throwable e) {
+                    UndertowLogger.ROOT_LOGGER.error("Suspended request was skipped", e);
                 }
-            } finally {
-                nextListener.proceed();
             }
+        
+            if (!found) {
+                decrementRequests();
+            }
+            
+            nextListener.proceed();
         }
     };
 

--- a/core/src/main/java/io/undertow/server/handlers/RequestLimit.java
+++ b/core/src/main/java/io/undertow/server/handlers/RequestLimit.java
@@ -75,11 +75,11 @@ public class RequestLimit {
                     UndertowLogger.ROOT_LOGGER.error("Suspended request was skipped", e);
                 }
             }
-        
+
             if (!found) {
                 decrementRequests();
             }
-            
+
             nextListener.proceed();
         }
     };


### PR DESCRIPTION
This two lines can throw exceptions in RequestLimit:

```java
task.exchange.addExchangeCompleteListener(COMPLETION_LISTENER);
task.exchange.dispatch(task.next);
```

There is a `finally` for calling the next listener, however `decrementRequests()` isn't in it. In case of an error the currently polled exchange will be skipped while `decrementRequests()` is also not called: oops, we lost a thread! At a larger workload we lose all the threads, sooner or later. We solved the problem with the change contained by this pull request.

The most common exception we experienced is this (this stack is from 1.4.18, but the problem still exists with 2.x):

```
java.lang.IllegalStateException: UT000139: Exchange already complete
        at io.undertow.server.HttpServerExchange.addExchangeCompleteListener(HttpServerExchange.java:923)
        at io.undertow.server.handlers.RequestLimit$2.exchangeEvent(RequestLimit.java:92)
        at io.undertow.server.HttpServerExchange$ExchangeCompleteNextListener.proceed(HttpServerExchange.java:1845)
        at io.undertow.server.handlers.proxy.ProxyHandler$2.exchangeEvent(ProxyHandler.java:196)
        at io.undertow.server.HttpServerExchange$ExchangeCompleteNextListener.proceed(HttpServerExchange.java:1845)
        at io.undertow.server.handlers.proxy.ProxyConnectionPool$3.exchangeEvent(ProxyConnectionPool.java:332)
        at io.undertow.server.HttpServerExchange.invokeExchangeCompleteListeners(HttpServerExchange.java:1258)
        at io.undertow.server.HttpServerExchange.terminateResponse(HttpServerExchange.java:1538)
        at io.undertow.server.Connectors.terminateResponse(Connectors.java:143)
        at io.undertow.server.protocol.http.ServerFixedLengthStreamSinkConduit.channelFinished(ServerFixedLengthStreamSinkConduit.java:56)
        at io.undertow.conduits.AbstractFixedLengthStreamSinkConduit.exitFlush(AbstractFixedLengthStreamSinkConduit.java:316)
        at io.undertow.conduits.AbstractFixedLengthStreamSinkConduit.flush(AbstractFixedLengthStreamSinkConduit.java:234)
        at org.xnio.conduits.AbstractSinkConduit.flush(AbstractSinkConduit.java:86)
        at org.xnio.conduits.ConduitStreamSinkChannel.flush(ConduitStreamSinkChannel.java:162)
        at io.undertow.channels.DetachableStreamSinkChannel.flush(DetachableStreamSinkChannel.java:119)
        at io.undertow.io.AsyncSenderImpl.close(AsyncSenderImpl.java:338)
        at io.undertow.io.DefaultIoCallback.onComplete(DefaultIoCallback.java:54)
        at io.undertow.io.AsyncSenderImpl.invokeOnComplete(AsyncSenderImpl.java:396)
        at io.undertow.io.AsyncSenderImpl.send(AsyncSenderImpl.java:233)
        at io.undertow.io.AsyncSenderImpl.send(AsyncSenderImpl.java:310)
        at io.undertow.io.AsyncSenderImpl.send(AsyncSenderImpl.java:282)
        at io.undertow.io.AsyncSenderImpl.send(AsyncSenderImpl.java:316)
        ...
```