### PR TITLE
Forwarded headers support for filtering sources

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ForwardedHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ForwardedHandler.java
@@ -1,6 +1,7 @@
 package io.undertow.server.handlers;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -8,10 +9,14 @@ import io.undertow.server.handlers.builder.HandlerBuilder;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
 import io.undertow.util.NetworkUtils;
+import io.undertow.util.PeerMatcher;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -20,6 +25,12 @@ import static io.undertow.UndertowMessages.MESSAGES;
 
 /**
  * Handler that implements rfc7239 Forwarded header
+ * <p>
+ * This should only be used behind a proxy that always sets this header, otherwise it
+ * is possible for an attacker to forge their peer address;
+ *
+ * It's possible to add rules, that either allow or deny Forwarded header from ips,
+ * using allowed-proxy-addresses and default-allow parameters.
  *
  * @author Stuart Douglas
  */
@@ -33,6 +44,7 @@ public class ForwardedHandler implements HttpHandler {
     private static final String UNKNOWN = "unknown";
 
 
+    private final PeerMatcher peerMatcher = new PeerMatcher();
     private final HttpHandler next;
 
     public ForwardedHandler(HttpHandler next) {
@@ -41,38 +53,40 @@ public class ForwardedHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        HeaderValues forwarded = exchange.getRequestHeaders().get(Headers.FORWARDED);
-        if (forwarded != null) {
-            Map<Token, String> values = new HashMap<>();
-            for (String val : forwarded) {
-                parseHeader(val, values);
-            }
-            String host = values.get(Token.HOST);
-            String proto = values.get(Token.PROTO);
-            String by = values.get(Token.BY);
-            String forVal = values.get(Token.FOR);
-
-            if (host != null) {
-                exchange.getRequestHeaders().put(Headers.HOST, host);
-                exchange.setDestinationAddress(InetSocketAddress.createUnresolved(exchange.getHostName(), exchange.getHostPort()));
-            } else if (by != null) {
-                //we only use 'by' if the host is null
-                InetSocketAddress destAddress = parseAddress(by);
-                if (destAddress != null) {
-                    exchange.setDestinationAddress(destAddress);
+        SocketAddress peer = exchange.getConnection().getPeerAddress();
+        if (peerMatcher.isAllowed(peer)) {
+            HeaderValues forwarded = exchange.getRequestHeaders().get(Headers.FORWARDED);
+            if (forwarded != null) {
+                Map<Token, String> values = new HashMap<>();
+                for (String val : forwarded) {
+                    parseHeader(val, values);
                 }
-            }
-            if (proto != null) {
-                exchange.setRequestScheme(proto);
-            }
-            if (forVal != null) {
-                InetSocketAddress sourceAddress = parseAddress(forVal);
-                if (sourceAddress != null) {
-                    exchange.setSourceAddress(sourceAddress);
+                String host = values.get(Token.HOST);
+                String proto = values.get(Token.PROTO);
+                String by = values.get(Token.BY);
+                String forVal = values.get(Token.FOR);
+
+                if (host != null) {
+                    exchange.getRequestHeaders().put(Headers.HOST, host);
+                    exchange.setDestinationAddress(InetSocketAddress.createUnresolved(exchange.getHostName(), exchange.getHostPort()));
+                } else if (by != null) {
+                    //we only use 'by' if the host is null
+                    InetSocketAddress destAddress = parseAddress(by);
+                    if (destAddress != null) {
+                        exchange.setDestinationAddress(destAddress);
+                    }
+                }
+                if (proto != null) {
+                    exchange.setRequestScheme(proto);
+                }
+                if (forVal != null) {
+                    InetSocketAddress sourceAddress = parseAddress(forVal);
+                    if (sourceAddress != null) {
+                        exchange.setSourceAddress(sourceAddress);
+                    }
                 }
             }
         }
-
 
         next.handleRequest(exchange);
     }
@@ -221,6 +235,24 @@ public class ForwardedHandler implements HttpHandler {
 
     }
 
+    void addAllow(String peer) {
+        peerMatcher.addRule(peer, false);
+    }
+
+    void addDeny(String peer) {
+        peerMatcher.addRule(peer, true);
+    }
+
+    public ForwardedHandler clearRules() {
+        peerMatcher.clearRules();
+        return this;
+    }
+
+    ForwardedHandler setDefaultAllow(final boolean defaultAllow) {
+        peerMatcher.setDefaultAllow(defaultAllow);
+        return this;
+    }
+
     enum Token {
         BY,
         FOR,
@@ -242,14 +274,6 @@ public class ForwardedHandler implements HttpHandler {
         START_OF_NAME, EQUALS_SIGN, START_OF_VALUE, LAST_QUOTE, END_OF_VALUE;
     }
 
-    public static final HandlerWrapper WRAPPER = new HandlerWrapper() {
-        @Override
-        public HttpHandler wrap(HttpHandler handler) {
-            return new ForwardedHandler(handler);
-        }
-    };
-
-
     public static class Builder implements HandlerBuilder {
 
         @Override
@@ -259,7 +283,10 @@ public class ForwardedHandler implements HttpHandler {
 
         @Override
         public Map<String, Class<?>> parameters() {
-            return Collections.emptyMap();
+            Map<String, Class<?>> params = new HashMap<>();
+            params.put("allowed-proxy-addresses", String[].class);
+            params.put("default-allow", boolean.class);
+            return params;
         }
 
         @Override
@@ -274,7 +301,64 @@ public class ForwardedHandler implements HttpHandler {
 
         @Override
         public HandlerWrapper build(Map<String, Object> config) {
-            return WRAPPER;
+            String[] allowedProxyAddresses = (String[]) config.get("allowed-proxy-addresses");
+            Boolean defaultAllow = (Boolean) config.get("default-allow");
+
+            List<Holder> peerMatches = null;
+            if (allowedProxyAddresses != null) {
+                peerMatches = new ArrayList<>();
+                for (String rule : allowedProxyAddresses) {
+                    String[] parts = rule.split(" ");
+                    if (parts.length != 2) {
+                        throw UndertowMessages.MESSAGES.invalidAclRule(rule);
+                    }
+                    if (parts[1].trim().equals("allow")) {
+                        peerMatches.add(new Holder(parts[0].trim(), false));
+                    } else if (parts[1].trim().equals("deny")) {
+                        peerMatches.add(new Holder(parts[0].trim(), true));
+                    } else {
+                        throw UndertowMessages.MESSAGES.invalidAclRule(rule);
+                    }
+                    if (defaultAllow == null && peerMatches.size() > 0) {
+                        defaultAllow = false;
+                    }
+                }
+            }
+            return new Wrapper(peerMatches, defaultAllow == null ? true : defaultAllow);
+        }
+    }
+
+    private static class Wrapper implements HandlerWrapper {
+        private final List<Holder> peerMatches;
+        private final boolean defaultAllow;
+
+        private Wrapper(List<Holder> peerMatches, boolean defaultAllow) {
+            this.peerMatches = peerMatches;
+            this.defaultAllow = defaultAllow;
+        }
+
+        @Override
+        public HttpHandler wrap(HttpHandler handler) {
+            ForwardedHandler res = new ForwardedHandler(handler);
+            for (Holder match : peerMatches) {
+                if (match.deny) {
+                    res.addDeny(match.rule);
+                } else {
+                    res.addAllow(match.rule);
+                }
+            }
+            res.setDefaultAllow(defaultAllow);
+            return res;
+        }
+    }
+
+    private static class Holder {
+        final String rule;
+        final boolean deny;
+
+        private Holder(String rule, boolean deny) {
+            this.rule = rule;
+            this.deny = deny;
         }
     }
 }

--- a/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
@@ -18,27 +18,22 @@
 
 package io.undertow.server.handlers;
 
-import java.net.Inet4Address;
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.regex.Pattern;
-
 import io.undertow.UndertowMessages;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.builder.HandlerBuilder;
+import io.undertow.util.PeerMatcher;
 import io.undertow.util.StatusCodes;
-import org.xnio.Bits;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Handler that can accept or reject a request based on the IP address of the remote peer.
@@ -47,41 +42,9 @@ import org.xnio.Bits;
  */
 public class IPAddressAccessControlHandler implements HttpHandler {
 
-    /**
-     * Standard IP address
-     */
-    private static final Pattern IP4_EXACT = Pattern.compile("(?:\\d{1,3}\\.){3}\\d{1,3}");
-
-    /**
-     * Standard IP address, with some octets replaced by a '*'
-     */
-    private static final Pattern IP4_WILDCARD = Pattern.compile("(?:(?:\\d{1,3}|\\*)\\.){3}(?:\\d{1,3}|\\*)");
-
-    /**
-     * IPv4 address with subnet specified via slash notation
-     */
-    private static final Pattern IP4_SLASH = Pattern.compile("(?:\\d{1,3}\\.){3}\\d{1,3}\\/\\d\\d?");
-
-    /**
-     * Standard full IPv6 address
-     */
-    private static final Pattern IP6_EXACT = Pattern.compile("(?:[a-zA-Z0-9]{1,4}:){7}[a-zA-Z0-9]{1,4}");
-
-    /**
-     * Standard full IPv6 address, with some parts replaced by a '*'
-     */
-    private static final Pattern IP6_WILDCARD = Pattern.compile("(?:(?:[a-zA-Z0-9]{1,4}|\\*):){7}(?:[a-zA-Z0-9]{1,4}|\\*)");
-
-    /**
-     * Standard full IPv6 address with subnet specified via slash notation
-     */
-    private static final Pattern IP6_SLASH = Pattern.compile("(?:[a-zA-Z0-9]{1,4}:){7}[a-zA-Z0-9]{1,4}\\/\\d{1,3}");
-
     private volatile HttpHandler next;
-    private volatile boolean defaultAllow = false;
+    private final PeerMatcher peerMatcher = new PeerMatcher();
     private final int denyResponseCode;
-    private final List<PeerMatch> ipv6acl = new CopyOnWriteArrayList<>();
-    private final List<PeerMatch> ipv4acl = new CopyOnWriteArrayList<>();
 
     public IPAddressAccessControlHandler(final HttpHandler next) {
       this(next, StatusCodes.FORBIDDEN);
@@ -109,20 +72,7 @@ public class IPAddressAccessControlHandler implements HttpHandler {
     }
 
     boolean isAllowed(InetAddress address) {
-        if(address instanceof Inet4Address) {
-            for (PeerMatch rule : ipv4acl) {
-                if (rule.matches(address)) {
-                    return !rule.isDeny();
-                }
-            }
-        } else if(address instanceof Inet6Address) {
-            for (PeerMatch rule : ipv6acl) {
-                if (rule.matches(address)) {
-                    return !rule.isDeny();
-                }
-            }
-        }
-        return defaultAllow;
+        return peerMatcher.isAllowed(address);
     }
 
     public int getDenyResponseCode() {
@@ -130,11 +80,11 @@ public class IPAddressAccessControlHandler implements HttpHandler {
     }
 
     public boolean isDefaultAllow() {
-        return defaultAllow;
+        return this.peerMatcher.isDefaultAllow();
     }
 
     public IPAddressAccessControlHandler setDefaultAllow(final boolean defaultAllow) {
-        this.defaultAllow = defaultAllow;
+        peerMatcher.setDefaultAllow(defaultAllow);
         return this;
     }
 
@@ -185,232 +135,13 @@ public class IPAddressAccessControlHandler implements HttpHandler {
     }
 
     public IPAddressAccessControlHandler clearRules() {
-        this.ipv4acl.clear();
-        this.ipv6acl.clear();
+        peerMatcher.clearRules();
         return this;
     }
 
     private IPAddressAccessControlHandler addRule(final String peer, final boolean deny) {
-        if (IP4_EXACT.matcher(peer).matches()) {
-            addIpV4ExactMatch(peer, deny);
-        } else if (IP4_WILDCARD.matcher(peer).matches()) {
-            addIpV4WildcardMatch(peer, deny);
-        } else if (IP4_SLASH.matcher(peer).matches()) {
-            addIpV4SlashPrefix(peer, deny);
-        } else if (IP6_EXACT.matcher(peer).matches()) {
-            addIpV6ExactMatch(peer, deny);
-        } else if (IP6_WILDCARD.matcher(peer).matches()) {
-            addIpV6WildcardMatch(peer, deny);
-        } else if (IP6_SLASH.matcher(peer).matches()) {
-            addIpV6SlashPrefix(peer, deny);
-        } else {
-            throw UndertowMessages.MESSAGES.notAValidIpPattern(peer);
-        }
+        peerMatcher.addRule(peer, deny);
         return this;
-    }
-
-    private void addIpV6SlashPrefix(final String peer, final boolean deny) {
-        String[] components = peer.split("\\/");
-        String[] parts = components[0].split("\\:");
-        int maskLen = Integer.parseInt(components[1]);
-        assert parts.length == 8;
-
-
-        byte[] pattern = new byte[16];
-        byte[] mask = new byte[16];
-
-        for (int i = 0; i < 8; ++i) {
-            int val = Integer.parseInt(parts[i], 16);
-            pattern[i * 2] = (byte) (val >> 8);
-            pattern[i * 2 + 1] = (byte) (val & 0xFF);
-        }
-        for (int i = 0; i < 16; ++i) {
-            if (maskLen > 8) {
-                mask[i] = (byte) (0xFF);
-                maskLen -= 8;
-            } else if (maskLen != 0) {
-                mask[i] = (byte) (Bits.intBitMask(8 - maskLen, 7) & 0xFF);
-                maskLen = 0;
-            } else {
-                break;
-            }
-        }
-        ipv6acl.add(new PrefixIpV6PeerMatch(deny, peer, mask, pattern));
-    }
-
-    private void addIpV4SlashPrefix(final String peer, final boolean deny) {
-        String[] components = peer.split("\\/");
-        String[] parts = components[0].split("\\.");
-        int maskLen = Integer.parseInt(components[1]);
-        final int mask = Bits.intBitMask(32 - maskLen, 31);
-        int prefix = 0;
-        for (int i = 0; i < 4; ++i) {
-            prefix <<= 8;
-            String part = parts[i];
-            int no = Integer.parseInt(part);
-            prefix |= no;
-        }
-        ipv4acl.add(new PrefixIpV4PeerMatch(deny, peer, mask, prefix));
-    }
-
-    private void addIpV6WildcardMatch(final String peer, final boolean deny) {
-        byte[] pattern = new byte[16];
-        byte[] mask = new byte[16];
-        String[] parts = peer.split("\\:");
-        assert parts.length == 8;
-        for (int i = 0; i < 8; ++i) {
-            if (!parts[i].equals("*")) {
-                int val = Integer.parseInt(parts[i], 16);
-                pattern[i * 2] = (byte) (val >> 8);
-                pattern[i * 2 + 1] = (byte) (val & 0xFF);
-                mask[i * 2] = (byte) (0xFF);
-                mask[i * 2 + 1] = (byte) (0xFF);
-            }
-        }
-        ipv6acl.add(new PrefixIpV6PeerMatch(deny, peer, mask, pattern));
-    }
-
-    private void addIpV4WildcardMatch(final String peer, final boolean deny) {
-        String[] parts = peer.split("\\.");
-        int mask = 0;
-        int prefix = 0;
-        for (int i = 0; i < 4; ++i) {
-            mask <<= 8;
-            prefix <<= 8;
-            String part = parts[i];
-            if (!part.equals("*")) {
-                int no = Integer.parseInt(part);
-                mask |= 0xFF;
-                prefix |= no;
-            }
-        }
-        ipv4acl.add(new PrefixIpV4PeerMatch(deny, peer, mask, prefix));
-    }
-
-    private void addIpV6ExactMatch(final String peer, final boolean deny) {
-        byte[] bytes = new byte[16];
-        String[] parts = peer.split("\\:");
-        assert parts.length == 8;
-        for (int i = 0; i < 8; ++i) {
-            int val = Integer.parseInt(parts[i], 16);
-            bytes[i * 2] = (byte) (val >> 8);
-            bytes[i * 2 + 1] = (byte) (val & 0xFF);
-        }
-        ipv6acl.add(new ExactIpV6PeerMatch(deny, peer, bytes));
-    }
-
-    private void addIpV4ExactMatch(final String peer, final boolean deny) {
-        String[] parts = peer.split("\\.");
-        byte[] bytes = {(byte) Integer.parseInt(parts[0]), (byte) Integer.parseInt(parts[1]), (byte) Integer.parseInt(parts[2]), (byte) Integer.parseInt(parts[3])};
-        ipv4acl.add(new ExactIpV4PeerMatch(deny, peer, bytes));
-    }
-
-
-    abstract static class PeerMatch {
-
-        private final boolean deny;
-        private final String pattern;
-
-        protected PeerMatch(final boolean deny, final String pattern) {
-            this.deny = deny;
-            this.pattern = pattern;
-        }
-
-        abstract boolean matches(final InetAddress address);
-
-        boolean isDeny() {
-            return deny;
-        }
-
-        @Override
-        public String toString() {
-            return getClass().getSimpleName() + "{" +
-                    "deny=" + deny +
-                    ", pattern='" + pattern + '\'' +
-                    '}';
-        }
-    }
-
-    static class ExactIpV4PeerMatch extends PeerMatch {
-
-        private final byte[] address;
-
-        protected ExactIpV4PeerMatch(final boolean deny, final String pattern, final byte[] address) {
-            super(deny, pattern);
-            this.address = address;
-        }
-
-        @Override
-        boolean matches(final InetAddress address) {
-            return Arrays.equals(address.getAddress(), this.address);
-        }
-    }
-
-    static class ExactIpV6PeerMatch extends PeerMatch {
-
-        private final byte[] address;
-
-        protected ExactIpV6PeerMatch(final boolean deny, final String pattern, final byte[] address) {
-            super(deny, pattern);
-            this.address = address;
-        }
-
-        @Override
-        boolean matches(final InetAddress address) {
-            return Arrays.equals(address.getAddress(), this.address);
-        }
-    }
-
-    private static class PrefixIpV4PeerMatch extends PeerMatch {
-
-        private final int mask;
-        private final int prefix;
-
-        protected PrefixIpV4PeerMatch(final boolean deny, final String pattern, final int mask, final int prefix) {
-            super(deny, pattern);
-            this.mask = mask;
-            this.prefix = prefix;
-        }
-
-        @Override
-        boolean matches(final InetAddress address) {
-            byte[] bytes = address.getAddress();
-            if (bytes == null) {
-                return false;
-            }
-            int addressInt = ((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16) | ((bytes[2] & 0xFF) << 8) | (bytes[3] & 0xFF);
-            return (addressInt & mask) == prefix;
-        }
-    }
-
-    static class PrefixIpV6PeerMatch extends PeerMatch {
-
-        private final byte[] mask;
-        private final byte[] prefix;
-
-        protected PrefixIpV6PeerMatch(final boolean deny, final String pattern, final byte[] mask, final byte[] prefix) {
-            super(deny, pattern);
-            this.mask = mask;
-            this.prefix = prefix;
-            assert mask.length == prefix.length;
-        }
-
-        @Override
-        boolean matches(final InetAddress address) {
-            byte[] bytes = address.getAddress();
-            if (bytes == null) {
-                return false;
-            }
-            if (bytes.length != mask.length) {
-                return false;
-            }
-            for (int i = 0; i < mask.length; ++i) {
-                if ((bytes[i] & mask[i]) != prefix[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
     }
 
 

--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -19,18 +19,23 @@
 package io.undertow.server.handlers;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
 import io.undertow.server.HandlerWrapper;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.builder.HandlerBuilder;
 import io.undertow.util.Headers;
 import io.undertow.util.NetworkUtils;
+import io.undertow.util.PeerMatcher;
 
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * Handler that sets the peer address to the value of the X-Forwarded-For header.
@@ -38,14 +43,14 @@ import java.util.regex.Pattern;
  * This should only be used behind a proxy that always sets this header, otherwise it
  * is possible for an attacker to forge their peer address;
  *
+ * It's possible to add rules, that either allow or deny X-Forwarded-* headers from ips,
+ * using allowed-proxy-addresses and default-allow parameters.
+ *
  * @author Stuart Douglas
  */
 public class ProxyPeerAddressHandler implements HttpHandler {
 
-    private static final Pattern IP4_EXACT = Pattern.compile("(?:\\d{1,3}\\.){3}\\d{1,3}");
-
-    private static final Pattern IP6_EXACT = Pattern.compile("(?:[a-zA-Z0-9]{1,4}:){7}[a-zA-Z0-9]{1,4}");
-
+    private final PeerMatcher peerMatcher = new PeerMatcher();
     private final HttpHandler next;
 
     public ProxyPeerAddressHandler(HttpHandler next) {
@@ -54,63 +59,59 @@ public class ProxyPeerAddressHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        String forwardedFor = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_FOR);
-        if (forwardedFor != null) {
-            String remoteClient = mostRecent(forwardedFor);
-            //we have no way of knowing the port
-            if(IP4_EXACT.matcher(forwardedFor).matches()) {
-                exchange.setSourceAddress(new InetSocketAddress(NetworkUtils.parseIpv4Address(remoteClient), 0));
-            } else if(IP6_EXACT.matcher(forwardedFor).matches()) {
-                exchange.setSourceAddress(new InetSocketAddress(NetworkUtils.parseIpv6Address(remoteClient), 0));
-            } else {
-                exchange.setSourceAddress(InetSocketAddress.createUnresolved(remoteClient, 0));
+        SocketAddress peer = exchange.getConnection().getPeerAddress();
+        if (peerMatcher.isAllowed(peer)) {
+            String forwardedFor = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_FOR);
+            if (forwardedFor != null) {
+                String remoteClient = mostRecent(forwardedFor);
+                exchange.setSourceAddress(ForwardedHandler.parseAddress(remoteClient));
             }
-        }
-        String forwardedProto = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PROTO);
-        if (forwardedProto != null) {
-            exchange.setRequestScheme(mostRecent(forwardedProto));
-        }
-        String forwardedHost = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_HOST);
-        String forwardedPort = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PORT);
-        if (forwardedHost != null) {
-            String value = mostRecent(forwardedHost);
-            if(value.startsWith("[")) {
-                int end = value.lastIndexOf("]");
-                if(end == -1 ) {
-                    end = 0;
-                }
-                int index = value.indexOf(":", end);
-                if(index != -1) {
-                    forwardedPort = value.substring(index + 1);
-                    value = value.substring(0, index);
-                }
-            } else {
-                int index = value.lastIndexOf(":");
-                if(index != -1) {
-                    forwardedPort = value.substring(index + 1);
-                    value = value.substring(0, index);
-                }
+            String forwardedProto = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PROTO);
+            if (forwardedProto != null) {
+                exchange.setRequestScheme(mostRecent(forwardedProto));
             }
-            int port = 0;
-            String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
-            if(forwardedPort != null) {
-                try {
-                    port = Integer.parseInt(mostRecent(forwardedPort));
-                    if(port > 0) {
-                        String scheme = exchange.getRequestScheme();
-
-                        if (!standardPort(port, scheme)) {
-                            hostHeader += ":" + port;
-                        }
-                    } else {
-                        UndertowLogger.REQUEST_LOGGER.debugf("Ignoring negative port: %s", forwardedPort);
+            String forwardedHost = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_HOST);
+            String forwardedPort = exchange.getRequestHeaders().getFirst(Headers.X_FORWARDED_PORT);
+            if (forwardedHost != null) {
+                String value = mostRecent(forwardedHost);
+                if (value.startsWith("[")) {
+                    int end = value.lastIndexOf("]");
+                    if (end == -1) {
+                        end = 0;
                     }
-                } catch (NumberFormatException ignore) {
-                    UndertowLogger.REQUEST_LOGGER.debugf("Cannot parse port: %s", forwardedPort);
+                    int index = value.indexOf(":", end);
+                    if (index != -1) {
+                        forwardedPort = value.substring(index + 1);
+                        value = value.substring(0, index);
+                    }
+                } else {
+                    int index = value.lastIndexOf(":");
+                    if (index != -1) {
+                        forwardedPort = value.substring(index + 1);
+                        value = value.substring(0, index);
+                    }
                 }
+                int port = 80;
+                String hostHeader = NetworkUtils.formatPossibleIpv6Address(value);
+                if (forwardedPort != null) {
+                    try {
+                        port = Integer.parseInt(mostRecent(forwardedPort));
+                        if (port > 0) {
+                            String scheme = exchange.getRequestScheme();
+
+                            if (!standardPort(port, scheme)) {
+                                hostHeader += ":" + port;
+                            }
+                        } else {
+                            UndertowLogger.REQUEST_LOGGER.debugf("Ignoring negative port: %s", forwardedPort);
+                        }
+                    } catch (NumberFormatException ignore) {
+                        UndertowLogger.REQUEST_LOGGER.debugf("Cannot parse port: %s", forwardedPort);
+                    }
+                }
+                exchange.getRequestHeaders().put(Headers.HOST, hostHeader);
+                exchange.setDestinationAddress(InetSocketAddress.createUnresolved(value, port));
             }
-            exchange.getRequestHeaders().put(Headers.HOST, hostHeader);
-            exchange.setDestinationAddress(InetSocketAddress.createUnresolved(value, port));
         }
         next.handleRequest(exchange);
     }
@@ -128,6 +129,24 @@ public class ProxyPeerAddressHandler implements HttpHandler {
         return (port == 80 && "http".equals(scheme)) || (port == 443 && "https".equals(scheme));
     }
 
+    void addAllow(String peer) {
+        peerMatcher.addRule(peer, false);
+    }
+
+    void addDeny(String peer) {
+        peerMatcher.addRule(peer, true);
+    }
+
+    public ProxyPeerAddressHandler clearRules() {
+        peerMatcher.clearRules();
+        return this;
+    }
+
+    ProxyPeerAddressHandler setDefaultAllow(final boolean defaultAllow) {
+        peerMatcher.setDefaultAllow(defaultAllow);
+        return this;
+    }
+
     public static class Builder implements HandlerBuilder {
 
         @Override
@@ -137,7 +156,10 @@ public class ProxyPeerAddressHandler implements HttpHandler {
 
         @Override
         public Map<String, Class<?>> parameters() {
-            return Collections.emptyMap();
+            Map<String, Class<?>> params = new HashMap<>();
+            params.put("allowed-proxy-addresses", String[].class);
+            params.put("default-allow", boolean.class);
+            return params;
         }
 
         @Override
@@ -152,15 +174,65 @@ public class ProxyPeerAddressHandler implements HttpHandler {
 
         @Override
         public HandlerWrapper build(Map<String, Object> config) {
-            return new Wrapper();
+            String[] allowedProxyAddresses = (String[]) config.get("allowed-proxy-addresses");
+            Boolean defaultAllow = (Boolean) config.get("default-allow");
+
+            List<Holder> peerMatches = null;
+            if (allowedProxyAddresses != null) {
+                peerMatches = new ArrayList<>();
+                for (String rule : allowedProxyAddresses) {
+                    String[] parts = rule.split(" ");
+                    if (parts.length != 2) {
+                        throw UndertowMessages.MESSAGES.invalidAclRule(rule);
+                    }
+                    if (parts[1].trim().equals("allow")) {
+                        peerMatches.add(new Holder(parts[0].trim(), false));
+                    } else if (parts[1].trim().equals("deny")) {
+                        peerMatches.add(new Holder(parts[0].trim(), true));
+                    } else {
+                        throw UndertowMessages.MESSAGES.invalidAclRule(rule);
+                    }
+                }
+                if (defaultAllow == null && peerMatches.size() > 0) {
+                    defaultAllow = false;
+                }
+            }
+            return new Wrapper(peerMatches, defaultAllow == null ? true : defaultAllow);
         }
 
     }
 
     private static class Wrapper implements HandlerWrapper {
+        private final List<Holder> peerMatches;
+        private final boolean defaultAllow;
+
+        private Wrapper(List<Holder> peerMatches, boolean defaultAllow) {
+            this.peerMatches = peerMatches;
+            this.defaultAllow = defaultAllow;
+        }
+
         @Override
         public HttpHandler wrap(HttpHandler handler) {
-            return new ProxyPeerAddressHandler(handler);
+            ProxyPeerAddressHandler res = new ProxyPeerAddressHandler(handler);
+            for (Holder match : peerMatches) {
+                if (match.deny) {
+                    res.addDeny(match.rule);
+                } else {
+                    res.addAllow(match.rule);
+                }
+            }
+            res.setDefaultAllow(defaultAllow);
+            return res;
+        }
+    }
+
+    private static class Holder {
+        final String rule;
+        final boolean deny;
+
+        private Holder(String rule, boolean deny) {
+            this.rule = rule;
+            this.deny = deny;
         }
     }
 }

--- a/core/src/main/java/io/undertow/util/PeerMatcher.java
+++ b/core/src/main/java/io/undertow/util/PeerMatcher.java
@@ -1,0 +1,351 @@
+package io.undertow.util;
+
+import io.undertow.UndertowMessages;
+import org.xnio.Bits;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.regex.Pattern;
+
+public class PeerMatcher {
+    /**
+     * Standard IP address
+     */
+    private static final Pattern IP4_EXACT = Pattern.compile("(?:\\d{1,3}\\.){3}\\d{1,3}");
+
+    /**
+     * Standard IP address, with some octets replaced by a '*'
+     */
+    private static final Pattern IP4_WILDCARD = Pattern.compile("(?:(?:\\d{1,3}|\\*)\\.){3}(?:\\d{1,3}|\\*)");
+
+    /**
+     * IPv4 address with subnet specified via slash notation
+     */
+    private static final Pattern IP4_SLASH = Pattern.compile("(?:\\d{1,3}\\.){3}\\d{1,3}\\/\\d\\d?");
+
+    /**
+     * Standard full IPv6 address
+     */
+    private static final Pattern IP6_EXACT = Pattern.compile("(?:[a-zA-Z0-9]{1,4}:){7}[a-zA-Z0-9]{1,4}");
+
+    /**
+     * Standard full IPv6 address, with some parts replaced by a '*'
+     */
+    private static final Pattern IP6_WILDCARD = Pattern.compile("(?:(?:[a-zA-Z0-9]{1,4}|\\*):){7}(?:[a-zA-Z0-9]{1,4}|\\*)");
+
+    /**
+     * Standard full IPv6 address with subnet specified via slash notation
+     */
+    private static final Pattern IP6_SLASH = Pattern.compile("(?:[a-zA-Z0-9]{1,4}:){7}[a-zA-Z0-9]{1,4}\\/\\d{1,3}");
+
+    private volatile boolean defaultAllow = false;
+    private final List<PeerMatch> ipv6acl = new CopyOnWriteArrayList<>();
+    private final List<PeerMatch> ipv4acl = new CopyOnWriteArrayList<>();
+
+    public PeerMatcher setDefaultAllow(final boolean defaultAllow) {
+        this.defaultAllow = defaultAllow;
+        return this;
+    }
+
+    public boolean isDefaultAllow() {
+        return defaultAllow;
+    }
+
+    public boolean isAllowed(SocketAddress peer) {
+        if (peer instanceof InetSocketAddress) {
+            InetAddress inetAddress = ((InetSocketAddress) peer).getAddress();
+            return isAllowed(inetAddress);
+        }
+        return defaultAllow;
+    }
+
+    public boolean isAllowed(InetAddress address) {
+        if(address instanceof Inet4Address) {
+            for (PeerMatch rule : ipv4acl) {
+                if (rule.matches(address)) {
+                    return !rule.isDeny();
+                }
+            }
+        } else if(address instanceof Inet6Address) {
+            for (PeerMatch rule : ipv6acl) {
+                if (rule.matches(address)) {
+                    return !rule.isDeny();
+                }
+            }
+        }
+        return defaultAllow;
+    }
+
+    /**
+     * Adds an allowed peer to the ACL list
+     * <p>
+     * Peer can take several forms:
+     * <p>
+     * a.b.c.d = Literal IPv4 Address
+     * a:b:c:d:e:f:g:h = Literal IPv6 Address
+     * a.b.* = Wildcard IPv4 Address
+     * a:b:* = Wildcard IPv6 Address
+     * a.b.c.0/24 = Classless wildcard IPv4 address
+     * a:b:c:d:e:f:g:0/120 = Classless wildcard IPv4 address
+     *
+     * @param peer The peer to add to the ACL
+     * @return
+     */
+    public PeerMatcher addAllow(final String peer) {
+        return addRule(peer, false);
+    }
+
+    /**
+     * Adds an denied peer to the ACL list
+     * <p>
+     * Peer can take several forms:
+     * <p>
+     * a.b.c.d = Literal IPv4 Address
+     * a:b:c:d:e:f:g:h = Literal IPv6 Address
+     * a.b.* = Wildcard IPv4 Address
+     * a:b:* = Wildcard IPv6 Address
+     * a.b.c.0/24 = Classless wildcard IPv4 address
+     * a:b:c:d:e:f:g:0/120 = Classless wildcard IPv4 address
+     *
+     * @param peer The peer to add to the ACL
+     * @return
+     */
+    public PeerMatcher addDeny(final String peer) {
+        return addRule(peer, true);
+    }
+
+    public PeerMatcher clearRules() {
+        this.ipv4acl.clear();
+        this.ipv6acl.clear();
+        return this;
+    }
+
+    public PeerMatcher addRule(final String peer, final boolean deny) {
+        if (IP4_EXACT.matcher(peer).matches()) {
+            addIpV4ExactMatch(peer, deny);
+        } else if (IP4_WILDCARD.matcher(peer).matches()) {
+            addIpV4WildcardMatch(peer, deny);
+        } else if (IP4_SLASH.matcher(peer).matches()) {
+            addIpV4SlashPrefix(peer, deny);
+        } else if (IP6_EXACT.matcher(peer).matches()) {
+            addIpV6ExactMatch(peer, deny);
+        } else if (IP6_WILDCARD.matcher(peer).matches()) {
+            addIpV6WildcardMatch(peer, deny);
+        } else if (IP6_SLASH.matcher(peer).matches()) {
+            addIpV6SlashPrefix(peer, deny);
+        } else {
+            throw UndertowMessages.MESSAGES.notAValidIpPattern(peer);
+        }
+        return this;
+    }
+
+    private void addIpV6SlashPrefix(final String peer, final boolean deny) {
+        String[] components = peer.split("\\/");
+        String[] parts = components[0].split("\\:");
+        int maskLen = Integer.parseInt(components[1]);
+        assert parts.length == 8;
+
+
+        byte[] pattern = new byte[16];
+        byte[] mask = new byte[16];
+
+        for (int i = 0; i < 8; ++i) {
+            int val = Integer.parseInt(parts[i], 16);
+            pattern[i * 2] = (byte) (val >> 8);
+            pattern[i * 2 + 1] = (byte) (val & 0xFF);
+        }
+        for (int i = 0; i < 16; ++i) {
+            if (maskLen > 8) {
+                mask[i] = (byte) (0xFF);
+                maskLen -= 8;
+            } else if (maskLen != 0) {
+                mask[i] = (byte) (Bits.intBitMask(8 - maskLen, 7) & 0xFF);
+                maskLen = 0;
+            } else {
+                break;
+            }
+        }
+        ipv6acl.add(new PrefixIpV6PeerMatch(deny, peer, mask, pattern));
+    }
+
+    private void addIpV4SlashPrefix(final String peer, final boolean deny) {
+        String[] components = peer.split("\\/");
+        String[] parts = components[0].split("\\.");
+        int maskLen = Integer.parseInt(components[1]);
+        final int mask = Bits.intBitMask(32 - maskLen, 31);
+        int prefix = 0;
+        for (int i = 0; i < 4; ++i) {
+            prefix <<= 8;
+            String part = parts[i];
+            int no = Integer.parseInt(part);
+            prefix |= no;
+        }
+        ipv4acl.add(new PrefixIpV4PeerMatch(deny, peer, mask, prefix));
+    }
+
+    private void addIpV6WildcardMatch(final String peer, final boolean deny) {
+        byte[] pattern = new byte[16];
+        byte[] mask = new byte[16];
+        String[] parts = peer.split("\\:");
+        assert parts.length == 8;
+        for (int i = 0; i < 8; ++i) {
+            if (!parts[i].equals("*")) {
+                int val = Integer.parseInt(parts[i], 16);
+                pattern[i * 2] = (byte) (val >> 8);
+                pattern[i * 2 + 1] = (byte) (val & 0xFF);
+                mask[i * 2] = (byte) (0xFF);
+                mask[i * 2 + 1] = (byte) (0xFF);
+            }
+        }
+        ipv6acl.add(new PrefixIpV6PeerMatch(deny, peer, mask, pattern));
+    }
+
+    private void addIpV4WildcardMatch(final String peer, final boolean deny) {
+        String[] parts = peer.split("\\.");
+        int mask = 0;
+        int prefix = 0;
+        for (int i = 0; i < 4; ++i) {
+            mask <<= 8;
+            prefix <<= 8;
+            String part = parts[i];
+            if (!part.equals("*")) {
+                int no = Integer.parseInt(part);
+                mask |= 0xFF;
+                prefix |= no;
+            }
+        }
+        ipv4acl.add(new PrefixIpV4PeerMatch(deny, peer, mask, prefix));
+    }
+
+    private void addIpV6ExactMatch(final String peer, final boolean deny) {
+        byte[] bytes = new byte[16];
+        String[] parts = peer.split("\\:");
+        assert parts.length == 8;
+        for (int i = 0; i < 8; ++i) {
+            int val = Integer.parseInt(parts[i], 16);
+            bytes[i * 2] = (byte) (val >> 8);
+            bytes[i * 2 + 1] = (byte) (val & 0xFF);
+        }
+        ipv6acl.add(new ExactIpV6PeerMatch(deny, peer, bytes));
+    }
+
+    private void addIpV4ExactMatch(final String peer, final boolean deny) {
+        String[] parts = peer.split("\\.");
+        byte[] bytes = {(byte) Integer.parseInt(parts[0]), (byte) Integer.parseInt(parts[1]), (byte) Integer.parseInt(parts[2]), (byte) Integer.parseInt(parts[3])};
+        ipv4acl.add(new ExactIpV4PeerMatch(deny, peer, bytes));
+    }
+
+
+    abstract static class PeerMatch {
+
+        private final boolean deny;
+        private final String pattern;
+
+        protected PeerMatch(final boolean deny, final String pattern) {
+            this.deny = deny;
+            this.pattern = pattern;
+        }
+
+        abstract boolean matches(final InetAddress address);
+
+        boolean isDeny() {
+            return deny;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{" +
+                    "deny=" + deny +
+                    ", pattern='" + pattern + '\'' +
+                    '}';
+        }
+    }
+
+    static class ExactIpV4PeerMatch extends PeerMatch {
+
+        private final byte[] address;
+
+        protected ExactIpV4PeerMatch(final boolean deny, final String pattern, final byte[] address) {
+            super(deny, pattern);
+            this.address = address;
+        }
+
+        @Override
+        boolean matches(final InetAddress address) {
+            return Arrays.equals(address.getAddress(), this.address);
+        }
+    }
+
+    static class ExactIpV6PeerMatch extends PeerMatch {
+
+        private final byte[] address;
+
+        protected ExactIpV6PeerMatch(final boolean deny, final String pattern, final byte[] address) {
+            super(deny, pattern);
+            this.address = address;
+        }
+
+        @Override
+        boolean matches(final InetAddress address) {
+            return Arrays.equals(address.getAddress(), this.address);
+        }
+    }
+
+    static class PrefixIpV4PeerMatch extends PeerMatch {
+
+        private final int mask;
+        private final int prefix;
+
+        protected PrefixIpV4PeerMatch(final boolean deny, final String pattern, final int mask, final int prefix) {
+            super(deny, pattern);
+            this.mask = mask;
+            this.prefix = prefix;
+        }
+
+        @Override
+        boolean matches(final InetAddress address) {
+            byte[] bytes = address.getAddress();
+            if (bytes == null) {
+                return false;
+            }
+            int addressInt = ((bytes[0] & 0xFF) << 24) | ((bytes[1] & 0xFF) << 16) | ((bytes[2] & 0xFF) << 8) | (bytes[3] & 0xFF);
+            return (addressInt & mask) == prefix;
+        }
+    }
+
+    static class PrefixIpV6PeerMatch extends PeerMatch {
+
+        private final byte[] mask;
+        private final byte[] prefix;
+
+        protected PrefixIpV6PeerMatch(final boolean deny, final String pattern, final byte[] mask, final byte[] prefix) {
+            super(deny, pattern);
+            this.mask = mask;
+            this.prefix = prefix;
+            assert mask.length == prefix.length;
+        }
+
+        @Override
+        boolean matches(final InetAddress address) {
+            byte[] bytes = address.getAddress();
+            if (bytes == null) {
+                return false;
+            }
+            if (bytes.length != mask.length) {
+                return false;
+            }
+            for (int i = 0; i < mask.length; ++i) {
+                if ((bytes[i] & mask[i]) != prefix[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/server/handlers/ProxyPeerAddressHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/ProxyPeerAddressHandlerTestCase.java
@@ -1,0 +1,275 @@
+package io.undertow.server.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.ProxyIgnore;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+@RunWith(DefaultServer.class)
+@ProxyIgnore
+public class ProxyPeerAddressHandlerTestCase {
+
+    @BeforeClass
+    public static void setup() {
+
+    }
+
+    private static String[] run(String forVal, String host, String port, String proto) throws IOException {
+
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            if (forVal != null) {
+                get.addHeader(Headers.X_FORWARDED_FOR_STRING, forVal);
+            }
+            if (host != null) {
+                get.addHeader(Headers.X_FORWARDED_HOST_STRING, host);
+            }
+            if (port != null) {
+                get.addHeader(Headers.X_FORWARDED_PORT_STRING, port);
+            }
+            if (proto != null) {
+                get.addHeader(Headers.X_FORWARDED_PROTO_STRING, proto);
+            }
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            return HttpClientUtils.readResponse(result).split("\\|");
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testProxyPeerAddressHandler() throws IOException {
+        DefaultServer.setRootHandler(new ProxyPeerAddressHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                exchange.getResponseSender().send(exchange.getRequestScheme() + "|" + exchange.getHostAndPort() + "|" + exchange.getDestinationAddress() + "|" + exchange.getSourceAddress());
+            }
+        }).setDefaultAllow(true));
+
+        String[] res = run(null, null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+
+        res = run(null, "google.com", null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals("google.com", res[1]);
+        Assert.assertEquals("google.com:80", res[2]);
+
+        res = run(null, "google.com", null, "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("google.com", res[1]);
+        Assert.assertEquals("google.com:80", res[2]);
+
+        res = run("8.8.8.8:3545", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/8.8.8.8:3545", res[3]);
+
+        res = run("8.8.8.8:3545, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/8.8.8.8:3545", res[3]);
+
+        res = run("[::1]:3545, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:3545", res[3]);
+
+        res = run("[::1]:_foo, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:0", res[3]);
+
+        res = run("[::1], 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:0", res[3]);
+
+        res = run("9.9.9.9:2343", "[::1]", null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals("[::1]", res[1]);
+        Assert.assertEquals("[::1]:80", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com", "0", null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals("google.com", res[1]);
+        Assert.assertEquals("google.com:0", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com", "80", "http");
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals("google.com", res[1]);
+        Assert.assertEquals("google.com:80", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+
+        res = run("9.9.9.9:2343", "google.com", "443", "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("google.com", res[1]);
+        Assert.assertEquals("google.com:443", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+
+        res = run("9.9.9.9:2343", "google.com", "8443", "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("google.com:8443", res[1]);
+        Assert.assertEquals("google.com:8443", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com:8443", null, "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("google.com:8443", res[1]);
+        Assert.assertEquals("google.com:8443", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com:8443", "8444", "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("google.com:8443", res[1]);
+        Assert.assertEquals("google.com:8443", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "[::1]:8443", null, "https");
+        Assert.assertEquals("https", res[0]);
+        Assert.assertEquals("[::1]:8443", res[1]);
+        Assert.assertEquals("[::1]:8443", res[2]);
+        Assert.assertEquals("/9.9.9.9:2343", res[3]);
+
+    }
+
+    @Test
+    public void testProxyPeerAddressHandlerWithAllowedProxyPeer() throws IOException {
+        ProxyPeerAddressHandler handler = new ProxyPeerAddressHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                exchange.getResponseSender().send(exchange.getRequestScheme() + "|" + exchange.getHostAndPort() + "|" + exchange.getDestinationAddress() + "|" + exchange.getSourceAddress());
+            }
+        }).setDefaultAllow(false);
+        DefaultServer.setRootHandler(handler);
+
+        String[] res = run(null, null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+
+        res = run(null, "google.com", null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+
+        res = run(null, "google.com", null, "https");
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+
+        handler.addAllow("127.0.0.1");
+
+        res = run("8.8.8.8:3545", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/8.8.8.8:3545", res[3]);
+
+        res = run("8.8.8.8:3545, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/8.8.8.8:3545", res[3]);
+
+        res = run("[::1]:3545, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:3545", res[3]);
+
+        res = run("[::1]:_foo, 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:0", res[3]);
+
+        res = run("[::1], 9.9.9.9:2343", null, null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertEquals(DefaultServer.getHostAddress() + ":" + DefaultServer.getHostPort(), res[1]);
+        Assert.assertEquals("/" + InetAddress.getByName(DefaultServer.getHostAddress()).getHostAddress() + ":" + DefaultServer.getHostPort(), res[2]);
+        Assert.assertEquals("/0:0:0:0:0:0:0:1:0", res[3]);
+
+        handler.clearRules();
+        handler.addDeny("127.0.0.1");
+
+        res = run("9.9.9.9:2343", "[::1]", null, null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertNotEquals("[::1]", res[1]);
+        Assert.assertNotEquals("[::1]:80", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com", "0", null);
+        Assert.assertEquals("http", res[0]);
+        Assert.assertNotEquals("google.com", res[1]);
+        Assert.assertNotEquals("google.com:0", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com", "80", "http");
+        Assert.assertEquals("http", res[0]);
+        Assert.assertNotEquals("google.com", res[1]);
+        Assert.assertNotEquals("google.com:80", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+
+        res = run("9.9.9.9:2343", "google.com", "443", "https");
+        Assert.assertNotEquals("https", res[0]);
+        Assert.assertNotEquals("google.com", res[1]);
+        Assert.assertNotEquals("google.com:443", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+
+        res = run("9.9.9.9:2343", "google.com", "8443", "https");
+        Assert.assertNotEquals("https", res[0]);
+        Assert.assertNotEquals("google.com:8443", res[1]);
+        Assert.assertNotEquals("google.com:8443", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com:8443", null, "https");
+        Assert.assertNotEquals("https", res[0]);
+        Assert.assertNotEquals("google.com:8443", res[1]);
+        Assert.assertNotEquals("google.com:8443", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "google.com:8443", "8444", "https");
+        Assert.assertNotEquals("https", res[0]);
+        Assert.assertNotEquals("google.com:8443", res[1]);
+        Assert.assertNotEquals("google.com:8443", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+        res = run("9.9.9.9:2343", "[::1]:8443", null, "https");
+        Assert.assertNotEquals("https", res[0]);
+        Assert.assertNotEquals("[::1]:8443", res[1]);
+        Assert.assertNotEquals("[::1]:8443", res[2]);
+        Assert.assertNotEquals("/9.9.9.9:2343", res[3]);
+
+    }
+
+
+}

--- a/core/src/test/java/io/undertow/util/PeerMatcherTestCase.java
+++ b/core/src/test/java/io/undertow/util/PeerMatcherTestCase.java
@@ -1,0 +1,109 @@
+package io.undertow.util;
+
+import io.undertow.testutils.category.UnitTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+
+@Category(UnitTest.class)
+public class PeerMatcherTestCase {
+
+    @Test
+    public void testIPv4ExactMatchSocketAddress() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(false)
+                .addAllow("127.0.0.1");
+
+        Assert.assertTrue(matcher.isAllowed(new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0)));
+        Assert.assertFalse(matcher.isAllowed(new InetSocketAddress(InetAddress.getByName("127.0.0.2"), 0)));
+    }
+
+    @Test
+    public void testIPv4ExactMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(false)
+                .addAllow("127.0.0.1");
+
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.1")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+    }
+
+    @Test
+    public void testIPv6ExactMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(false)
+                .addAllow("FE45:00:00:000:0:AAA:FFFF:0045");
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:45")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:46")));
+    }
+
+    @Test
+    public void testIPv4WildcardMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(true)
+                .addAllow("127.0.0.1")
+                .addDeny("127.0.*.*");
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.1")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.1.0.2")));
+    }
+
+    @Test
+    public void testIPv6PrefixMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(true)
+                .addAllow("FE45:00:00:000:0:AAA:FFFF:0045")
+                .addDeny("FE45:00:00:000:0:AAA:FFFF:*");
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:45")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:46")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFb:46")));
+    }
+
+    @Test
+    public void testIPv4SlashMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(true)
+                .addAllow("127.0.0.1")
+                .addAllow("127.0.0.48/30")
+                .addDeny("127.0.0.0/16");
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.1")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.1.1")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.1.0.2")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.47")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.48")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.49")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.50")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.51")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("127.0.0.52")));
+    }
+
+
+    @Test
+    public void testIPv6SlashMatch() throws UnknownHostException {
+        PeerMatcher matcher = new PeerMatcher()
+                .setDefaultAllow(true)
+                .addAllow("FE45:00:00:000:0:AAA:FFFF:0045")
+                .addAllow("FE45:00:00:000:0:AAA:FFFF:01F4/127")
+                .addDeny("FE45:00:00:000:0:AAA:FFFF:0/112");
+        runIpv6SlashMatchTest(matcher);
+    }
+
+    private void runIpv6SlashMatchTest(PeerMatcher matcher) throws UnknownHostException {
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:45")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("127.0.0.2")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFF:46")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("FE45:0:0:0:0:AAA:FFFb:46")));
+
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f3")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f4")));
+        Assert.assertTrue(matcher.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f5")));
+        Assert.assertFalse(matcher.isAllowed(InetAddress.getByName("fe45:0000:0000:0000:0000:0aaa:ffff:01f6")));
+    }
+}


### PR DESCRIPTION
Hi
I added a little more security to the Forwarded and ProxyPeerAddress handlers, to allow only specific proxies by IP.

I hope this feature also will be useful for others.

Moved peer matching logic from IPAddressAccessControlHandler to PeerMatcher.
Added support for filtering Forwarded headers source peers.

