### PR TITLE
UNDERTOW-1565 Don't encode query strings and URI paths while redirecting

### DIFF
--- a/core/src/main/java/io/undertow/security/handlers/SinglePortConfidentialityHandler.java
+++ b/core/src/main/java/io/undertow/security/handlers/SinglePortConfidentialityHandler.java
@@ -43,10 +43,12 @@ public class SinglePortConfidentialityHandler extends AbstractConfidentialityHan
         return getRedirectURI(exchange, redirectPort);
     }
 
-    protected URI getRedirectURI(HttpServerExchange exchange, int port) throws URISyntaxException {
-        String host = exchange.getHostName();
-
-        String queryString = exchange.getQueryString();
+    protected URI getRedirectURI(final HttpServerExchange exchange, final int port) throws URISyntaxException {
+        final StringBuilder uriBuilder = new StringBuilder();
+        uriBuilder.append("https://").append(exchange.getHostName());
+        if (port > 0) {
+            uriBuilder.append(":").append(port);
+        }
         String uri = exchange.getRequestURI();
         if(exchange.isHostIncludedInRequestURI()) {
             int slashCount = 0;
@@ -60,8 +62,12 @@ public class SinglePortConfidentialityHandler extends AbstractConfidentialityHan
                 }
             }
         }
-        return new URI("https", null, host, port, uri,
-                queryString == null || queryString.length() == 0 ? null : queryString, null);
+        uriBuilder.append(uri);
+        final String queryString = exchange.getQueryString();
+        if (queryString != null && !queryString.isEmpty()) {
+            uriBuilder.append("?").append(queryString);
+        }
+        return new URI(uriBuilder.toString());
     }
 
 }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/UNDERTOW-1565

The code in `SinglePortConfidentialityHandler` which deals with forming the redirect URI was using the 7 argument constructor of `java.net.URI`, which as per its javadoc, internally encodes the passed parameters, like the `queryString`. We do not want that to happen, since the query string and other components of the URI that we are building aren't expected to be decoded/encoded, by the container, while we are building the redirect URI.

The commit here uses a `StringBuilder` to form the redirect URI and then passes it to the single argument constructor of `java.net.URI` which doesn't do the encoding of the passed parameter, unlike the 7 argument constructor.

The commit also includes an update to an existing testcase to reproduce the issue and verify the fix.
