### PR TITLE
UNDERTOW-1581: Fix RoutingHandler allMethodsMatcher validation

### DIFF
--- a/core/src/main/java/io/undertow/server/RoutingHandler.java
+++ b/core/src/main/java/io/undertow/server/RoutingHandler.java
@@ -125,7 +125,7 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
-        if (allMethodsMatcher.get(template) == null) {
+        if (allMethodsMatcher.match(template) == null) {
             allMethodsMatcher.add(template, res);
         }
         res.defaultHandler = handler;
@@ -161,7 +161,7 @@ public class RoutingHandler implements HttpHandler {
         if (res == null) {
             matcher.add(template, res = new RoutingMatch());
         }
-        if (allMethodsMatcher.get(template) == null) {
+        if (allMethodsMatcher.match(template) == null) {
             allMethodsMatcher.add(template, res);
         }
         res.predicatedHandlers.add(new HandlerHolder(predicate, handler));
@@ -195,7 +195,7 @@ public class RoutingHandler implements HttpHandler {
             // If we use allMethodsMatcher.addAll() we can have duplicate
             // PathTemplates which we want to ignore here so it does not crash.
             for (PathTemplate template : entry.getValue().getPathTemplates()) {
-                if (allMethodsMatcher.get(template.getTemplateString()) == null) {
+                if (allMethodsMatcher.match(template.getTemplateString()) == null) {
                     allMethodsMatcher.add(template, new RoutingMatch());
                 }
             }

--- a/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RoutingHandlerTestCase.java
@@ -126,6 +126,12 @@ public class RoutingHandlerTestCase {
                         exchange.getResponseSender().send("posted foo");
                     }
                 })
+                .add(Methods.POST, "/foo/{baz}", new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        exchange.getResponseSender().send("foo-path" + exchange.getQueryParameters().get("bar"));
+                    }
+                })
                 .add(Methods.GET, "/foo/{bar}", new HttpHandler() {
                     @Override
                     public void handleRequest(HttpServerExchange exchange) throws Exception {


### PR DESCRIPTION
Updates the allMethodsMatcher to lookup templates using the
match method instead of get in order to normalize the input.

Previously registration would throw an exception when routes
were added for the same path template with different parameter names
despite being equivalent.