### PR TITLE
UNDERTOW-1582 Fix NPE while setting up temporary directory

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -20,6 +20,7 @@ package io.undertow.servlet.api;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -653,6 +654,18 @@ public class DeploymentInfo implements Cloneable {
 
     public Path getTempPath() {
         return tempDir;
+    }
+
+    /**
+     * @return Returns the {@link #getTempDir() temp directory path} if it's
+     * not null, else returns the system level temporary directory path
+     * pointed to by the Java system property {@code java.io.tmpdir}
+     */
+    public Path requireTempPath() {
+        if (tempDir != null) {
+            return tempDir;
+        }
+        return Paths.get(SecurityActions.getSystemProperty("java.io.tmpdir"));
     }
 
     public DeploymentInfo setTempDir(final File tempDir) {

--- a/servlet/src/main/java/io/undertow/servlet/api/SecurityActions.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/SecurityActions.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.api;
+
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+final class SecurityActions {
+
+    private SecurityActions() {
+        // forbidden inheritance
+    }
+
+    static String getSystemProperty(final String prop) {
+        if (System.getSecurityManager() == null) {
+            return System.getProperty(prop);
+        } else {
+            return (String) AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                public Object run() {
+                    return System.getProperty(prop);
+                }
+            });
+        }
+    }
+}

--- a/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ManagedServlet.java
@@ -37,6 +37,7 @@ import io.undertow.server.handlers.resource.ResourceChangeListener;
 import io.undertow.server.handlers.resource.ResourceManager;
 import io.undertow.servlet.UndertowServletLogger;
 import io.undertow.servlet.UndertowServletMessages;
+import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.InstanceFactory;
 import io.undertow.servlet.api.InstanceHandle;
@@ -104,7 +105,8 @@ public class ManagedServlet implements Lifecycle {
                 if(locFile.isAbsolute()) {
                     tempDir = locFile;
                 } else {
-                    tempDir = servletContext.getDeployment().getDeploymentInfo().getTempPath().resolve(location);
+                    final DeploymentInfo deploymentInfo = servletContext.getDeployment().getDeploymentInfo();
+                    tempDir = deploymentInfo.requireTempPath().resolve(location);
                 }
             }
 


### PR DESCRIPTION
The commit here fixes a NPE that's reported in https://issues.jboss.org/browse/UNDERTOW-1582. The change here uses the system level temporary directory as the base directory, if no explicit temporary directory is setup.