### PR TITLE
Added missing value to sameorigin cookie parser

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -518,7 +518,7 @@ public interface UndertowMessages {
     @Message(id = 161, value = "HTTP/2 header block is too large")
     String headerBlockTooLarge();
 
-    @Message(id = 162, value = "Same-site attribute %s is invalid. It must be Strict or Lax")
+    @Message(id = 162, value = "Same-site attribute %s is invalid. It must be Strict, Lax or None")
     IllegalArgumentException invalidSameSiteMode(String mode);
 
     @Message(id = 163, value = "Invalid token %s")

--- a/core/src/main/java/io/undertow/server/handlers/CookieImpl.java
+++ b/core/src/main/java/io/undertow/server/handlers/CookieImpl.java
@@ -174,6 +174,10 @@ public class CookieImpl implements Cookie {
                     this.setSameSite(true);
                     this.sameSiteMode = "Lax";
                     break;
+                case "none":
+                    this.setSameSite(true);
+                    this.sameSiteMode = "None";
+                    break;
                 default:
                     throw UndertowMessages.MESSAGES.invalidSameSiteMode(sameSiteMode);
             }

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -382,6 +382,13 @@ public class CookiesTestCase {
         Assert.assertEquals("/acme", cookie.getPath());
         Assert.assertTrue(cookie.isSameSite());
         Assert.assertEquals("Lax", cookie.getSameSiteMode());
+
+        cookie = Cookies.parseSetCookieHeader("SHIPPING=FEDEX; path=/pepe; SameSite=None");
+        Assert.assertEquals("SHIPPING", cookie.getName());
+        Assert.assertEquals("FEDEX", cookie.getValue());
+        Assert.assertEquals("/pepe", cookie.getPath());
+        Assert.assertTrue(cookie.isSameSite());
+        Assert.assertEquals("None", cookie.getSameSiteMode());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Hello,

I've encountered the following error while trying to parse cookies using undertow:

```
java.lang.IllegalArgumentException: UT000162: Same-site attribute none is invalid. It must be Strict or Lax
	at io.undertow.server.handlers.CookieImpl.setSameSiteMode(CookieImpl.java:178)
	at io.undertow.util.Cookies.handleValue(Cookies.java:170)
	at io.undertow.util.Cookies.parseSetCookieHeader(Cookies.java:139)
```

This is caused because some sites (e.g. google.com) are sending the following value for sameorigin cookie `SameSite=none`, and your undertow cookie parser only accepts `Strict` or `Lax`:

```    @Override
    public Cookie setSameSiteMode(final String sameSiteMode) {
        if (sameSiteMode != null) {
            switch (sameSiteMode.toLowerCase(Locale.ENGLISH)) {
                case "strict":
                    this.setSameSite(true);
                    this.sameSiteMode = "Strict";
                    break;
                case "lax":
                    this.setSameSite(true);
                    this.sameSiteMode = "Lax";
                    break;
                default:
                    throw UndertowMessages.MESSAGES.invalidSameSiteMode(sameSiteMode);
            }
        }
        return this;
    }
```
Doing some research I've found that `None` appears to be a valid value for that cookie ([draft-ietf](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00)):

```
   Note: There's got to be a better way to specify this.  Until I figure
   out what that is, monkey-patching!

   Alter Section 5.3 of [RFC6265] as follows:

   1.  Add "samesite-flag" to the list of fields stored for each cookie.
       This field's value is one of "None", "Strict", or "Lax".
```

I've added it for you. Hopes it helps.
