### PR TITLE
UNDERTOW-1533 Send SNI when connecting via HTTP Proxy

### DIFF
--- a/core/src/main/java/io/undertow/websockets/client/WebSocketClient.java
+++ b/core/src/main/java/io/undertow/websockets/client/WebSocketClient.java
@@ -258,7 +258,7 @@ public class WebSocketClient {
                                                     StreamConnection targetConnection = connection.performUpgrade();
                                                     WebSocketLogger.REQUEST_LOGGER.debugf("Established websocket connection to %s", uri);
                                                     if (uri.getScheme().equals("wss") || uri.getScheme().equals("https")) {
-                                                        handleConnectionWithExistingConnection(((UndertowXnioSsl) ssl).wrapExistingConnection(targetConnection, optionMap));
+                                                        handleConnectionWithExistingConnection(((UndertowXnioSsl) ssl).wrapExistingConnection(targetConnection, optionMap, uri));
                                                     } else {
                                                         handleConnectionWithExistingConnection(targetConnection);
                                                     }


### PR DESCRIPTION
This is basically the same code as is used in `UndertowXnioSsl.StreamConnectionChannelListener#handleEvent` to enforce SNI on the connection.