### PR TITLE
Make FormParserFactory builder more fluent

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/FormParserFactory.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/FormParserFactory.java
@@ -113,12 +113,28 @@ public class FormParserFactory {
             this.parsers = parsers;
         }
 
+        /**
+         * A chainable version of {@link #setParsers}.
+         */
+        public Builder withParsers(List<ParserDefinition> parsers) {
+            setParsers(parsers);
+            return this;
+        }
+
         public String getDefaultCharset() {
             return defaultCharset;
         }
 
         public void setDefaultCharset(String defaultCharset) {
             this.defaultCharset = defaultCharset;
+        }
+
+        /**
+         * A chainable version of {@link #setDefaultCharset}.
+         */
+        public Builder withDefaultCharset(String defaultCharset) {
+            setDefaultCharset(defaultCharset);
+            return this;
         }
 
         public FormParserFactory build() {


### PR DESCRIPTION
A non-breaking change that makes the FormParserFactory.Builder methods chainable.