### PR TITLE
[UNDERTOW-1615] Remove unused dependencies

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -42,27 +42,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-servlet</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.undertow</groupId>
-            <artifactId>undertow-websockets-jsr</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.xnio</groupId>
-            <artifactId>xnio-nio</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
         </dependency>
@@ -73,21 +52,11 @@
         </dependency>
 
         <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>compile</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Hello, I noticed that dependencies `undertow-servlet`, `undertow-websockets-jsr`, `jboss-logging-processor`, `xnio-nio`, `jmh-generator-annprocess`, and `httpmime` are declared in the `pom` of the `undertow-benchmarks` module. However, these dependencies are not used in any of the four classes of the module. Removing these unused dependencies in the `pom` has an impact on the size of the packaged jar file for the benchmarks (reduction is more than 1MB), and also decreases the complexity of the Maven dependency tree of the module.