### PR TITLE
ReceiverTestCase#testAsyncReceiveWholeBytesFailed[proxy][http2] fails…

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/ReceiverTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/ReceiverTestCase.java
@@ -174,6 +174,9 @@ public class ReceiverTestCase {
 
     @Test
     public void testAsyncReceiveWholeBytesFailed() throws Exception {
+        // TODO un-@Ignore - https://issues.jboss.org/browse/UNDERTOW-1531 - ReceiverTestCase#testAsyncReceiveWholeBytesFailed[proxy][http2] fails intermittently on Windows
+        org.junit.Assume.assumeFalse(DefaultServer.isH2() && org.apache.commons.lang.SystemUtils.IS_OS_WINDOWS);
+
         EXCEPTIONS.clear();
         Socket socket = new Socket();
         socket.connect(DefaultServer.getDefaultServerAddress());


### PR DESCRIPTION
… intermittently on Windows

At this point (40% failure rate) this is a good candidate for disabling.. opened https://issues.jboss.org/browse/UNDERTOW-1531.