### PR TITLE
[UNDERTOW-1554] Improve handling and leniency of bad POST parameters

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -27,6 +27,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 
 import io.undertow.server.RequestTooBigException;
 import io.undertow.server.handlers.form.MultiPartParserDefinition;
+import io.undertow.util.UrlDecodeException;
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
@@ -249,7 +250,7 @@ public interface UndertowMessages {
     IllegalStateException matcherAlreadyContainsTemplate(String templateString, String templateString1);
 
     @Message(id = 72, value = "Failed to decode url %s to charset %s")
-    IllegalArgumentException failedToDecodeURL(String s, String enc, @Cause Exception e);
+    UrlDecodeException failedToDecodeURL(String s, String enc, @Cause Exception e);
 
 
     @Message(id = 73, value = "Resource change listeners are not supported")
@@ -597,4 +598,10 @@ public interface UndertowMessages {
 
     @Message(id = 192, value = "Form value is a in-memory file, use getFileItem() instead")
     IllegalStateException formValueIsInMemoryFile();
+
+    @Message(id = 193, value = "Character decoding failed. Parameter [%s] with value [%s] has been ignored. Note: further occurrences of Parameter errors will be logged at DEBUG level.")
+    String failedToDecodeParameterValue(String parameter, String value, @Cause Exception e);
+
+    @Message(id = 194, value = "Character decoding failed. Parameter with name [%s] has been ignored. Note: further occurrences of Parameter errors will be logged at DEBUG level.")
+    String failedToDecodeParameterName(String parameter, @Cause Exception e);
 }

--- a/core/src/main/java/io/undertow/util/UrlDecodeException.java
+++ b/core/src/main/java/io/undertow/util/UrlDecodeException.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.undertow.util;
+
+/**
+ * Created by Marek Marusic <mmarusic@redhat.com> on 7/25/19.
+ */
+public class UrlDecodeException extends IllegalArgumentException {
+
+    public UrlDecodeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/UNDERTOW-1554

Improve handling and leniency of bad POST parameters - Ignore incorrect parameters or values (ones that contain % without any hexadecimal number) in data query.

Example query with result:
$ curl -d "test1=%&test2=foo" http://127.0.0.1:8080/helloworld/HelloWorld 
test2=foo 

Example log:
13:38:04,820 ERROR [io.undertow.request] (default task-1) UT000193: Character decoding failed. Parameter [test1] with value [%] has been ignored. Note: further occurrences of Parameter errors will be logged at DEBUG level.