### PR TITLE
Included getUnsafe in try/catch to make it work with Java 11+

### DIFF
--- a/core/src/main/java/io/undertow/server/DirectByteBufferDeallocator.java
+++ b/core/src/main/java/io/undertow/server/DirectByteBufferDeallocator.java
@@ -43,8 +43,8 @@ public final class DirectByteBufferDeallocator {
                 supported = false;
             }
         } else {
-            tmpUnsafe = getUnsafe();
             try {
+                tmpUnsafe = getUnsafe();
                 tmpCleanerClean = tmpUnsafe.getClass().getDeclaredMethod("invokeCleaner", ByteBuffer.class);
                 tmpCleanerClean.setAccessible(true);
                 supported = true;


### PR DESCRIPTION
On Java 11.0.2 there was an exception during Unsafe retrieval.
With this patch, there is still exception printed: UndertowLogger.ROOT_LOGGER.directBufferDeallocatorInitializationFailed(t);
but supported flag is set to false and everything works as intended.

`java.lang.ExceptionInInitializerError: null
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.queueIfUnderMax(DefaultByteBufferPool.java:209)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.freeInternal(DefaultByteBufferPool.java:201)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.access$200(DefaultByteBufferPool.java:40)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool$DefaultPooledBuffer.close(DefaultByteBufferPool.java:271)
	at undertow.core@2.0.19.Final/io.undertow.protocols.ssl.SslConduit.doUnwrap(SslConduit.java:843)
	at undertow.core@2.0.19.Final/io.undertow.protocols.ssl.SslConduit.read(SslConduit.java:567)
	at xnio.api@3.3.8.Final/org.xnio.conduits.AbstractStreamSourceConduit.read(AbstractStreamSourceConduit.java:51)
	at undertow.core@2.0.19.Final/io.undertow.conduits.ReadDataStreamSourceConduit.read(ReadDataStreamSourceConduit.java:67)
	at undertow.core@2.0.19.Final/io.undertow.conduits.FixedLengthStreamSourceConduit.read(FixedLengthStreamSourceConduit.java:244)
	at xnio.api@3.3.8.Final/org.xnio.conduits.ConduitStreamSourceChannel.read(ConduitStreamSourceChannel.java:127)
	at undertow.core@2.0.19.Final/io.undertow.channels.DetachableStreamSourceChannel.read(DetachableStreamSourceChannel.java:209)
	at undertow.core@2.0.19.Final/io.undertow.server.HttpServerExchange$ReadDispatchChannel.read(HttpServerExchange.java:2341)
	at undertow.core@2.0.19.Final/io.undertow.server.handlers.form.FormEncodedDataDefinition$FormEncodedDataParser.doParse(FormEncodedDataDefinition.java:134)
	at undertow.core@2.0.19.Final/io.undertow.server.handlers.form.FormEncodedDataDefinition$FormEncodedDataParser.parseBlocking(FormEncodedDataDefinition.java:252)
	at ...
undertow.core@2.0.19.Final/io.undertow.server.Connectors.executeRootHandler(Connectors.java:364)
	at undertow.core@2.0.19.Final/io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.RuntimeException: JDK did not allow accessing unsafe
	at undertow.core@2.0.19.Final/io.undertow.server.DirectByteBufferDeallocator.getUnsafe0(DirectByteBufferDeallocator.java:106)
	at undertow.core@2.0.19.Final/io.undertow.server.DirectByteBufferDeallocator.getUnsafe(DirectByteBufferDeallocator.java:97)
	at undertow.core@2.0.19.Final/io.undertow.server.DirectByteBufferDeallocator.<clinit>(DirectByteBufferDeallocator.java:46)
	... 20 common frames omitted
Caused by: java.lang.NoClassDefFoundError: sun/misc/Unsafe
	at undertow.core@2.0.19.Final/io.undertow.server.DirectByteBufferDeallocator.getUnsafe0(DirectByteBufferDeallocator.java:102)
	... 22 common frames omitted
Caused by: java.lang.ClassNotFoundException: sun.misc.Unsafe
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 23 common frames omitted
2019-02-25T14:54:53.060 ERROR [XNIO-1 task-8] io.undertow.request - UT005071: Undertow request failed
java.lang.NoClassDefFoundError: Could not initialize class io.undertow.server.DirectByteBufferDeallocator
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.queueIfUnderMax(DefaultByteBufferPool.java:209)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.freeInternal(DefaultByteBufferPool.java:201)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool.access$200(DefaultByteBufferPool.java:40)
	at undertow.core@2.0.19.Final/io.undertow.server.DefaultByteBufferPool$DefaultPooledBuffer.close(DefaultByteBufferPool.java:271)
	at undertow.core@2.0.19.Final/io.undertow.protocols.ssl.SslConduit.doUnwrap(SslConduit.java:843)
	at undertow.core@2.0.19.Final/io.undertow.protocols.ssl.SslConduit.read(SslConduit.java:567)
	at xnio.api@3.3.8.Final/org.xnio.conduits.AbstractStreamSourceConduit.read(AbstractStreamSourceConduit.java:51)
	at undertow.core@2.0.19.Final/io.undertow.conduits.ReadDataStreamSourceConduit.read(ReadDataStreamSourceConduit.java:67)
	at undertow.core@2.0.19.Final/io.undertow.conduits.FixedLengthStreamSourceConduit.read(FixedLengthStreamSourceConduit.java:244)
	at xnio.api@3.3.8.Final/org.xnio.conduits.ConduitStreamSourceChannel.read(ConduitStreamSourceChannel.java:127)
	at undertow.core@2.0.19.Final/io.undertow.channels.DetachableStreamSourceChannel.read(DetachableStreamSourceChannel.java:209)
	at undertow.core@2.0.19.Final/io.undertow.server.HttpServerExchange$ReadDispatchChannel.read(HttpServerExchange.java:2341)
	at undertow.core@2.0.19.Final/io.undertow.server.handlers.form.FormEncodedDataDefinition$FormEncodedDataParser.doParse(FormEncodedDataDefinition.java:134)
	at undertow.core@2.0.19.Final/io.undertow.server.handlers.form.FormEncodedDataDefinition$FormEncodedDataParser.parseBlocking(FormEncodedDataDefinition.java:252)
	at ...
	at undertow.core@2.0.19.Final/io.undertow.server.Connectors.executeRootHandler(Connectors.java:364)
	at undertow.core@2.0.19.Final/io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
`