### PR TITLE
[UNDERTOW-1548] Make a request cookie parser behavior tunable with ALLOW_HTTP_SEPARATORS_IN_V0 setting

### DIFF
--- a/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
+++ b/core/src/main/java/io/undertow/util/LegacyCookieSupport.java
@@ -42,7 +42,7 @@ public final class LegacyCookieSupport {
      *
      * Defaults to false.
      */
-    private static final boolean ALLOW_HTTP_SEPARATORS_IN_V0 = Boolean.getBoolean("io.undertow.legacy.cookie.ALLOW_HTTP_SEPARATORS_IN_V0");
+    static final boolean ALLOW_HTTP_SEPARATORS_IN_V0 = Boolean.getBoolean("io.undertow.legacy.cookie.ALLOW_HTTP_SEPARATORS_IN_V0");
 
 
     /**
@@ -143,7 +143,7 @@ public final class LegacyCookieSupport {
      * @throws IllegalArgumentException if a control character was supplied as
      *         input
      */
-    private static boolean isHttpSeparator(final char c) {
+    static boolean isHttpSeparator(final char c) {
         if (c < 0x20 || c >= 0x7f) {
             if (c != 0x09) {
                 throw UndertowMessages.MESSAGES.invalidControlCharacter(Integer.toString(c));

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -223,6 +223,45 @@ public class CookiesTestCase {
     }
 
     @Test
+    public void testHttpSeparaterInV0CookieValue() {
+        Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, false, Arrays.asList("CUSTOMER=WILE_E COYOTE; SHIPPING=FEDEX" ), true, false);
+        Assert.assertEquals(2, cookies.size());
+        Cookie cookie = cookies.get("CUSTOMER");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("WILE_E", cookie.getValue());
+        cookie = cookies.get("SHIPPING");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("FEDEX", cookie.getValue());
+
+        cookies = Cookies.parseRequestCookies(2, false, Arrays.asList("CUSTOMER=WILE_E COYOTE; SHIPPING=FEDEX" ), true, true);
+        Assert.assertEquals(2, cookies.size());
+        cookie = cookies.get("CUSTOMER");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("WILE_E COYOTE", cookie.getValue());
+        cookie = cookies.get("SHIPPING");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("FEDEX", cookie.getValue());
+
+        cookies = Cookies.parseRequestCookies(2, false, Arrays.asList("CUSTOMER=WILE_E_COYOTE\"; SHIPPING=FEDEX" ), true, false);
+        Assert.assertEquals(2, cookies.size());
+        cookie = cookies.get("CUSTOMER");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        cookie = cookies.get("SHIPPING");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("FEDEX", cookie.getValue());
+
+        cookies = Cookies.parseRequestCookies(2, false, Arrays.asList("CUSTOMER=WILE_E_COYOTE\"; SHIPPING=FEDEX" ), true, true);
+        Assert.assertEquals(2, cookies.size());
+        cookie = cookies.get("CUSTOMER");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("WILE_E_COYOTE\"", cookie.getValue());
+        cookie = cookies.get("SHIPPING");
+        Assert.assertNotNull(cookie);
+        Assert.assertEquals("FEDEX", cookie.getValue());
+    }
+
+    @Test
     public void testQuotedEscapedStringInRequestCookie() {
         Map<String, Cookie> cookies = Cookies.parseRequestCookies(3, false, Arrays.asList(
                     "Customer=\"WILE_\\\"E_\\\"COYOTE\"; $Version=\"1\"; $Path=\"/acme\";"
@@ -245,9 +284,11 @@ public class CookiesTestCase {
 
     @Test
     public void testSimpleJSONObjectInRequestCookies() {
+        // allowEqualInValue and allowHttpSepartorsV0 needs to be enabled to handle this cookie
+        // Also, commaIsSeperator needs to be set to false
         Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, true, Arrays.asList(
                 "CUSTOMER={\"v1\":1, \"id\":\"some_unique_id\", \"c\":\"http://www.google.com?q=love me\"};"
-                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"));
+                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"), false, true);
 
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertEquals("CUSTOMER", cookie.getName());
@@ -267,9 +308,11 @@ public class CookiesTestCase {
 
     @Test
     public void testQuotedJSONObjectInRequestCookies() {
+        // allowEqualInValue and allowHttpSepartorsV0 needs to be enabled to handle this cookie
+        // Also, commaIsSeperator needs to be set to false
         Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, true, Arrays.asList(
                 "CUSTOMER=\"{\\\"v1\\\":1, \\\"id\\\":\\\"some_unique_id\\\", \\\"c\\\":\\\"http://www.google.com?q=love me\\\"}\";"
-                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"));
+                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"), false, true);
 
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertEquals("CUSTOMER", cookie.getName());
@@ -289,12 +332,14 @@ public class CookiesTestCase {
 
     @Test
     public void testComplexJSONObjectInRequestCookies() {
+        // allowHttpSepartorsV0 needs to be enabled to handle this cookie
+        // Also, commaIsSeperator needs to be set to false
         Map<String, Cookie> cookies = Cookies.parseRequestCookies(2, false, Arrays.asList(
                 "CUSTOMER={ \"accounting\" : [ { \"firstName\" : \"John\", \"lastName\" : \"Doe\", \"age\" : 23 },"
                 + " { \"firstName\" : \"Mary\",  \"lastName\" : \"Smith\", \"age\" : 32 }], "
                 + "\"sales\" : [ { \"firstName\" : \"Sally\", \"lastName\" : \"Green\", \"age\" : 27 }, "
                 + "{ \"firstName\" : \"Jim\", \"lastName\" : \"Galley\", \"age\" : 41 } ] };"
-                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"));
+                + " $Domain=LOONEY_TUNES; $Version=1; $Path=/; SHIPPING=FEDEX"), false, true);
 
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertEquals("CUSTOMER", cookie.getName());


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-1548