### PR TITLE
Normalize file path before checking if file exists

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/PathResourceManager.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/PathResourceManager.java
@@ -194,7 +194,7 @@ public class PathResourceManager implements ResourceManager  {
             path = p;
         }
         try {
-            Path file = fileSystem.getPath(base, path);
+            Path file = fileSystem.getPath(base, path).normalize();
             String normalizedFile = file.normalize().toString();
             if(!normalizedFile.startsWith(base)) {
                 if(normalizedFile.length() == base.length() - 1) {


### PR DESCRIPTION
Reason: Fix "false" file doesn't exist issues

Trace logs from my web application:
2019-03-19 12:39:50,954 [issuer: Test Account] TRACE [io.undertow.server.handlers.resource.PathResourceManager] (default task-29) Failed to get path resource CustomerInfo/../WEB-INF/jsp/customer/profile/IndividualProfileQuery.jsp from path resource manager with base /appl/jboss/jboss-eap-7.2-AFStagJ/standalone/tmp/vfs/temp/temp8235cca585546399/content-ab1ec3bf15aee59c/, as the path did not exist

However, same server and application running on Windows:
12:50:48,418 TRACE [io.undertow.server.handlers.resource.PathResourceManager] (default task-11) Found path resource CustomerInfo/../WEB-INF/jsp/customer/profile/IndividualProfileQuery.jsp from path resource manager with base C:\Develop\jboss-eap-7.2-AFStagJ\standalone\tmp\vfs\temp\temp9584729df25c03a9\content-78189cb1518d12e\
12:50:51,224 TRACE [io.undertow.server.handlers.resource.PathResourceManager] (default task-11) Found path resource WEB-INF/jsp/customer/profile/IndividualProfileQuery.jsp from path resource manager with base C:\Develop\jboss-eap-7.2-AFStagJ\standalone\tmp\vfs\temp\temp9584729df25c03a9\content-78189cb1518d12e\


"/CustomerInfo" is a struts module which gets added to the forward path.  This is NOT a real directory.  In JBoss EAP 6.2 running on Java 7u67, this pathing does not create an issue.  JBoss EAP 7.2 running on Java 8u181 does create an issue.

For some reason, Files.exists(file) on windows has no issue, but in Linux, there is an issue.  Normalizing the path first fixes it.

My questions if my proposed change isn't accepted are: 
Why wouldn't you normalize the Path?
What's the point of walking the directory structure needlessly?