### PR TITLE
UNDERTOW-1464 Proper handling of matrix parameters

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -687,9 +687,16 @@ public abstract class HttpRequestParser {
                     state.segmentStart = stringBuilder.length();
                     state.parseState = ParseState.PATH;
                     return;
+                } else if (next == ',') {
+                    if(param == null) {
+                        throw UndertowMessages.MESSAGES.failedToParsePath();
+                    } else {
+                        // parse value and add param
+                        exchange.addPathParam(param, decode(stringBuilder.substring(pos), urlDecodeRequired, state, true, true));
+                        pos = stringBuilder.length() + 1;
+                    }
                 }
                 stringBuilder.append(next);
-
             }
 
         }

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -640,9 +640,10 @@ public abstract class HttpRequestParser {
                 }
                 finalizePath(state, exchange, urlDecodeRequired);
                 if(next == '?') {
-                    state.parseState = ParseState.QUERY_PARAMETERS;
+                    state.state = ParseState.QUERY_PARAMETERS;
+                    handleQueryParameters(buffer, state, exchange);
                 } else {
-                    state.parseState = ParseState.VERSION;
+                    state.state = ParseState.VERSION;
                 }
                 state.stringBuilder.setLength(0);
                 state.pos = 0;

--- a/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
@@ -82,6 +82,16 @@ class ParseState {
     final StringBuilder stringBuilder = new StringBuilder();
 
     /**
+     * Start of a path segment, used for creating the canonical path
+     */
+    int segmentStart;
+
+    /**
+     * We need to keep track of the canonical path
+     */
+    final StringBuilder canonicalPath = new StringBuilder();
+
+    /**
      * This has different meanings depending on the current state.
      *
      * In state {@link #HEADER} it is a the first character of the header, that was read by

--- a/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
@@ -82,11 +82,6 @@ class ParseState {
     final StringBuilder stringBuilder = new StringBuilder();
 
     /**
-     * Start of a path segment, used for creating the canonical path
-     */
-    int segmentStart;
-
-    /**
      * We need to keep track of the canonical path
      */
     final StringBuilder canonicalPath = new StringBuilder();

--- a/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
+++ b/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
@@ -113,13 +113,13 @@ public class PathParameterSessionConfig implements SessionConfig {
                     for (int i = 1; i < fragment.length(); ++i) {
                         char c = fragment.charAt(i);
                         if (key == null) {
-                            if (c == '&' || c == '=') {
+                            if (c == ';' || c == '=') {
                                 key = paramBuilder.toString();
                                 paramBuilder.setLength(0);
-                                if (c == '&') {
+                                if (c == ';') {
                                     if (!key.equals(name)) { //we don't append if it matches the name
                                         sb.append(key);
-                                        sb.append('&');
+                                        sb.append(';');
                                     }
                                     key = null;
                                 }
@@ -127,14 +127,14 @@ public class PathParameterSessionConfig implements SessionConfig {
                                 paramBuilder.append(c);
                             }
                         } else {
-                            if (c == '&') {
+                            if (c == ';') {
                                 String value = paramBuilder.toString();
                                 paramBuilder.setLength(0);
                                 if (!key.equals(name)) { //we don't append if it matches the name
                                     sb.append(key);
                                     sb.append('=');
                                     sb.append(value);
-                                    sb.append('&');
+                                    sb.append(';');
                                 }
                                 key = null;
                             } else {
@@ -147,7 +147,7 @@ public class PathParameterSessionConfig implements SessionConfig {
                             key = paramBuilder.toString();
                             if (!key.equals(name)) { //we don't append if it matches the name
                                 sb.append(key);
-                                sb.append('&');
+                                sb.append(';');
                             }
                         } else {
                             String value = paramBuilder.toString();
@@ -155,13 +155,13 @@ public class PathParameterSessionConfig implements SessionConfig {
                                 sb.append(key);
                                 sb.append('=');
                                 sb.append(value);
-                                sb.append('&');
+                                sb.append(';');
                             }
                         }
                     }
                 } else {
                     sb.append(fragment);
-                    sb.append("&");
+                    sb.append(";");
                 }
             } else {
                 sb.append(';');

--- a/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
+++ b/core/src/main/java/io/undertow/server/session/PathParameterSessionConfig.java
@@ -84,95 +84,48 @@ public class PathParameterSessionConfig implements SessionConfig {
         String path = url;
         String query = "";
         String anchor = "";
-        String fragment = "";
-        int question = url.indexOf('?');
+        final int question = url.indexOf('?');
         if (question >= 0) {
             path = url.substring(0, question);
             query = url.substring(question);
         }
-        int pound = path.indexOf('#');
+        final int pound = path.indexOf('#');
         if (pound >= 0) {
             anchor = path.substring(pound);
             path = path.substring(0, pound);
         }
-        int fragmentIndex = path.lastIndexOf(';');
-        if(fragmentIndex >= 0) {
-            fragment = path.substring(fragmentIndex);
-            path = path.substring(0, fragmentIndex);
-        }
-
-        StringBuilder sb = new StringBuilder(path);
-        if (sb.length() > 0) { // jsessionid can't be first.
-            if(fragmentIndex > 0) {
-                if(fragment.contains(name)) {
-                    //this does not necessarily mean that this parameter is present. It could be part of the value, or the
-                    //name could be a substring of a larger key name
-                    sb.append(';'); //we make sure we append the fragment portion
-                    String key = null;
-                    StringBuilder paramBuilder = new StringBuilder();
-                    for (int i = 1; i < fragment.length(); ++i) {
-                        char c = fragment.charAt(i);
-                        if (key == null) {
-                            if (c == ';' || c == '=') {
-                                key = paramBuilder.toString();
-                                paramBuilder.setLength(0);
-                                if (c == ';') {
-                                    if (!key.equals(name)) { //we don't append if it matches the name
-                                        sb.append(key);
-                                        sb.append(';');
-                                    }
-                                    key = null;
-                                }
-                            } else {
-                                paramBuilder.append(c);
-                            }
-                        } else {
-                            if (c == ';') {
-                                String value = paramBuilder.toString();
-                                paramBuilder.setLength(0);
-                                if (!key.equals(name)) { //we don't append if it matches the name
-                                    sb.append(key);
-                                    sb.append('=');
-                                    sb.append(value);
-                                    sb.append(';');
-                                }
-                                key = null;
-                            } else {
-                                paramBuilder.append(c);
-                            }
-                        }
-                    }
-                    if(paramBuilder.length() > 0) {
-                        if(key == null) {
-                            key = paramBuilder.toString();
-                            if (!key.equals(name)) { //we don't append if it matches the name
-                                sb.append(key);
-                                sb.append(';');
-                            }
-                        } else {
-                            String value = paramBuilder.toString();
-                            if (!key.equals(name)) { //we don't append if it matches the name
-                                sb.append(key);
-                                sb.append('=');
-                                sb.append(value);
-                                sb.append(';');
-                            }
-                        }
-                    }
+        final StringBuilder sb = new StringBuilder();
+        // look for param
+        final int paramIndex = path.indexOf(";" + name);
+        // found param, strip it off from path
+        if (paramIndex >= 0) {
+            sb.append(path.substring(0, paramIndex));
+            final String remainder = path.substring(paramIndex + name.length() + 1);
+            final int endIndex1 = remainder.indexOf(";");
+            final int endIndex2 = remainder.indexOf("/");
+            if (endIndex1 != -1) {
+                if (endIndex2 != -1 && endIndex2 < endIndex1) {
+                    sb.append(remainder.substring(endIndex2));
                 } else {
-                    sb.append(fragment);
-                    sb.append(";");
+                    sb.append(remainder.substring(endIndex1));
                 }
-            } else {
-                sb.append(';');
+            } else if (endIndex2 != -1) {
+                sb.append(remainder.substring(endIndex2));
             }
-            sb.append(name);
-            sb.append('=');
-            sb.append(sessionId);
+            // else the rest of the path will be discarded, as it contains just the parameter we want to exclude
+        } else {
+            // name param was not found, we can use the path as is
+            sb.append(path);
         }
+        // append ;name=sessionId
+        sb.append(';');
+        sb.append(name);
+        sb.append('=');
+        sb.append(sessionId);
+        // apend anchor and query
         sb.append(anchor);
         sb.append(query);
-        UndertowLogger.SESSION_LOGGER.tracef("Rewrote URL from %s to %s", url, sessionId);
-        return (sb.toString());
+        UndertowLogger.SESSION_LOGGER.tracef("Rewrote URL from %s to %s", url, sb);
+        return sb.toString();
     }
 }

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -216,6 +216,19 @@ public class SimpleParserTestCase {
         Assert.assertEquals("http://myurl.com", result.getRequestURI());
     }
 
+    @Test
+    public void testSth() throws BadRequestException {
+        byte[] in = "GET http://myurl.com/goo;foo=bar;blah=foobar HTTP/1.1\r\n\r\n".getBytes();
+
+        final ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+//        Assert.assertEquals("/", result.getRequestPath());
+//        Assert.assertEquals("http://myurl.com", result.getRequestURI());
+        Assert.assertEquals(2, result.getPathParameters().size());
+    }
+
     @Test(expected = BadRequestException.class)
     public void testLineEndingInsteadOfSpacesAfterVerb() throws BadRequestException {
         byte[] in = "GET\r/somepath HTTP/1.1\r\nHost:   www.somehost.net\r\nOtherHeader: some\r\n    value\r\n\r\n".getBytes();

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -143,6 +143,68 @@ public class SimpleParserTestCase {
     }
 
     @Test
+    public void testServletURLWithPathParam() throws BadRequestException {
+        byte[] in = "GET http://localhost:7777/servletContext/aaaa/b;param=1 HTTP/1.1\r\n\r\n".getBytes();
+        ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("http://localhost:7777/servletContext/aaaa/b;param=1", result.getRequestURI());
+        Assert.assertEquals("/servletContext/aaaa/b", result.getRequestPath());
+        Assert.assertEquals(1, result.getPathParameters().size());
+        Assert.assertEquals("param", result.getPathParameters().keySet().toArray()[0]);
+        Assert.assertEquals("1", result.getPathParameters().get("param").getFirst());
+        Assert.assertSame(Protocols.HTTP_1_1, result.getProtocol());
+    }
+
+    @Test
+    public void testServletURLWithPathParams() throws BadRequestException {
+        byte[] in = "GET http://localhost:7777/servletContext/aa/b;foo=bar;mysessioncookie=mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI HTTP/1.1\r\n\r\n".getBytes();
+        ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("http://localhost:7777/servletContext/aa/b;foo=bar;mysessioncookie=mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI", result.getRequestURI());
+        Assert.assertEquals("/servletContext/aa/b", result.getRequestPath());
+        Assert.assertEquals(2, result.getPathParameters().size());
+
+        Assert.assertEquals("bar", result.getPathParameters().get("foo").getFirst());
+        Assert.assertEquals("mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI", result.getPathParameters().get("mysessioncookie").getFirst());
+        Assert.assertSame(Protocols.HTTP_1_1, result.getProtocol());
+    }
+
+    @Test
+    public void testServletPathWithPathParam() throws BadRequestException {
+        byte[] in = "GET /servletContext/aaaa/b;param=1 HTTP/1.1\r\n\r\n".getBytes();
+        ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("/servletContext/aaaa/b;param=1", result.getRequestURI());
+        Assert.assertEquals("/servletContext/aaaa/b", result.getRequestPath());
+        Assert.assertEquals(1, result.getPathParameters().size());
+        Assert.assertEquals("param", result.getPathParameters().keySet().toArray()[0]);
+        Assert.assertEquals("1", result.getPathParameters().get("param").getFirst());
+        Assert.assertSame(Protocols.HTTP_1_1, result.getProtocol());
+    }
+
+    @Test
+    public void testServletPathWithPathParams() throws BadRequestException {
+        byte[] in = "GET /servletContext/aa/b;foo=bar;mysessioncookie=mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI HTTP/1.1\r\n\r\n".getBytes();
+        ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("/servletContext/aa/b;foo=bar;mysessioncookie=mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI", result.getRequestURI());
+        Assert.assertEquals("/servletContext/aa/b", result.getRequestPath());
+        Assert.assertEquals(2, result.getPathParameters().size());
+
+        Assert.assertEquals("bar", result.getPathParameters().get("foo").getFirst());
+        Assert.assertEquals("mSwrYUX8_e3ukAylNMkg3oMRglB4-YjxqeWqXQsI", result.getPathParameters().get("mysessioncookie").getFirst());
+        Assert.assertSame(Protocols.HTTP_1_1, result.getProtocol());
+    }
+
+    @Test
     public void testRootMatrixParam() throws BadRequestException {
         // TODO decide what should happen for a single semicolon as the path URI and other edge cases
         byte[] in = "GET ; HTTP/1.1\r\n\r\n".getBytes();
@@ -224,8 +286,8 @@ public class SimpleParserTestCase {
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertSame(Methods.GET, result.getRequestMethod());
-//        Assert.assertEquals("/", result.getRequestPath());
-//        Assert.assertEquals("http://myurl.com", result.getRequestURI());
+        Assert.assertEquals("/goo", result.getRequestPath());
+        Assert.assertEquals("http://myurl.com/goo;foo=bar;blah=foobar", result.getRequestURI());
         Assert.assertEquals(2, result.getPathParameters().size());
     }
 

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -174,13 +174,13 @@ public class SimpleParserTestCase {
 
     @Test
     public void testMultiLevelMatrixParameter() throws BadRequestException {
-        byte[] in = "GET /some;p1=v1/canonicalPath;p1=v2?q1=v3 HTTP/1.1\r\n\r\n".getBytes();
+        byte[] in = "GET /some;p1=v1/path;p1=v2?q1=v3 HTTP/1.1\r\n\r\n".getBytes();
         ParseState context = new ParseState(10);
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertSame(Methods.GET, result.getRequestMethod());
-        Assert.assertEquals("/some;p1=v1/canonicalPath;p1=v2", result.getRequestURI());
-        Assert.assertEquals("/some/canonicalPath", result.getRequestPath());
+        Assert.assertEquals("/some;p1=v1/path;p1=v2", result.getRequestURI());
+        Assert.assertEquals("/some/path", result.getRequestPath());
         Assert.assertEquals("q1=v3", result.getQueryString());
         Assert.assertEquals("v1", result.getPathParameters().get("p1").getFirst());
         Assert.assertEquals("v2", result.getPathParameters().get("p1").getLast());
@@ -190,13 +190,13 @@ public class SimpleParserTestCase {
 
     @Test
     public void testMultiLevelMatrixParameters() throws BadRequestException {
-        byte[] in = "GET /some;p1=v1/canonicalPath;p2=v2?q1=v3 HTTP/1.1\r\n\r\n".getBytes();
+        byte[] in = "GET /some;p1=v1/path;p2=v2?q1=v3 HTTP/1.1\r\n\r\n".getBytes();
         ParseState context = new ParseState(10);
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertSame(Methods.GET, result.getRequestMethod());
-        Assert.assertEquals("/some;p1=v1/canonicalPath;p2=v2", result.getRequestURI());
-        Assert.assertEquals("/some/canonicalPath", result.getRequestPath());
+        Assert.assertEquals("/some;p1=v1/path;p2=v2", result.getRequestURI());
+        Assert.assertEquals("/some/path", result.getRequestPath());
         Assert.assertEquals("q1=v3", result.getQueryString());
         Assert.assertEquals("v1", result.getPathParameters().get("p1").getFirst());
         Assert.assertEquals("v2", result.getPathParameters().get("p2").getFirst());


### PR DESCRIPTION
Hi @stuartwdouglas, @fl4via,

Please review and provide feedback on my first stab at resolving the [UNDERTOW-1464](https://issues.redhat.com/browse/UNDERTOW-1464)! Some notes on the code
* The PR puts all matrix parameters in the path parameter collection and makes no difference between the two `p1` matrix parameters in the following example
  ```
  /some;p1=v1/path;p1=v2
  ```
  An alternative implementation could take into account the fact that these are really two separate parameters, perhaps by using the canonical path as a namespace which would give the following two variable names:
  ```
  /some;p1
  /some/path;p1
  ```
* The current PR does not include support for comma separated values, I will add that shortly if you think this PR is going anywhere.
  ```
  /some;p1=v1,v2
  ```
* The `result.getRequestPath()` returns the canonical path without the matrix parameters and the `result.getRequestURI()` returns the URI including the matrix parameters. Maybe the path should include the parameters as well? Not sure what's best, thoughts?

References:
* [Matrix URLs](https://www.w3.org/DesignIssues/MatrixURIs.html) as first discussed by Tim Berners Lee...