### PR TITLE
[UNDERTOW-1573] Servlet request attributes are cleared before access log exchange completion listener runs

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletInitialHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletInitialHandler.java
@@ -326,7 +326,6 @@ public class ServletInitialHandler implements HttpHandler, ServletDispatcher {
         //if it is not dispatched and is not a mock request
         if (!exchange.isDispatched() && !(exchange.getConnection() instanceof MockServerConnection)) {
             servletRequestContext.getOriginalResponse().responseDone();
-            servletRequestContext.getOriginalRequest().clearAttributes();
         }
         if(!exchange.isDispatched()) {
             AsyncContextImpl ctx = servletRequestContext.getOriginalRequest().getAsyncContextInternal();

--- a/servlet/src/main/java/io/undertow/servlet/spec/AsyncContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/AsyncContextImpl.java
@@ -607,7 +607,6 @@ public class AsyncContextImpl implements AsyncContext {
             response.responseDone();
             try {
                 servletRequestContext.getOriginalRequest().closeAndDrainRequest();
-                servletRequestContext.getOriginalRequest().clearAttributes();
             } catch (IOException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
             } catch (Throwable t) {

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -1179,12 +1179,6 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
         return "HttpServletRequestImpl [ " + getMethod() + ' ' + getRequestURI() + " ]";
     }
 
-    public void clearAttributes() {
-        if(attributes != null) {
-            this.attributes.clear();
-        }
-    }
-
     @Override
     public PushBuilder newPushBuilder() {
         if(exchange.getConnection().isPushSupported()) {

--- a/servlet/src/test/java/io/undertow/servlet/test/proprietry/ExchangeCompletionTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/proprietry/ExchangeCompletionTestCase.java
@@ -1,0 +1,131 @@
+package io.undertow.servlet.test.proprietry;
+
+import static org.junit.Assert.assertEquals;
+
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.handlers.ServletRequestContext;
+import io.undertow.servlet.test.SimpleServletTestCase;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @see <a href="https://issues.jboss.org/browse/UNDERTOW-1573">UNDERTOW-1573</a>
+ */
+@RunWith(DefaultServer.class)
+public class ExchangeCompletionTestCase {
+    private static final String AN_ATTRIBUTE = "an.attribute";
+    private static final String A_VALUE = "a.value";
+
+    private static final BlockingQueue<String> completedExchangeAttributes = new LinkedBlockingQueue<>();
+
+    @BeforeClass
+    public static void setup() throws ServletException {
+
+        final PathHandler root = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(SimpleServletTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setDeploymentName("servletContext.war")
+                .addServlet(
+                        new ServletInfo("servlet", IgnoresRequestAndSetsAttributeServlet.class)
+                                .addMapping("/sync")
+                                .addInitParam(IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_KEY, AN_ATTRIBUTE)
+                                .addInitParam(IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_VALUE, A_VALUE))
+                .addServlet(
+                        new ServletInfo("asyncservlet", IgnoresRequestAndSetsAttributeAsyncServlet.class)
+                                .addMapping("/async")
+                                .addInitParam(IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_KEY, AN_ATTRIBUTE)
+                                .addInitParam(IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_VALUE, A_VALUE)
+                                .setAsyncSupported(true))
+                .addInitialHandlerChainWrapper(new HandlerWrapper() {
+                    @Override
+                    public HttpHandler wrap(final HttpHandler handler) {
+                        return new HttpHandler() {
+                            @Override
+                            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                                exchange.addExchangeCompleteListener(new ExchangeCompletionListener() {
+                                    @Override
+                                    public void exchangeEvent(HttpServerExchange exchange, NextListener nextListener) {
+                                        ServletRequestContext context = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+
+                                        if (context != null) {
+                                            Object result = context.getServletRequest().getAttribute(AN_ATTRIBUTE);
+
+                                            if (result instanceof String) {
+                                                completedExchangeAttributes.add((String) result);
+                                            }
+                                        }
+
+                                        nextListener.proceed();
+                                    }
+                                });
+
+                                handler.handleRequest(exchange);
+                            }
+                        };
+                    }
+                });
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(root);
+    }
+
+    @Before
+    public void clearLoggedAttributes() {
+        completedExchangeAttributes.clear();
+    }
+
+    @Test
+    public void exchangeCompletionListenersSeeRequestAttributesEvenIfRequestBodyIsNotRead() throws IOException, InterruptedException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL() + "/servletContext/sync");
+            post.setEntity(new StringEntity("some body that isn't read"));
+            client.execute(post);
+            assertEquals(A_VALUE, completedExchangeAttributes.poll(1, TimeUnit.SECONDS));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void exchangeCompletionListenersSeeRequestAttributesEvenIfRequestBodyIsNotReadAsync() throws IOException, InterruptedException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL() + "/servletContext/async");
+            post.setEntity(new StringEntity("some body that isn't read"));
+            client.execute(post);
+            assertEquals(A_VALUE, completedExchangeAttributes.poll(1, TimeUnit.SECONDS));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/proprietry/IgnoresRequestAndSetsAttributeAsyncServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/proprietry/IgnoresRequestAndSetsAttributeAsyncServlet.java
@@ -1,0 +1,48 @@
+package io.undertow.servlet.test.proprietry;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class IgnoresRequestAndSetsAttributeAsyncServlet extends HttpServlet {
+
+    public static final String ATTRIBUTE_KEY = IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_KEY;
+    public static final String ATTRIBUTE_VALUE = IgnoresRequestAndSetsAttributeServlet.ATTRIBUTE_VALUE;
+
+    private String attributeKey;
+    private String attributeValue;
+
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+        super.init(config);
+        attributeKey = config.getInitParameter(ATTRIBUTE_KEY);
+        attributeValue = config.getInitParameter(ATTRIBUTE_VALUE);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.setAttribute(attributeKey, attributeValue);
+        final AsyncContext ctx = req.startAsync();
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(100);
+                    ctx.complete();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        t.start();
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doGet(req, resp);
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/proprietry/IgnoresRequestAndSetsAttributeServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/proprietry/IgnoresRequestAndSetsAttributeServlet.java
@@ -1,0 +1,34 @@
+package io.undertow.servlet.test.proprietry;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class IgnoresRequestAndSetsAttributeServlet extends HttpServlet {
+
+    public static final String ATTRIBUTE_KEY = "attributeKey";
+    public static final String ATTRIBUTE_VALUE = "attributeValue";
+
+    private String attributeKey;
+    private String attributeValue;
+
+    @Override
+    public void init(final ServletConfig config) throws ServletException {
+        super.init(config);
+        attributeKey = config.getInitParameter(ATTRIBUTE_KEY);
+        attributeValue = config.getInitParameter(ATTRIBUTE_VALUE);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.setAttribute(attributeKey, attributeValue);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        doGet(req, resp);
+    }
+}


### PR DESCRIPTION
This reverts commit ebc30db09bb9c69f293e7059d15f6a59d3771868.

Issue: https://issues.jboss.org/browse/UNDERTOW-1573