### PR TITLE
UNDERTOW-1595 NullPointerException can happen on a range request for …

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/PathResource.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/PathResource.java
@@ -153,8 +153,10 @@ public class PathResource implements RangeAwareResource {
             public void run() {
                 if(range && remaining == 0) {
                     //we are done
-                    pooled.close();
-                    pooled = null;
+                    if (pooled != null) {
+                        pooled.close();
+                        pooled = null;
+                    }
                     IoUtils.safeClose(fileChannel);
                     callback.onComplete(exchange, sender);
                     return;


### PR DESCRIPTION
…a static content