### PR TITLE
UNDERTOW-1627 gzip encoding is not enabled by RequestEncodingHandler$…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/encoding/RequestEncodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/RequestEncodingHandler.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.xnio.conduits.StreamSourceConduit;
+import io.undertow.conduits.GzipStreamSourceConduit;
 import io.undertow.conduits.InflatingStreamSourceConduit;
 import io.undertow.server.ConduitWrapper;
 import io.undertow.server.HandlerWrapper;
@@ -108,6 +109,7 @@ public class RequestEncodingHandler implements HttpHandler {
                 @Override
                 public HttpHandler wrap(HttpHandler handler) {
                     return new RequestEncodingHandler(handler)
+                            .addEncoding("gzip", GzipStreamSourceConduit.WRAPPER)
                             .addEncoding("deflate", InflatingStreamSourceConduit.WRAPPER);
                 }
             };

--- a/core/src/main/resources/META-INF/services/io.undertow.server.handlers.builder.HandlerBuilder
+++ b/core/src/main/resources/META-INF/services/io.undertow.server.handlers.builder.HandlerBuilder
@@ -25,6 +25,7 @@ io.undertow.server.handlers.PathSeparatorHandler$Builder
 io.undertow.server.handlers.IPAddressAccessControlHandler$Builder
 io.undertow.server.handlers.ByteRangeHandler$Builder
 io.undertow.server.handlers.encoding.EncodingHandler$Builder
+io.undertow.server.handlers.encoding.RequestEncodingHandler$Builder
 io.undertow.server.handlers.LearningPushHandler$Builder
 io.undertow.server.handlers.SetHeaderHandler$Builder
 io.undertow.predicate.PredicatesHandler$DoneHandlerBuilder


### PR DESCRIPTION
…Builder

Add gzip encoding in RequestEncodingHandler$Builder as it enables only
the deflate encoding. Also, rename the handler builder name to a more
appropriate one and add a missing RequestEncodingHandler$Builder
definition in a provider configuration file.