### PR TITLE
UNDERTOW-1550 Make undertow build fine on JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,6 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.2.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/UNDERTOW-1550 letting the `jboss-parent` pom dictate the version of `maven-bundle-plugin`. The `jboss-parent` pom version `35` correctly uses a version of `maven-bundle-plugin` which understands Java 9+ multi-release jars and allows builds to pass on JDK11.

P.S: With this change, the build works fine with both JDK 8 and 11.