### PR TITLE
UNDERTOW-1616: Invoke setUseCipherSuitesOrder without reflection

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -401,9 +401,9 @@ public interface UndertowLogger extends BasicLogger {
     @Message(id = 5086, value = "Failed to accept SSL request")
     void failedToAcceptSSLRequest(@Cause Exception e);
 
-    @LogMessage(level = ERROR)
-    @Message(id = 5087, value = "Failed to use the server order")
-    void failedToUseServerOrder(@Cause ReflectiveOperationException e);
+//    @LogMessage(level = ERROR)
+//    @Message(id = 5087, value = "Failed to use the server order")
+//    void failedToUseServerOrder(@Cause ReflectiveOperationException e);
 
     @LogMessage(level = ERROR)
     @Message(id = 5088, value = "Failed to execute ServletOutputStream.closeAsync() on IO thread")


### PR DESCRIPTION
Now that Undertow requires java 8, it's no longer necessary to use
reflection to access this method.