### PR TITLE
Fix Javadoc errors

### DIFF
--- a/core/src/main/java/io/undertow/Undertow.java
+++ b/core/src/main/java/io/undertow/Undertow.java
@@ -558,7 +558,7 @@ public final class Undertow {
          * to the various worker-related configuration (ioThreads, workerThreads, workerOptions)
          * when {@link Undertow#start()} is called.
          * Additionally, this newly created worker will be shutdown when {@link Undertow#stop()} is called.
-         * <br/>
+         * <br>
          * <p>
          * When non-null, the provided {@link XnioWorker} will be reused instead of creating a new {@link XnioWorker}
          * when {@link Undertow#start()} is called.

--- a/core/src/main/java/io/undertow/client/http/ResponseParseState.java
+++ b/core/src/main/java/io/undertow/client/http/ResponseParseState.java
@@ -67,10 +67,10 @@ class ResponseParseState {
 
     /**
      * This has different meanings depending on the current state.
-     * <p/>
+     * <p>
      * In state {@link #HEADER} it is a the first character of the header, that was read by
      * {@link #HEADER_VALUE} to see if this was a continuation.
-     * <p/>
+     * <p>
      * In state {@link #HEADER_VALUE} if represents the last character that was seen.
      */
     byte leftOver;

--- a/core/src/main/java/io/undertow/protocols/http2/HPackHuffman.java
+++ b/core/src/main/java/io/undertow/protocols/http2/HPackHuffman.java
@@ -34,7 +34,7 @@ public class HPackHuffman {
 
     /**
      * array based tree representation of a huffman code.
-     * <p/>
+     * <p>
      * the high two bytes corresponds to the tree node if the bit is set, and the low two bytes for if it is clear
      * if the high bit is set it is a terminal node, otherwise it contains the next node position.
      */

--- a/core/src/main/java/io/undertow/protocols/http2/Hpack.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Hpack.java
@@ -140,7 +140,7 @@ final class Hpack {
      * Decodes an integer in the HPACK prefex format. If the return value is -1
      * it means that there was not enough data in the buffer to complete the decoding
      * sequence.
-     * <p/>
+     * <p>
      * If this method returns -1 then the source buffer will not have been modified.
      *
      * @param source The buffer that contains the integer
@@ -188,7 +188,7 @@ final class Hpack {
 
     /**
      * Encodes an integer in the HPACK prefix format.
-     * <p/>
+     * <p>
      * This method assumes that the buffer has already had the first 8-n bits filled.
      * As such it will modify the last byte that is already present in the buffer, and
      * potentially add more if required

--- a/core/src/main/java/io/undertow/protocols/http2/HpackDecoder.java
+++ b/core/src/main/java/io/undertow/protocols/http2/HpackDecoder.java
@@ -298,7 +298,7 @@ public class HpackDecoder {
     /**
      * because we use a ring buffer type construct, and don't actually shuffle
      * items in the array, we need to figure out he real index to use.
-     * <p/>
+     * <p>
      * package private for unit tests
      *
      * @param index The index from the hpack

--- a/core/src/main/java/io/undertow/protocols/http2/Http2GoAwayStreamSinkChannel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2GoAwayStreamSinkChannel.java
@@ -25,7 +25,7 @@ import io.undertow.util.ImmediatePooledByteBuffer;
 
 /**
  * The go away
- * <p/>
+ * <p>
  * TODO: at the moment we don't allow the additional debug data
  *
  * @author Stuart Douglas

--- a/core/src/main/java/io/undertow/protocols/http2/Http2NoDataStreamSinkChannel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2NoDataStreamSinkChannel.java
@@ -28,7 +28,7 @@ import io.undertow.UndertowMessages;
 /**
  * Stream sink channel that serves as the basis for channels that do not have the ability
  * to write data.
- * <p/>
+ * <p>
  * In particular these are:
  * - PING
  * - GO_AWAY

--- a/core/src/main/java/io/undertow/security/handlers/SecurityInitialHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/SecurityInitialHandler.java
@@ -66,7 +66,7 @@ public class SecurityInitialHandler extends AbstractSecurityContextAssociationHa
     }
 
     /**
-     * @see io.undertow.security.handlers.AbstractSecurityContextAssociationHandler#createSecurityContext()
+     * @see io.undertow.security.handlers.AbstractSecurityContextAssociationHandler#createSecurityContext
      */
     @Override
     public SecurityContext createSecurityContext(final HttpServerExchange exchange) {

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -1762,18 +1762,18 @@ public final class HttpServerExchange extends AbstractAttachable {
     /**
      * Transmit the response headers. After this method successfully returns,
      * the response channel may become writable.
-     * <p/>
+     * <p>
      * If this method fails the request and response channels will be closed.
-     * <p/>
+     * <p>
      * This method runs asynchronously. If the channel is writable it will
      * attempt to write as much of the response header as possible, and then
      * queue the rest in a listener and return.
-     * <p/>
+     * <p>
      * If future handlers in the chain attempt to write before this is finished
      * XNIO will just magically sort it out so it works. This is not actually
      * implemented yet, so we just terminate the connection straight away at
      * the moment.
-     * <p/>
+     * <p>
      * TODO: make this work properly
      *
      * @throws IllegalStateException if the response headers were already sent
@@ -1939,10 +1939,10 @@ public final class HttpServerExchange extends AbstractAttachable {
 
     /**
      * Channel implementation that is actually provided to clients of the exchange.
-     * <p/>
+     * <p>
      * We do not provide the underlying conduit channel, as this is shared between requests, so we need to make sure that after this request
      * is done the the channel cannot affect the next request.
-     * <p/>
+     * <p>
      * It also delays a wakeup/resumesWrites calls until the current call stack has returned, thus ensuring that only 1 thread is
      * active in the exchange at any one time.
      */
@@ -2110,10 +2110,10 @@ public final class HttpServerExchange extends AbstractAttachable {
      * Channel implementation that is actually provided to clients of the exchange. We do not provide the underlying
      * conduit channel, as this will become the next requests conduit channel, so if a thread is still hanging onto this
      * exchange it can result in problems.
-     * <p/>
+     * <p>
      * It also delays a readResume call until the current call stack has returned, thus ensuring that only 1 thread is
      * active in the exchange at any one time.
-     * <p/>
+     * <p>
      * It also handles buffered request data.
      */
     private final class ReadDispatchChannel extends DetachableStreamSourceChannel implements StreamSourceChannel {

--- a/core/src/main/java/io/undertow/server/handlers/JDBCLogHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/JDBCLogHandler.java
@@ -259,7 +259,7 @@ public class JDBCLogHandler implements HttpHandler, Runnable {
 
     /**
      * For tests only. Blocks the current thread until all messages are written Just does a busy wait.
-     * <p/>
+     * <p>
      * DO NOT USE THIS OUTSIDE OF A TEST
      */
     void awaitWrittenForTest() throws InterruptedException {

--- a/core/src/main/java/io/undertow/server/handlers/accesslog/DefaultAccessLogReceiver.java
+++ b/core/src/main/java/io/undertow/server/handlers/accesslog/DefaultAccessLogReceiver.java
@@ -42,7 +42,7 @@ import io.undertow.UndertowLogger;
 /**
  * Log Receiver that stores logs in a directory under the specified file name, and rotates them after
  * midnight.
- * <p/>
+ * <p>
  * Web threads do not touch the log file, but simply queue messages to be written later by a worker thread.
  * A lightweight CAS based locking mechanism is used to ensure than only 1 thread is active writing messages at
  * any given time
@@ -212,7 +212,7 @@ public class DefaultAccessLogReceiver implements AccessLogReceiver, Runnable, Cl
     /**
      * For tests only. Blocks the current thread until all messages are written
      * Just does a busy wait.
-     * <p/>
+     * <p>
      * DO NOT USE THIS OUTSIDE OF A TEST
      */
     void awaitWrittenForTest() throws InterruptedException {

--- a/core/src/main/java/io/undertow/server/handlers/builder/PredicatedHandlersParser.java
+++ b/core/src/main/java/io/undertow/server/handlers/builder/PredicatedHandlersParser.java
@@ -48,7 +48,7 @@ import java.util.ServiceLoader;
 
 /**
  * Parser for the undertow-handlers.conf file.
- * <p/>
+ * <p>
  * This file has a line by line syntax, specifying predicate -&gt; handler. If no predicate is specified then
  * the line is assumed to just contain a handler.
  *

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyClient.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModClusterProxyClient.java
@@ -35,7 +35,7 @@ class ModClusterProxyClient implements ProxyClient {
 
     /**
      * The attachment key that is used to attach the proxy connection to the exchange.
-     * <p/>
+     * <p>
      * This cannot be static as otherwise a connection from a different client could be re-used.
      */
     private final AttachmentKey<ExclusiveConnectionHolder> exclusiveConnectionKey = AttachmentKey

--- a/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
@@ -99,12 +99,12 @@ public class ResourceHandler implements HttpHandler {
     private volatile ResourceManager resourceManager;
     /**
      * If this is set this will be the maximum time (in seconds) the client will cache the resource.
-     * <p/>
+     * <p>
      * Note: Do not set this for private resources, as it will cause a Cache-Control: public
      * to be sent.
-     * <p/>
+     * <p>
      * TODO: make this more flexible
-     * <p/>
+     * <p>
      * This will only be used if the {@link #cachable} predicate returns true
      */
     private volatile Integer cacheTime;

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
@@ -109,7 +109,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
      * Handles writing out the header data. It can also take a byte buffer of user
      * data, to enable both user data and headers to be written out in a single operation,
      * which has a noticeable performance impact.
-     * <p/>
+     * <p>
      * It is up to the caller to note the current position of this buffer before and after they
      * call this method, and use this to figure out how many bytes (if any) have been written.
      *

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpTransferEncoding.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpTransferEncoding.java
@@ -42,7 +42,7 @@ import org.xnio.conduits.StreamSourceConduit;
 /**
  * Class that is  responsible for HTTP transfer encoding, this could be part of the {@link HttpReadListener},
  * but is separated out for clarity.
- * <p/>
+ * <p>
  * For more info see http://tools.ietf.org/html/rfc2616#section-4.4
  *
  * @author Stuart Douglas

--- a/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
@@ -22,7 +22,7 @@ import io.undertow.util.HttpString;
 
 /**
  * The current state of the tokenizer state machine. This class is mutable and not thread safe.
- * <p/>
+ * <p>
  * As the machine changes state this class is updated rather than allocating a new one each time.
  *
  * fields are not private to allow for efficient putfield / getfield access

--- a/core/src/main/java/io/undertow/util/ConnectionUtils.java
+++ b/core/src/main/java/io/undertow/util/ConnectionUtils.java
@@ -46,7 +46,7 @@ public class ConnectionUtils {
 
     /**
      * Cleanly close a connection, by shutting down and flushing writes and then draining reads.
-     * <p/>
+     * <p>
      * If this fails the connection is forcibly closed.
      *
      * @param connection The connection

--- a/core/src/main/java/io/undertow/util/DateUtils.java
+++ b/core/src/main/java/io/undertow/util/DateUtils.java
@@ -47,7 +47,7 @@ public class DateUtils {
     /**
      * Thread local cache of this date format. This is technically a small memory leak, however
      * in practice it is fine, as it will only be used by server threads.
-     * <p/>
+     * <p>
      * This is the most common date format, which is why we cache it.
      */
     private static final ThreadLocal<SimpleDateFormat> RFC1123_PATTERN_FORMAT = new ThreadLocal<SimpleDateFormat>() {

--- a/core/src/main/java/io/undertow/util/FastConcurrentDirectDeque.java
+++ b/core/src/main/java/io/undertow/util/FastConcurrentDirectDeque.java
@@ -82,7 +82,7 @@ import sun.misc.Unsafe;
  * Java Collections Framework</a>.
  *
  * Based on revision 1.50 of ConcurrentLinkedDeque
- * (see http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/ConcurrentLinkedDeque.java?revision=1.50&view=markup)
+ * (see http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/src/main/java/util/concurrent/ConcurrentLinkedDeque.java?revision=1.50&amp;view=markup)
  * This is the version used in JDK 1.8.0_121.
  *
  * @since 1.7

--- a/core/src/main/java/io/undertow/util/FileUtils.java
+++ b/core/src/main/java/io/undertow/util/FileUtils.java
@@ -52,7 +52,7 @@ public class FileUtils {
     }
 
     /**
-     * Reads the {@link InputStream file} and converting it to {@link String using UTF-8 encoding.
+     * Reads the {@link InputStream file} and converting it to {@link String} using UTF-8 encoding.
      */
     public static String readFile(InputStream file) {
         try (BufferedInputStream stream = new BufferedInputStream(file)) {

--- a/core/src/main/java/io/undertow/util/QValueParser.java
+++ b/core/src/main/java/io/undertow/util/QValueParser.java
@@ -135,7 +135,7 @@ public class QValueParser {
 
         /**
          * we keep the qvalue as a string to avoid parsing the double.
-         * <p/>
+         * <p>
          * This should give both performance and also possible security improvements
          */
         private String qvalue = "1";

--- a/core/src/main/java/io/undertow/util/RedirectBuilder.java
+++ b/core/src/main/java/io/undertow/util/RedirectBuilder.java
@@ -103,7 +103,7 @@ public class RedirectBuilder {
 
     /**
      * perform URL encoding
-     * <p/>
+     * <p>
      * TODO: this whole thing is kinda crappy.
      *
      * @return

--- a/core/src/main/java/io/undertow/websockets/core/WebSocketFramePriority.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSocketFramePriority.java
@@ -34,9 +34,9 @@ public class WebSocketFramePriority implements FramePriority<WebSocketChannel, S
 
     /**
      * Strict ordering queue. Makes sure that the initial frame for a stream is sent in the order that send() is called.
-     * <p/>
+     * <p>
      * Required to pass the autobahn test suite with no non-strict performance.
-     * <p/>
+     * <p>
      * TODO: provide a way to disable this.
      */
     private final Queue<StreamSinkFrameChannel> strictOrderQueue = new ConcurrentLinkedDeque<>();

--- a/core/src/main/java/io/undertow/websockets/extensions/ExtensionFunction.java
+++ b/core/src/main/java/io/undertow/websockets/extensions/ExtensionFunction.java
@@ -26,12 +26,12 @@ import java.io.IOException;
 
 /**
  * Base interface for WebSocket Extensions implementation.
- * <p/>
+ * <p>
  * It interacts at the connection phase. It is responsible to apply extension's logic before to write and after to read to/from
  * a WebSocket Endpoint.
- * <p/>
+ * <p>
  * Several extensions can be present in a WebSocket Endpoint being executed in a chain pattern.
- * <p/>
+ * <p>
  * Extension state is stored per WebSocket connection.
  *
  * @author Lucas Ponce

--- a/core/src/main/java/io/undertow/websockets/extensions/PerMessageDeflateFunction.java
+++ b/core/src/main/java/io/undertow/websockets/extensions/PerMessageDeflateFunction.java
@@ -37,11 +37,11 @@ import java.util.zip.Inflater;
 
 /**
  * Implementation of {@code permessage-deflate} WebSocket Extension.
- * <p/>
+ * <p>
  * This implementation supports parameters: {@code server_no_context_takeover, client_no_context_takeover} .
- * <p/>
+ * <p>
  * This implementation does not support parameters: {@code server_max_window_bits, client_max_window_bits} .
- * <p/>
+ * <p>
  * It uses the DEFLATE implementation algorithm packaged on {@link Deflater} and {@link Inflater} classes.
  *
  * @author Lucas Ponce

--- a/core/src/test/java/io/undertow/server/handlers/encoding/EncodingSelectionTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/encoding/EncodingSelectionTestCase.java
@@ -47,7 +47,7 @@ public class EncodingSelectionTestCase {
 
     /**
      * Tests encoding selection with no qvalue
-     * <p/>
+     * <p>
      * Also tests a lot of non standard formats for Accept-Encoding to make sure that
      * we are liberal in what we accept
      *

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -36,9 +36,9 @@ import java.nio.ByteBuffer;
 
 /**
  * Basic test of the HTTP parser functionality.
- * <p/>
+ * <p>
  * This tests parsing the same basic request, over and over, with minor differences.
- * <p/>
+ * <p>
  *
  * @author Stuart Douglas
  */

--- a/core/src/test/java/io/undertow/server/security/AuthenticationTestBase.java
+++ b/core/src/test/java/io/undertow/server/security/AuthenticationTestBase.java
@@ -317,7 +317,7 @@ public abstract class AuthenticationTestBase {
 
     /**
      * A simple end of chain handler to set a header and cause the call to return.
-     * <p/>
+     * <p>
      * Reaching this handler is a sign the mechanism handlers have allowed the request through.
      */
     protected static class ResponseHandler implements HttpHandler {

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -577,7 +577,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
 
     /**
      * When using the default SSL settings returns the corresponding client context.
-     * <p/>
+     * <p>
      * If a test case is initialising a custom server side SSLContext then the test case will be responsible for creating it's
      * own client side.
      *
@@ -592,7 +592,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
 
     /**
      * Start the SSL server using the default settings.
-     * <p/>
+     * <p>
      * The default settings initialise a server with a key for 'localhost' and a trust store containing the certificate of a
      * single client, the client authentication mode is set to 'REQUESTED' to optionally allow progression to CLIENT-CERT
      * authentication.
@@ -622,7 +622,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
 
     /**
      * Start the SSL server using the default ssl context and the provided option map
-     * <p/>
+     * <p>
      * The default settings initialise a server with a key for 'localhost' and a trust store containing the certificate of a
      * single client. Client cert mode is not set by default
      */
@@ -633,7 +633,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
 
     /**
      * Start the SSL server using the default ssl context and the provided option map
-     * <p/>
+     * <p>
      * The default settings initialise a server with a key for 'localhost' and a trust store containing the certificate of a
      * single client. Client cert mode is not set by default
      */
@@ -793,7 +793,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
     /**
      * The root handler is tied to the connection, and AJP can re-use connections for different tests, so we
      * use a delegating handler to chance the next handler after the root.
-     * <p/>
+     * <p>
      * TODO: should we re-read the root handler for every request?
      */
     private static final class DelegatingHandler implements HttpHandler {

--- a/core/src/test/java/io/undertow/websockets/core/protocol/server/AutobahnWebSocketServer.java
+++ b/core/src/test/java/io/undertow/websockets/core/protocol/server/AutobahnWebSocketServer.java
@@ -44,38 +44,38 @@ import java.net.InetSocketAddress;
 /**
  * This class is intended for use with testing against the Python
  * <a href="http://www.tavendo.de/autobahn/testsuite.html">AutoBahn test suite</a>.
- * <p/>
+ * <p>
  * Autobahn installation documentation can be found <a href="http://autobahn.ws/testsuite/installation">here</a>.
- * <p/>
+ * <p>
  * <h3>How to run the tests on Linux/OSX.</h3>
- * <p/>
+ * <p>
  * <p>01. Install AutoBahn: <tt>sudo easy_install autobahntestsuite</tt>.  Test using <tt>wstest --help</tt>.
- * <p/>
+ * <p>
  * <p>02. Create a directory for test configuration and results: <tt>mkdir ~/autobahn</tt> <tt>cd ~/autobahn</tt>.
- * <p/>
+ * <p>
  * <p>03. Create <tt>fuzzing_client_spec.json</tt> in the above directory
  * {@code
  * {
  * "options": {"failByDrop": false},
  * "outdir": "./reports/servers",
- * <p/>
+ * <p>
  * "servers": [
  * {"agent": "Netty4",
  * "url": "ws://localhost:9000",
  * "options": {"version": 18}}
  * ],
- * <p/>
+ * <p>
  * "cases": ["*"],
  * "exclude-cases": [],
  * "exclude-agent-cases": {}
  * }
  * }
- * <p/>
+ * <p>
  * <p>04. Run the <tt>AutobahnServer</tt> located in this package. If you are in Eclipse IDE, right click on
  * <tt>AutobahnServer.java</tt> and select Run As > Java Application.
- * <p/>
+ * <p>
  * <p>05. Run the Autobahn test <tt>wstest -m fuzzingclient -s fuzzing_client_spec.json</tt>.
- * <p/>
+ * <p>
  * <p>06. See the results in <tt>./reports/servers/index.html</tt>
  *
  * @author <a href="mailto:nmaurer@redhat.com">Norman Maurer</a>

--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,19 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <!--
-                        The Javadoc comments contains a lot of minor HTML errors
-                        which will cause Javadoc generation to fail without the
+                        The Javadoc comments contain a lot of warnings
+                        that add a lot of noise to the build without the
                         following setting.
                     -->
                     <doclint>none</doclint>
+                    <!-- @implNote is a non-standard tag and must be declared or the build will fail -->
+                    <tags>
+                        <tag>
+                            <name>implNote</name>
+                            <placement>a</placement>
+                            <head>Implementation Note:</head>
+                        </tag>
+                    </tags>
                 </configuration>
                 <executions>
                     <execution>

--- a/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteCond.java
+++ b/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteCond.java
@@ -49,9 +49,9 @@ public class RewriteCond {
 
     public static class LexicalCondition extends Condition {
         /**
-         * -1: <
+         * -1: &lt;
          * 0: =
-         * 1: >
+         * 1: &gt;
          */
         public int type = 0;
         public String condition;

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -302,7 +302,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
 
     /**
      * sets up the outer security handlers.
-     * <p/>
+     * <p>
      * the handler that actually performs the access check happens later in the chain, it is not setup here
      *
      * @param initialHandler The handler to wrap with security handlers

--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
@@ -190,10 +190,10 @@ public class ServletPathMatches {
     /**
      * Sets up the handlers in the servlet chain. We setup a chain for every path + extension match possibility.
      * (i.e. if there a m path mappings and n extension mappings we have n*m chains).
-     * <p/>
+     * <p>
      * If a chain consists of only the default servlet then we add it as an async handler, so that resources can be
      * served up directly without using blocking operations.
-     * <p/>
+     * <p>
      * TODO: this logic is a bit convoluted at the moment, we should look at simplifying it
      */
     private ServletPathMatchesData setupServletChains() {

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamEarlyCloseClientSideTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamEarlyCloseClientSideTestCase.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Tests the behaviour of the input stream when the connection is closed on the client side
- * <p/>
+ * <p>
  * https://issues.jboss.org/browse/WFLY-4827
  *
  * @author Stuart Douglas

--- a/servlet/src/test/java/io/undertow/servlet/test/wrapper/NonStandardResponseWrapper.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/wrapper/NonStandardResponseWrapper.java
@@ -468,7 +468,7 @@ public class NonStandardResponseWrapper implements HttpServletResponse {
      * The default behaviour of this method is to call
      * {@link HttpServletResponse#getHeaders} on the wrapped response
      * object.
-     * <p/>
+     * <p>
      * <p>Any changes to the returned <code>Collection</code> must not
      * affect this <code>HttpServletResponseWrapper</code>.
      *
@@ -486,7 +486,7 @@ public class NonStandardResponseWrapper implements HttpServletResponse {
      * The default behaviour of this method is to call
      * {@link HttpServletResponse#getHeaderNames} on the wrapped response
      * object.
-     * <p/>
+     * <p>
      * <p>Any changes to the returned <code>Collection</code> must not
      * affect this <code>HttpServletResponseWrapper</code>.
      *


### PR DESCRIPTION
This fixes all Javadoc **errors** by replacing all self-closing elements and then correcting the remaining five errors on a case-by-case basis. Javadoc generation will now succeed with the `doclint all` setting but I have left it at `doclint none` to prevent the build from being flooded by Javadoc **warnings**.