### PR TITLE
UNDERTOW-1572 ProxyProtocolTestCase fails when IPv6 enabled

### DIFF
--- a/core/src/test/java/io/undertow/server/protocol/proxy/ProxyProtocolTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/proxy/ProxyProtocolTestCase.java
@@ -435,7 +435,12 @@ public class ProxyProtocolTestCase {
 
         // simple valid request
         request = createProxyHeaderV2(LOCAL, (byte) 0, 0, null, null,null,null);
-        String expectedResponse = "result: /127.0.0.1";
+        String expectedResponse;
+        if (isIpV6()) {
+            expectedResponse = "result: /0:0:0:0:0:0:0:1";
+        } else {
+            expectedResponse = "result: /127.0.0.1";
+        }
         proxyProtocolRequestResponseCheck(request, requestHttp, expectedResponse);
     }
 
@@ -575,5 +580,10 @@ public class ProxyProtocolTestCase {
         } finally {
             undertow.stop();
         }
+    }
+
+    private static boolean isIpV6() {
+        String preferIpV6Property = System.getProperty("java.net.preferIPv6Addresses");
+        return preferIpV6Property != null && preferIpV6Property.toLowerCase().equals("true");
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/UNDERTOW-1572

Test case fix for ProxyProtocolTestCase with IPv6.

Reproducer:

```mvn test -Dtest=ProxyProtocolTestCase -Dtest.ipv6```