### PR TITLE
[3.x] Remove staic list of all HttpServerConnection instances

### DIFF
--- a/core/src/main/java/io/undertow/protocol/http/HttpServerConnection.java
+++ b/core/src/main/java/io/undertow/protocol/http/HttpServerConnection.java
@@ -135,13 +135,10 @@ public class HttpServerConnection extends ServerConnection implements Closeable 
 
     private volatile IoCallback<ByteBuf> readCallback;
 
-    private static CopyOnWriteArrayList<Object> INST = new CopyOnWriteArrayList<>();
-
     public HttpServerConnection(ChannelHandlerContext ctx, Executor executor, SSLSessionInfo sslSessionInfo) {
         this.ctx = ctx;
         this.executor = executor;
         this.sslSessionInfo = sslSessionInfo;
-        INST.add(this);
     }
 
     @Override


### PR DESCRIPTION
Likely existed for debugging at some point, was checked in with
async read fixes in c6a146ac3bdcf0d4a949028c1b088a532aadbaa3