### PR TITLE
Fixing rewrite handler so that it properly routes to destination servlet

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
@@ -218,6 +218,7 @@ public class RewriteHandler implements HttpHandler {
                 chunk.append(request.getContextPath());
                 chunk.append(urlString);
                 String requestPath = chunk.toString();
+                exchange.setRequestURI(requestPath);
                 exchange.setRequestPath(requestPath);
                 exchange.setRelativePath(urlString);
 

--- a/servlet/src/test/java/io/undertow/servlet/test/compat/rewrite/RewriteTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/compat/rewrite/RewriteTestCase.java
@@ -50,7 +50,6 @@ import java.nio.charset.StandardCharsets;
 @RunWith(DefaultServer.class)
 public class RewriteTestCase {
 
-
     @BeforeClass
     public static void setup() throws ServletException {
         DeploymentUtils.setupServlet(new ServletExtension() {
@@ -68,12 +67,12 @@ public class RewriteTestCase {
                                              });
                                          }
                                      },
-                new ServletInfo("servlet", PathTestServlet.class)
-                        .addMapping("/"));
+                new ServletInfo("fooServlet", PathTestServlet.class).addMapping("/bar1")
+        );
     }
 
     @Test
-    public void testRewrite() throws Exception{
+    public void testRewrite() throws Exception {
 
         TestHttpClient client = new TestHttpClient();
         try {
@@ -81,7 +80,7 @@ public class RewriteTestCase {
             HttpResponse result = client.execute(get);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             String response = HttpClientUtils.readResponse(result);
-            Assert.assertEquals("pathInfo:null queryString:null servletPath:/bar1 requestUri:/servletContext/foo1", response);
+            Assert.assertEquals("pathInfo:null queryString:null servletPath:/bar1 requestUri:/servletContext/bar1", response);
 
         } finally {
             client.getConnectionManager().shutdown();


### PR DESCRIPTION
## Description
- Using `RewriteHandler` does not cause requests to be routed to destination servlet, requests are routed to original servlets instead

  With the rule defined as `RewriteRule /foo1 /bar1` request were still send to `/foo1` servlet

- Enhancing test case to replicate rewrite scenario by removing original servlet that could handle inappropriately rewritten request

## Fix
Setting `requestURI` on `HttpServerExchange` solves the problem
 