### PR TITLE
UNDERTOW-1567 Redirect to absolute URL with special characters broken

### DIFF
--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -19,8 +19,7 @@
 package io.undertow.util;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.net.URISyntaxException;
+import java.util.regex.Pattern;
 
 import io.undertow.UndertowMessages;
 import io.undertow.server.HttpServerExchange;
@@ -47,6 +46,12 @@ public class URLUtils {
             exchange.addPathParam(key, value);
         }
     };
+
+    // RFC-3986 (URI Generic Syntax) states:
+    // URI         = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+    // scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    // "The scheme and path components are required, though the path may be empty (no characters)."
+    private static final Pattern SCHEME_PATTERN = Pattern.compile("^[a-zA-Z][a-zA-Z0-9+-.]*:.*");
 
     private URLUtils() {
 
@@ -327,12 +332,8 @@ public class URLUtils {
      */
     public static boolean isAbsoluteUrl(String location) {
         if (location != null && location.length() > 0 && location.contains(":")) {
-            try {
-                URI uri = new URI(location);
-                return uri.getScheme() != null;
-            } catch (URISyntaxException e) {
-                // ignore invalid locations and consider not absolute
-            }
+            // consider it absolute URL if location contains valid scheme part
+            return SCHEME_PATTERN.matcher(location).matches();
         }
         return false;
     }

--- a/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/URLUtilsTestCase.java
@@ -83,6 +83,7 @@ public class URLUtilsTestCase {
         assertFalse(URLUtils.isAbsoluteUrl("relative"));
         assertFalse(URLUtils.isAbsoluteUrl("relative/path"));
         assertFalse(URLUtils.isAbsoluteUrl("relative/path?query=val"));
+        assertFalse(URLUtils.isAbsoluteUrl("relative/path:path"));
         assertFalse(URLUtils.isAbsoluteUrl("/root/relative/path"));
     }
 
@@ -112,4 +113,10 @@ public class URLUtilsTestCase {
             }
         }
     }
+
+    @Test
+    public void testIsAbsoluteUrlInvalidChars() {
+        assertTrue(URLUtils.isAbsoluteUrl("http://test.com/foobar?test={abc}"));
+    }
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-1567
https://issues.jboss.org/browse/JBEAP-16826

Use regex to determine URI scheme instead of `new URI(location).getScheme()`.

The presence of scheme in given `location` is used to determine whether `location` is an absolute or relative URI. The URI instantiation fails when `location` contains technically illegal characters like {}, the `location` is then always determined as relative. This was not the case in previous EAP versions.