### PR TITLE
Fix index out of bounds exception in StoredResponseStreamSinkConduit

### DIFF
--- a/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
@@ -93,7 +93,7 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
         for (int i = 0; i < len; ++i) {
             ByteBuffer buf = srcs[i + offs];
             int pos = starts[i];
-            while (rem > 0 && pos <= buf.position()) {
+            while (rem > 0 && pos < buf.position()) {
                 outputStream.write(buf.get(pos));
                 pos++;
                 rem--;
@@ -130,7 +130,7 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
         for (int i = 0; i < len; ++i) {
             ByteBuffer buf = srcs[i + offs];
             int pos = starts[i];
-            while (rem > 0 && pos <= buf.position()) {
+            while (rem > 0 && pos < buf.position()) {
                 outputStream.write(buf.get(pos));
                 pos++;
                 rem--;


### PR DESCRIPTION
Obvious mistake. buf.position() actually indicates buffer size, so last buffer index is equal to **buf.position() -1**.

With this error, when buffer array has more than one element (so when response is bigger than 16KB by default), exception is thrown and exchange will never be finalized properly (even though HTTP response is received by client and seems fine). Listeners won't be executed, graceful shutdown will fail etc.

Below there is a simple code snippet for reproducing this error:

    public static void main(String[] args) {

        HttpHandler targetHandler = exchange -> {
            exchange.getResponseHeaders().add(Headers.CONTENT_TYPE, "text/plain");
            exchange.getResponseSender().send("A".repeat(20000));
        };

        StoredResponseHandler storedResponseHandler = new StoredResponseHandler(targetHandler);

        Undertow server = Undertow.builder()
                .addHttpListener(5050, "0.0.0.0")
                .setHandler(storedResponseHandler)
                .build();

        server.start();
    }
