### PR TITLE
UNDERTOW-1511 Guard against infinite loops in DeflatingStreamSinkConduit

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -598,6 +598,6 @@ public interface UndertowMessages {
     @Message(id = 192, value = "Form value is a in-memory file, use getFileItem() instead")
     IllegalStateException formValueIsInMemoryFile();
 
-    @Message(id = 193, value = "Encountered an infinite loop deflating data. shutdown: %s, finished %s, needsInput: %s")
-    IOException deflaterInfiniteLoopDetected(boolean shutdown, boolean finished, boolean needsInput);
+    @Message(id = 193, value = "Encountered an infinite loop deflating data. state: %s, finished %s, needsInput: %s")
+    IOException deflaterInfiniteLoopDetected(int state, boolean finished, boolean needsInput);
 }

--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -597,4 +597,7 @@ public interface UndertowMessages {
 
     @Message(id = 192, value = "Form value is a in-memory file, use getFileItem() instead")
     IllegalStateException formValueIsInMemoryFile();
+
+    @Message(id = 193, value = "Encountered an infinite loop deflating data. shutdown: %s, finished %s, needsInput: %s")
+    IOException deflaterInfiniteLoopDetected(boolean shutdown, boolean finished, boolean needsInput);
 }

--- a/core/src/main/java/io/undertow/conduits/DeflatingStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/DeflatingStreamSinkConduit.java
@@ -519,7 +519,7 @@ public class DeflatingStreamSinkConduit implements StreamSinkConduit {
                     force = false;
                     if (iterationsWithZeroBytes++ > 10) {
                         throw UndertowMessages.MESSAGES.deflaterInfiniteLoopDetected(
-                                shutdown, deflater.finished(), deflater.needsInput());
+                                state, deflater.finished(), deflater.needsInput());
                     }
                 }
             }


### PR DESCRIPTION
Added a iterationsWithZeroBytes counter to break out of infinite
loops based on a similar concept from SslConduit.readListenerInvocationCount.