### PR TITLE
[2.1] UNDERTOW-1622: Implement blocking IO timeouts

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -73,9 +73,25 @@ public class UndertowOptions {
     public static final Option<Integer> REQUEST_PARSE_TIMEOUT = Option.simple(UndertowOptions.class, "REQUEST_PARSE_TIMEOUT", Integer.class);
 
     /**
-     * The amount of time the connection can be idle with no current requests before it is closed;
+     * The amount of time the connection can be idle with no current requests before it is closed.
      */
     public static final Option<Integer> NO_REQUEST_TIMEOUT = Option.simple(UndertowOptions.class, "NO_REQUEST_TIMEOUT", Integer.class);
+
+    /**
+     * The amount of time in milliseconds a single blocking read operation may take before a timeout IOException is thrown.
+     * Unlike Options.READ_TIMEOUT this only applies to blocking operations which can be helpful to prevent the worker
+     * pool from becoming saturated when clients stop responding.
+     * <code>-1</code> or missing value disables this functionality. There is no timeout by default.
+     */
+    public static final Option<Integer> BLOCKING_READ_TIMEOUT = Option.simple(UndertowOptions.class, "BLOCKING_READ_TIMEOUT", Integer.class);
+
+    /**
+     * The amount of time in milliseconds a single blocking write operation may take before a timeout IOException is thrown.
+     * Unlike Options.WRITE_TIMEOUT this only applies to blocking operations which can be helpful to prevent the worker
+     * pool from becoming saturated when clients stop responding.
+     * <code>-1</code> or missing value disables this functionality. There is no timeout by default.
+     */
+    public static final Option<Integer> BLOCKING_WRITE_TIMEOUT = Option.simple(UndertowOptions.class, "BLOCKING_WRITE_TIMEOUT", Integer.class);
 
     public static final int DEFAULT_MAX_PARAMETERS = 1000;
 

--- a/core/src/main/java/io/undertow/io/UndertowOutputStream.java
+++ b/core/src/main/java/io/undertow/io/UndertowOutputStream.java
@@ -56,6 +56,7 @@ public class UndertowOutputStream extends OutputStream implements BufferWritable
     private int state;
     private long written;
     private final long contentLength;
+    /** {@link UndertowOptions#BLOCKING_WRITE_TIMEOUT}. */
     private final int writeTimeoutMillis;
 
     private static final int FLAG_CLOSED = 1;
@@ -286,10 +287,6 @@ public class UndertowOutputStream extends OutputStream implements BufferWritable
         if (channel == null) {
             channel = exchange.getResponseChannel();
         }
-        flushBlocking();
-    }
-
-    private void flushBlocking() throws IOException {
         BlockingChannels.flushBlockingOrThrow(channel, writeTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
@@ -355,7 +352,7 @@ public class UndertowOutputStream extends OutputStream implements BufferWritable
             }
             StreamSinkChannel channel = this.channel;
             channel.shutdownWrites();
-            flushBlocking();
+            BlockingChannels.flushBlockingOrThrow(channel, writeTimeoutMillis, TimeUnit.MILLISECONDS);
         } finally {
             if (pooledBuffer != null) {
                 pooledBuffer.close();

--- a/core/src/main/java/io/undertow/server/BlockingChannels.java
+++ b/core/src/main/java/io/undertow/server/BlockingChannels.java
@@ -55,6 +55,7 @@ public final class BlockingChannels {
     /**
      * Same as flushBlocking with two exceptions: A timeout exception is thrown if an operation does not succeed
      * within the time limit, and non-positive values do not apply a timeout.
+     * When the timeout is exceeded and an exception is thrown, the provided channel is closed.
      * @throws WriteTimeoutException when a flush does not succeed before the timeout is exceeded.
      */
     public static void flushBlockingOrThrow(
@@ -105,6 +106,7 @@ public final class BlockingChannels {
     /**
      * Same as readBlocking with two exceptions: A timeout exception is thrown if an operation does not succeed
      * within the time limit, and non-positive values do not apply a timeout.
+     * When the timeout is exceeded and an exception is thrown, the provided channel is closed.
      * @throws ReadTimeoutException when a read does not succeed before the timeout is exceeded.
      */
     public static <C extends ReadableByteChannel & SuspendableReadChannel> int readBlockingOrThrow(
@@ -171,7 +173,8 @@ public final class BlockingChannels {
      * Same as writeBlocking with two exceptions: A timeout exception is thrown if a write does not succeed
      * within the time limit, and non-positive values do not apply a timeout.
      * Note that the timeout applies between writes, execution may take longer as long as writes
-     * ucceed within the specified time.
+     * succeed within the specified time.
+     * When the timeout is exceeded and an exception is thrown, the provided channel is closed.
      * @throws WriteTimeoutException when a write does not succeed before the timeout is exceeded.
      */
     public static <C extends GatheringByteChannel & SuspendableWriteChannel> long writeBlockingOrThrow(
@@ -200,6 +203,7 @@ public final class BlockingChannels {
      * within the time limit, and non-positive values do not apply a timeout.
      * Note that the timeout applies between writes, execution may take longer as long as writes
      * succeed within the specified time.
+     * When the timeout is exceeded and an exception is thrown, the provided channel is closed.
      * @throws WriteTimeoutException when a write does not succeed before the timeout is exceeded.
      */
     public static <C extends WritableByteChannel & SuspendableWriteChannel> int writeBlockingOrThrow(

--- a/core/src/main/java/io/undertow/server/BlockingChannels.java
+++ b/core/src/main/java/io/undertow/server/BlockingChannels.java
@@ -1,0 +1,224 @@
+package io.undertow.server;
+
+import org.xnio.Buffers;
+import org.xnio.IoUtils;
+import org.xnio.channels.Channels;
+import org.xnio.channels.ReadTimeoutException;
+import org.xnio.channels.SuspendableReadChannel;
+import org.xnio.channels.SuspendableWriteChannel;
+import org.xnio.channels.WriteTimeoutException;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class provides utility functionality for blocking operations on {@link java.nio.channels.Channel channels}.
+ *
+ * @author Carter Kozak
+ */
+public final class BlockingChannels {
+
+    /**
+     * TODO(ckozak): Delete in favor of XNIO Channels.flushBlocking once XNIO-357 has been released.
+     *
+     * @see <a href="https://github.com/xnio/xnio/pull/213">xnio#214</a>
+     * @see <a href="https://issues.redhat.com/browse/XNIO-357">XNIO-357</a>
+     */
+    private static boolean flushBlocking(
+            SuspendableWriteChannel channel,
+            long time,
+            TimeUnit unit) throws IOException {
+        // In the fast path, the timeout is not used because bytes can be flushed without blocking.
+        if (channel.flush()) {
+            return true;
+        }
+        long remaining = unit.toNanos(time);
+        long now = System.nanoTime();
+        do {
+            // awaitWritable may return spuriously so looping is required.
+            channel.awaitWritable(remaining, TimeUnit.NANOSECONDS);
+            // flush prior to recalculating remaining time to avoid a nanoTime
+            // invocation in the optimal path.
+            if (channel.flush()) {
+                return true;
+            }
+            // Nanotime must only be used in comparison with another nanotime value
+            // This implementation allows us to avoid immediate subsequent nanoTime calls
+        } while ((remaining -= Math.max(-now + (now = System.nanoTime()), 0L)) > 0L);
+        return false;
+    }
+
+    /**
+     * Same as flushBlocking with two exceptions: A timeout exception is thrown if an operation does not succeed
+     * within the time limit, and non-positive values do not apply a timeout.
+     * @throws WriteTimeoutException when a flush does not succeed before the timeout is exceeded.
+     */
+    public static void flushBlockingOrThrow(
+            SuspendableWriteChannel channel,
+            long time,
+            TimeUnit unit) throws IOException {
+        if (time > 0) {
+            if (!flushBlocking(channel, time, unit)) {
+                IoUtils.safeClose(channel);
+                throw new WriteTimeoutException();
+            }
+        } else {
+            Channels.flushBlocking(channel);
+        }
+    }
+
+    /**
+     * TODO(ckozak): Delete in favor of XNIO Channels.readBlocking once XNIO-356 has been released.
+     *
+     * @see <a href="https://github.com/xnio/xnio/pull/212">xnio#212</a>
+     * @see <a href="https://issues.redhat.com/browse/XNIO-356">XNIO-356</a>
+     */
+    private static <C extends ReadableByteChannel & SuspendableReadChannel> int readBlocking(
+            C channel, ByteBuffer buffer, long time, TimeUnit unit) throws IOException {
+        // In the fast path, the timeout is not used because bytes can be read without blocking.
+        int res = channel.read(buffer);
+        if (res != 0) {
+            return res;
+        }
+        long remaining = unit.toNanos(time);
+        long now = System.nanoTime();
+        while (buffer.hasRemaining() && remaining > 0) {
+            // awaitReadable may return spuriously, so looping is required.
+            channel.awaitReadable(remaining, TimeUnit.NANOSECONDS);
+            // read prior to recalculating remaining time to avoid a nanoTime
+            // invocation in the optimal path.
+            res = channel.read(buffer);
+            if (res != 0) {
+                return res;
+            }
+            // Nanotime must only be used in comparison with another nanotime value
+            // This implementation allows us to avoid immediate subsequent nanoTime calls
+            remaining -= Math.max(-now + (now = System.nanoTime()), 0L);
+        }
+        return res;
+    }
+
+    /**
+     * Same as readBlocking with two exceptions: A timeout exception is thrown if an operation does not succeed
+     * within the time limit, and non-positive values do not apply a timeout.
+     * @throws ReadTimeoutException when a read does not succeed before the timeout is exceeded.
+     */
+    public static <C extends ReadableByteChannel & SuspendableReadChannel> int readBlockingOrThrow(
+            C channel, ByteBuffer buffer, long time, TimeUnit unit) throws IOException {
+        if (time > 0) {
+            int result = readBlocking(channel, buffer, time, unit);
+            if (result == 0 && buffer.hasRemaining()) {
+                IoUtils.safeClose(channel);
+                throw new ReadTimeoutException();
+            }
+            return result;
+        } else {
+            return Channels.readBlocking(channel, buffer);
+        }
+    }
+
+    /**
+     * TODO(ckozak): Delete in favor of XNIO Channels.writeBlocking once XNIO-356 has been released.
+     *
+     * @see <a href="https://github.com/xnio/xnio/pull/212">xnio#212</a>
+     * @see <a href="https://issues.redhat.com/browse/XNIO-356">XNIO-356</a>
+     */
+    private static <C extends GatheringByteChannel & SuspendableWriteChannel> long writeBlocking(
+            C channel, ByteBuffer[] buffers, int offs, int len, long time, TimeUnit unit) throws IOException {
+        long remaining = unit.toNanos(time);
+        long now = System.nanoTime();
+        long t = 0;
+        while (Buffers.hasRemaining(buffers, offs, len) && remaining > 0L) {
+            long res = channel.write(buffers, offs, len);
+            if (res == 0) {
+                channel.awaitWritable(remaining, TimeUnit.NANOSECONDS);
+                remaining -= Math.max(-now + (now = System.nanoTime()), 0L);
+            } else {
+                t += res;
+            }
+        }
+        return t;
+    }
+
+    /**
+     * TODO(ckozak): Delete in favor of XNIO Channels.writeBlocking once XNIO-356 has been released.
+     *
+     * @see <a href="https://github.com/xnio/xnio/pull/212">xnio#212</a>
+     * @see <a href="https://issues.redhat.com/browse/XNIO-356">XNIO-356</a>
+     */
+    private static <C extends WritableByteChannel & SuspendableWriteChannel> int writeBlocking(
+            C channel, ByteBuffer buffer, long time, TimeUnit unit) throws IOException {
+        long remaining = unit.toNanos(time);
+        long now = System.nanoTime();
+        int t = 0;
+        while (buffer.hasRemaining() && remaining > 0L) {
+            int res = channel.write(buffer);
+            if (res == 0) {
+                channel.awaitWritable(remaining, TimeUnit.NANOSECONDS);
+                remaining -= Math.max(-now + (now = System.nanoTime()), 0L);
+            } else {
+                t += res;
+            }
+        }
+        return t;
+    }
+
+    /**
+     * Same as writeBlocking with two exceptions: A timeout exception is thrown if a write does not succeed
+     * within the time limit, and non-positive values do not apply a timeout.
+     * Note that the timeout applies between writes, execution may take longer as long as writes
+     * ucceed within the specified time.
+     * @throws WriteTimeoutException when a write does not succeed before the timeout is exceeded.
+     */
+    public static <C extends GatheringByteChannel & SuspendableWriteChannel> long writeBlockingOrThrow(
+            C channel, ByteBuffer[] buffers, int offs, int len, long time, TimeUnit unit) throws IOException {
+        if (time > 0) {
+            long total = 0;
+            // Attempt to write until there is no remaining data, or failure.
+            while (Buffers.hasRemaining(buffers, offs, len)) {
+                long result = writeBlocking(channel, buffers, offs, len, time, unit);
+                if (result == 0 && Buffers.hasRemaining(buffers, offs, len)) {
+                    // readBlocking returns zero if either the input does not have any available space
+                    // or the timeout was reached.
+                    IoUtils.safeClose(channel);
+                    throw new WriteTimeoutException();
+                }
+                total += result;
+            }
+            return total;
+        } else {
+            return Channels.writeBlocking(channel, buffers, offs, len);
+        }
+    }
+
+    /**
+     * Same as writeBlocking with two exceptions: A timeout exception is thrown if a write does not succeed
+     * within the time limit, and non-positive values do not apply a timeout.
+     * Note that the timeout applies between writes, execution may take longer as long as writes
+     * succeed within the specified time.
+     * @throws WriteTimeoutException when a write does not succeed before the timeout is exceeded.
+     */
+    public static <C extends WritableByteChannel & SuspendableWriteChannel> int writeBlockingOrThrow(
+            C channel, ByteBuffer buffer, long time, TimeUnit unit) throws IOException {
+        if (time > 0) {
+            int total = 0;
+            while (buffer.hasRemaining()) {
+                int result = writeBlocking(channel, buffer, time, unit);
+                if (result == 0 && buffer.hasRemaining()) {
+                    // readBlocking returns zero if either the input does not have any available space
+                    // or the timeout was reached.
+                    IoUtils.safeClose(channel);
+                    throw new WriteTimeoutException();
+                }
+                total += result;
+            }
+            return total;
+        } else {
+            return Channels.writeBlocking(channel, buffer);
+        }
+    }
+}

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -27,8 +27,6 @@ import org.xnio.IoUtils;
 import org.xnio.Options;
 import io.undertow.connector.PooledByteBuffer;
 import org.xnio.SslClientAuthMode;
-import org.xnio.channels.Channels;
-import org.xnio.channels.ReadTimeoutException;
 import org.xnio.channels.SslChannel;
 import org.xnio.channels.StreamSourceChannel;
 
@@ -205,15 +203,7 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
     private int readBlocking(HttpServerExchange exchange, StreamSourceChannel channel, ByteBuffer buffer) throws IOException {
         int readTimeoutMillis = exchange.getConnection().getUndertowOptions()
                 .get(UndertowOptions.BLOCKING_READ_TIMEOUT, -1);
-        if (readTimeoutMillis > 0) {
-            int result = Channels.readBlocking(channel, buffer, readTimeoutMillis, TimeUnit.MILLISECONDS);
-            if (result == 0 && buffer.hasRemaining()) {
-                throw new ReadTimeoutException();
-            }
-            return result;
-        } else {
-            return Channels.readBlocking(channel, buffer);
-        }
+        return BlockingChannels.readBlockingOrThrow(channel, buffer, readTimeoutMillis, TimeUnit.MILLISECONDS);
     }
 
     public void renegotiateNoRequest(HttpServerExchange exchange, SslClientAuthMode newAuthMode) throws IOException {

--- a/core/src/test/java/io/undertow/server/BlockingReadTimeoutTestCase.java
+++ b/core/src/test/java/io/undertow/server/BlockingReadTimeoutTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server;
+
+import io.undertow.UndertowOptions;
+import io.undertow.server.handlers.BlockingHandler;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.OptionMap;
+import org.xnio.channels.ReadTimeoutException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * Tests blocking read timeout with a slow request
+ *
+ * @author Carter Kozak
+ */
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+public class BlockingReadTimeoutTestCase {
+
+    private static final OutputStream STUB_OUTPUT_STREAM = new OutputStream() {
+        @Override
+        public void write(byte[] var1, int var2, int var3) throws IOException {
+
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+
+        }
+    };
+
+    private volatile Exception exception;
+    private static final CountDownLatch errorLatch = new CountDownLatch(1);
+
+    @Test
+    public void testReadTimeout() throws InterruptedException {
+        OptionMap originalOptions = DefaultServer.getUndertowOptions();
+        DefaultServer.setUndertowOptions(OptionMap.builder()
+                .addAll(originalOptions)
+                .set(UndertowOptions.BLOCKING_READ_TIMEOUT, 1)
+                .getMap());
+        DefaultServer.setRootHandler(new BlockingHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                try {
+                    IOUtils.copyLarge(exchange.getInputStream(), STUB_OUTPUT_STREAM);
+                    exchange.getOutputStream().write("COMPLETED".getBytes(StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    exception = e;
+                    errorLatch.countDown();
+                }
+            }
+        }));
+
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL());
+            post.setEntity(new AbstractHttpEntity() {
+
+                @Override
+                public InputStream getContent() throws IOException, IllegalStateException {
+                    return null;
+                }
+
+                @Override
+                public void writeTo(final OutputStream outstream) throws IOException {
+                    for (int i = 0; i < 5; ++i) {
+                        outstream.write('*');
+                        outstream.flush();
+                        try {
+                            Thread.sleep(200);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+
+                @Override
+                public boolean isStreaming() {
+                    return true;
+                }
+
+                @Override
+                public boolean isRepeatable() {
+                    return false;
+                }
+
+                @Override
+                public long getContentLength() {
+                    return 5;
+                }
+            });
+            post.addHeader(Headers.CONNECTION_STRING, "close");
+            try {
+                client.execute(post);
+            } catch (IOException e) {
+
+            }
+            if (errorLatch.await(5, TimeUnit.SECONDS)) {
+                Assert.assertEquals(ReadTimeoutException.class, exception.getClass());
+            } else {
+                Assert.fail("Read did not time out");
+            }
+        } finally {
+            DefaultServer.setUndertowOptions(originalOptions);
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/server/BlockingWriteTimeoutTestCase.java
+++ b/core/src/test/java/io/undertow/server/BlockingWriteTimeoutTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server;
+
+import io.undertow.UndertowOptions;
+import io.undertow.server.handlers.BlockingHandler;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.ProxyIgnore;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.OptionMap;
+import org.xnio.channels.WriteTimeoutException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests blocking write timeout with a client that is slow to read the response
+ *
+ * @author Carter Kozak
+ */
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+@ProxyIgnore
+public class BlockingWriteTimeoutTestCase {
+
+    private volatile Exception exception;
+    private static final CountDownLatch errorLatch = new CountDownLatch(1);
+
+    @Test
+    public void testWriteTimeout() throws InterruptedException {
+        OptionMap originalOptions = DefaultServer.getUndertowOptions();
+        DefaultServer.setUndertowOptions(OptionMap.builder()
+                .addAll(originalOptions)
+                .set(UndertowOptions.BLOCKING_WRITE_TIMEOUT, 1)
+                .getMap());
+        DefaultServer.setRootHandler(new BlockingHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                final int capacity = 1 * 1024 * 1024; // 1mb
+
+                final byte[] data = new byte[capacity];
+                for (int i = 0; i < capacity; ++i) {
+                    data[i] = (byte) '*';
+                }
+
+                try {
+                    // Must write enough data that it's not buffered
+                    for (int i = 0; i < 20; i++) {
+                        exchange.getOutputStream().write(data);
+                    }
+                } catch (IOException e) {
+                    exception = e;
+                    errorLatch.countDown();
+                }
+            }
+        }));
+
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            try {
+                HttpResponse result = client.execute(get);
+                Assert.assertFalse("The result entity is buffered", result.getEntity().isRepeatable());
+                InputStream content = result.getEntity().getContent();
+                byte[] buffer = new byte[512];
+                int r = 0;
+                while ((r = content.read(buffer)) > 0) {
+                    Thread.sleep(200);
+                    if (exception != null) {
+                        Assert.assertEquals(WriteTimeoutException.class, exception.getClass());
+                        return;
+                    }
+                }
+                Assert.fail("Write did not time out");
+            } catch (IOException e) {
+                if (errorLatch.await(5, TimeUnit.SECONDS)) {
+                    Assert.assertEquals(WriteTimeoutException.class, exception.getClass());
+                } else {
+                    Assert.fail("Write did not time out");
+                }
+            }
+        } finally {
+            DefaultServer.setUndertowOptions(originalOptions);
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/servlet/src/main/java/io/undertow/servlet/core/ServletUpgradeListener.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/ServletUpgradeListener.java
@@ -51,7 +51,11 @@ public class ServletUpgradeListener<T extends HttpUpgradeHandler> implements Htt
                 DelayedExecutor executor = new DelayedExecutor(exchange.getIoThread());
                 try {
                     //run the upgrade in the worker thread
-                    instance.getInstance().init(new WebConnectionImpl(context, ServletUpgradeListener.this.exchange.getConnection().getByteBufferPool(), executor));
+                    instance.getInstance().init(new WebConnectionImpl(
+                            context,
+                            ServletUpgradeListener.this.exchange.getConnection().getByteBufferPool(),
+                            executor,
+                            ServletUpgradeListener.this.exchange.getConnection().getUndertowOptions()));
                 } finally {
                     executor.openGate();
                 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletInputStream.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletInputStream.java
@@ -50,6 +50,7 @@ public class UpgradeServletInputStream extends ServletInputStream {
     private final StreamSourceChannel channel;
     private final ByteBufferPool bufferPool;
     private final Executor ioExecutor;
+    /** {@link UndertowOptions#BLOCKING_READ_TIMEOUT}. */
     private final int readTimeoutMillis;
 
     private volatile ReadListener listener;

--- a/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletOutputStream.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletOutputStream.java
@@ -48,6 +48,7 @@ public class UpgradeServletOutputStream extends ServletOutputStream {
 
     private WriteListener listener;
     private final Executor ioExecutor;
+    /** {@link UndertowOptions#BLOCKING_WRITE_TIMEOUT}. */
     private final int writeTimeoutMillis;
 
     /**


### PR DESCRIPTION
Added two new UndertowOptions:
- `BLOCKING_READ_TIMEOUT`: The amount of time in milliseconds a single
  blocking read operation may take before a timeout IOException is thrown.
  Unlike Options.READ_TIMEOUT this only applies to blocking operations
  which can be helpful to prevent the worker pool from becoming saturated
  when clients stop responding.
- `BLOCKING_WRITE_TIMEOUT`: The amount of time in milliseconds a single
  blocking write operation may take before a timeout IOException is
  thrown. Unlike Options.WRITE_TIMEOUT this only applies to blocking
  operations which can be helpful to prevent the worker pool from becoming
  saturated when clients stop responding.

A version of `xnio-api` containing the fix for [XNIO-356](https://issues.redhat.com/browse/XNIO-356) is required
for these options to work correctly, otherwise erronious timeouts
may be reported when channel.await{Readable,Writable} returns
spuriously.

This commit does not apply the write timeout to Channels.flushBlocking
invocations because that will require either a local utility class
to support flushBlocking with a timeout, or a backport of [XNIO-357](https://issues.redhat.com/browse/XNIO-357).