### PR TITLE
UNDERTOW-1529 - Don't let StatusCodes#getReason() throw an ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/main/java/io/undertow/util/StatusCodes.java
+++ b/core/src/main/java/io/undertow/util/StatusCodes.java
@@ -217,7 +217,11 @@ public class StatusCodes {
     }
 
     public static final String getReason(final int code) {
-        final Entry result = TABLE[code & SIZE];
+        final int hash = code & SIZE;
+        if (hash == SIZE) {
+            return "Unknown";
+        }
+        final Entry result = TABLE[hash];
         if (result == null || result.code != code) {
             return "Unknown";
         } else {

--- a/core/src/test/java/io/undertow/util/NodeStatusCodesTestCase.java
+++ b/core/src/test/java/io/undertow/util/NodeStatusCodesTestCase.java
@@ -33,4 +33,13 @@ public class NodeStatusCodesTestCase {
     public void testCodeLookup() {
         Assert.assertEquals("OK", StatusCodes.getReason(StatusCodes.OK));
     }
+
+    @Test
+    public void testUnknownCode() {
+        Assert.assertEquals("Unexpected reason phrase", "Unknown", StatusCodes.getReason(-1));
+        Assert.assertEquals("Unexpected reason phrase", "Unknown", StatusCodes.getReason(999));
+        Assert.assertEquals("Unexpected reason phrase", "Unknown", StatusCodes.getReason(735));
+        Assert.assertEquals("Unexpected reason phrase", "Unknown", StatusCodes.getReason(Integer.MAX_VALUE));
+        Assert.assertEquals("Unexpected reason phrase", "Unknown", StatusCodes.getReason(Integer.MIN_VALUE));
+    }
 }


### PR DESCRIPTION
The commit here fixes an issue reported in https://issues.jboss.org/browse/UNDERTOW-1529.
This also includes a testcase to reproduce the issue and verify the fix.