### PR TITLE
[UNDERTOW-1515] HttpServerExchange.toString does not include headers

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -2441,6 +2441,6 @@ public final class HttpServerExchange extends AbstractAttachable {
 
     @Override
     public String toString() {
-        return "HttpServerExchange{ " + getRequestMethod().toString() + " " + getRequestURI() + " request " + requestHeaders + " response " + responseHeaders + '}';
+        return "HttpServerExchange{ " + getRequestMethod().toString() + " " + getRequestURI() + '}';
     }
 }


### PR DESCRIPTION
This reverts commit 51144633f22ba0e73ee1f435db72025720395797.