### PR TITLE
UNDERTOW-1553 Use the correct character encoding for the reader/writer

### DIFF
--- a/core/src/test/java/io/undertow/testutils/HttpClientUtils.java
+++ b/core/src/test/java/io/undertow/testutils/HttpClientUtils.java
@@ -24,6 +24,7 @@ import org.apache.http.HttpResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -36,11 +37,15 @@ public class HttpClientUtils {
     }
 
     public static String readResponse(final HttpResponse response) throws IOException {
+        return readResponse(response, StandardCharsets.UTF_8);
+    }
+
+    public static String readResponse(final HttpResponse response, final Charset charset) throws IOException {
         HttpEntity entity = response.getEntity();
         if(entity == null) {
             return "";
         }
-        return readResponse(entity.getContent());
+        return readResponse(entity.getContent(), charset);
     }
 
     public static String readResponse(InputStream stream) throws IOException {
@@ -52,6 +57,17 @@ public class HttpClientUtils {
             out.write(data, 0, read);
         }
         return new String(out.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    public static String readResponse(final InputStream stream, final Charset charset) throws IOException {
+
+        byte[] data = new byte[100];
+        int read;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        while ((read = stream.read(data)) != -1) {
+            out.write(data, 0, read);
+        }
+        return new String(out.toByteArray(), charset);
     }
 
     public static byte[] readRawResponse(final HttpResponse response) throws IOException {

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
@@ -23,6 +23,7 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -324,10 +325,20 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
 
     @Override
     public String getCharacterEncoding() {
-        if (charset == null) {
-            return servletContext.getDeployment().getDefaultResponseCharset().name();
+        if (charset != null) {
+            return charset;
         }
-        return charset;
+        // first check, web-app context level default response encoding
+        if (servletContext.getDeployment().getDeploymentInfo().getDefaultResponseEncoding() != null) {
+            return servletContext.getDeployment().getDeploymentInfo().getDefaultResponseEncoding();
+        }
+        // now check the container level default encoding
+        if (servletContext.getDeployment().getDeploymentInfo().getDefaultEncoding() != null) {
+            return servletContext.getDeployment().getDeploymentInfo().getDefaultEncoding();
+        }
+        // if no explicit encoding is specified, this method is supposed to return ISO-8859-1 as per the
+        // expectation of this API
+        return StandardCharsets.ISO_8859_1.name();
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/charset/DefaultCharacterEncodingServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/charset/DefaultCharacterEncodingServlet.java
@@ -24,6 +24,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Reader;
 
 /**
  * @author Artemy Osipov
@@ -31,13 +32,31 @@ import java.io.PrintWriter;
 public class DefaultCharacterEncodingServlet extends HttpServlet {
 
     @Override
-    protected void service(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         String requestCharacterEncoding = req.getCharacterEncoding();
         String responseCharacterEncoding = resp.getCharacterEncoding();
 
         PrintWriter writer = resp.getWriter();
         writer.write(String.format("requestCharacterEncoding=%s;responseCharacterEncoding=%s;",
                 requestCharacterEncoding, responseCharacterEncoding));
+        writer.close();
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        final Reader reader = req.getReader();
+        final char[] buf = new char[1024];
+        final StringBuilder contentBuilder = new StringBuilder();
+        int numRead = -1;
+        while ((numRead = reader.read(buf)) != -1) {
+            contentBuilder.append(buf, 0, numRead);
+        }
+        final String requestCharacterEncoding = req.getCharacterEncoding();
+        final String responseCharacterEncoding = resp.getCharacterEncoding();
+
+        final PrintWriter writer = resp.getWriter();
+        writer.write(String.format("requestCharacterEncoding=%s;responseCharacterEncoding=%s;content=%s;",
+                requestCharacterEncoding, responseCharacterEncoding, contentBuilder.toString()));
         writer.close();
     }
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/charset/DefaultCharacterEncodingTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/charset/DefaultCharacterEncodingTestCase.java
@@ -28,6 +28,8 @@ import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +37,7 @@ import org.junit.runner.RunWith;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -77,7 +80,8 @@ public class DefaultCharacterEncodingTestCase {
         }
     }
 
-    private void testServletContextCharacterEncoding(final String requestCharacterEncoding, final String responseCharacterEncoding)
+    private void testServletContextCharacterEncoding(final String requestCharacterEncoding, final String responseCharacterEncoding,
+                                                     final String defaultContainerLevelEncoding, final String body)
             throws IOException, ServletException {
         DeploymentUtils.setupServlet(new ServletExtension() {
                                          @Override
@@ -89,17 +93,23 @@ public class DefaultCharacterEncodingTestCase {
                 Servlets.servlet("servlet", DefaultCharacterEncodingServlet.class).addMapping("/"));
         TestHttpClient client = new TestHttpClient();
         try {
-            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext");
-            HttpResponse result = client.execute(get);
+            final HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL() + "/servletContext");
+            if (body != null) {
+                post.setEntity(new StringEntity(body, requestCharacterEncoding));
+            }
+            // spec mandates "ISO-8859-1" as the default (see javadoc of ServletResponse#getCharacterEncoding())
+            final String expectedResponseCharEncoding = responseCharacterEncoding == null ? "ISO-8859-1" : responseCharacterEncoding;
+            final HttpResponse result = client.execute(post);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            String response = HttpClientUtils.readResponse(result);
+            String response = HttpClientUtils.readResponse(result, Charset.forName(expectedResponseCharEncoding));
             final String expectedRequestCharEncoding = requestCharacterEncoding == null ? "null" : requestCharacterEncoding;
             Assert.assertEquals("Unexpected request character encoding",
                     expectedRequestCharEncoding, readParameter(response, "requestCharacterEncoding"));
-            // spec mandates "ISO-8859-1" as the default (see javadoc of ServletResponse#getCharacterEncoding())
-            final String expectedResponseCharEncoding = responseCharacterEncoding == null ? "ISO-8859-1" : responseCharacterEncoding;
             Assert.assertEquals("Unexpected response character encoding",
                     expectedResponseCharEncoding, readParameter(response, "responseCharacterEncoding"));
+            if (body != null) {
+                Assert.assertEquals("Unexpected response body", body, readParameter(response, "content"));
+            }
         } finally {
             client.getConnectionManager().shutdown();
         }
@@ -139,10 +149,16 @@ public class DefaultCharacterEncodingTestCase {
      */
     @Test
     public void testServletContextCharEncoding() throws Exception {
-        testServletContextCharacterEncoding(null, null);
-        testServletContextCharacterEncoding("UTF-8", null);
-        testServletContextCharacterEncoding("UTF-8", "UTF-8");
-        testServletContextCharacterEncoding(null, "UTF-8");
-        testServletContextCharacterEncoding(StandardCharsets.UTF_16BE.name(), "UTF-8");
+        final String[] defaultContainerLevelEncodings = new String[]{null, StandardCharsets.ISO_8859_1.name(),
+                StandardCharsets.UTF_8.name(), StandardCharsets.UTF_16BE.name()};
+        for (final String defaultContainerLevelEncoding : defaultContainerLevelEncodings) {
+            testServletContextCharacterEncoding(null, null, defaultContainerLevelEncoding, null);
+            testServletContextCharacterEncoding("UTF-8", null, defaultContainerLevelEncoding, null);
+            testServletContextCharacterEncoding(null, "UTF-8", defaultContainerLevelEncoding, null);
+            testServletContextCharacterEncoding(StandardCharsets.UTF_16BE.name(), "UTF-8", defaultContainerLevelEncoding, null);
+            // send a unicode string in body
+            testServletContextCharacterEncoding("UTF-8", "UTF-8", defaultContainerLevelEncoding, "\u3042");
+
+        }
     }
 }


### PR DESCRIPTION
The commit here fixes the issue noted in this forum thread https://developer.jboss.org/message/989396#989396 (and tracked in JIRA https://issues.jboss.org/browse/UNDERTOW-1553). 

This commit makes sure the reader's charset encoding takes into account the encoding set on servletcontext level and then falls back to the default container level encoding. The commit does a similar thing with the response's writer.

The changes in this commit follow the rules noted in the javadoc of `javax.servlet.ServletRequest#getCharacterEncoding` and `javax.servlet.ServletResponse#getCharacterEncoding`

The existing testcase has been updated to reproduce and verify this fix.