### PR TITLE
Fix for UNDERTOW-1540 

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -807,7 +807,7 @@ public class ServletContextImpl implements ServletContext {
     public void setRequestCharacterEncoding(String encoding) {
         ensureNotInitialized();
         ensureNotProgramaticListener();
-        deploymentInfo.setDefaultRequestEncoding(getContextPath());
+        deploymentInfo.setDefaultRequestEncoding(encoding);
     }
 
     @Override


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/UNDERTOW-1540 by correctly setting the passed character encoding in `ServletContext#setRequestCharacterEncoding`.
This also includes a test case which reproduces the issue and verifies the fix.