### PR TITLE
UNDERTOW-1539 Allow checking server DNS name vs. its certificate

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -332,6 +332,13 @@ public class UndertowOptions {
      */
     public static final Option<Integer> SHUTDOWN_TIMEOUT = Option.simple(UndertowOptions.class, "SHUTDOWN_TIMEOUT", Integer.class);
 
+    /**
+     * The endpoint identification algorithm.
+     *
+     * @see javax.net.ssl.SSLParameters#setEndpointIdentificationAlgorithm(String)
+     */
+    public static final Option<String> ENDPOINT_IDENTIFICATION_ALGORITHM = Option.simple(UndertowOptions.class, "ENDPOINT_IDENTIFICATION_ALGORITHM", String.class);
+
     private UndertowOptions() {
 
     }

--- a/core/src/main/java/io/undertow/protocols/ssl/UndertowXnioSsl.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/UndertowXnioSsl.java
@@ -298,6 +298,12 @@ public class UndertowXnioSsl extends XnioSsl {
                 UndertowLogger.ROOT_LOGGER.failedToUseServerOrder(e);
             }
         }
+        final String endpointIdentificationAlgorithm = optionMap.get(UndertowOptions.ENDPOINT_IDENTIFICATION_ALGORITHM, null);
+        if (endpointIdentificationAlgorithm != null) {
+            SSLParameters sslParameters = engine.getSSLParameters();
+            sslParameters.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+            engine.setSSLParameters(sslParameters);
+        }
         return engine;
     }
 
@@ -436,6 +442,12 @@ public class UndertowXnioSsl extends XnioSsl {
                 SSLEngine sslEngine = JsseSslUtils.createSSLEngine(sslContext, optionMap, destination);
                 SSLParameters params = sslEngine.getSSLParameters();
                 params.setServerNames(Collections.singletonList(new SNIHostName(destination.getHostString())));
+
+                final String endpointIdentificationAlgorithm = optionMap.get(UndertowOptions.ENDPOINT_IDENTIFICATION_ALGORITHM, null);
+                if (endpointIdentificationAlgorithm != null) {
+                    params.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+                }
+
                 sslEngine.setSSLParameters(params);
 
                 final SslConnection wrappedConnection = new UndertowSslConnection(connection, sslEngine, bufferPool);


### PR DESCRIPTION
The patch is pretty self-explanatory. I'm a bit bugged by the fact that the `SSLEngine` itself is created by different means in two places but that's how it is and I don't think changing this right now would provide any more benefits.