### PR TITLE
Reduce Log Level for "should never happen" Log Message

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -393,7 +393,7 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 5084, value = "Attempted to write %s bytes however content-length has been set to %s")
     IOException dataLargerThanContentLength(long totalToWrite, long responseContentLength);
 
-    @LogMessage(level = ERROR)
+    @LogMessage(level = INFO)
     @Message(id = 5085, value = "Connection %s for exchange %s was not closed cleanly, forcibly closing connection")
     void responseWasNotTerminated(ServerConnection connection, HttpServerExchange exchange);
 


### PR DESCRIPTION
Hi,
I suggest to reduce Log Level for a "should never happen" error message as implementet here
https://github.com/undertow-io/undertow/commit/a2826a719834d1de4c8ec55f59a5bc853919f6f9#diff-317364a823cdb4584cdadbbd39e4f91c

We're facing this specific error message on every request in wildfly 14.0.1.Final when enabling http2. The responses are correct. So the messages  are blowing up the log files for no real reason as I suppose.

I found a ticket with recommendation to ignore this specific log entry here: https://issues.jboss.org/browse/JBEAP-15570?focusedCommentId=13676630&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13676630

However the ROOT_LOGGER was used for this specific log message and there might be other relevant messages logged with this logger.

Maybe log level should be reduced even to debug ...