### PR TITLE
[UNDERTOW-1580] Improve EJB over HTTPS logging

### DIFF
--- a/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
@@ -1083,6 +1083,7 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
                                                 try {
                                                     doHandshake();
                                                 } catch (IOException | RuntimeException | Error e) {
+                                                    UndertowLogger.REQUEST_LOGGER.error("Closing SSLConduit after exception on handshake", e);
                                                     IoUtils.safeClose(connection);
                                                 }
                                                 if (anyAreSet(state, FLAG_READS_RESUMED)) {


### PR DESCRIPTION
When the handshake fails, the close listener is notified, connection closes and throws a ClosedChannelException hiding the underlaying cause, proposed fix just logs the error on the client side before the exception is thrown.

Issue: https://issues.jboss.org/browse/UNDERTOW-1580