### PR TITLE
[UNDERTOW-1672] Unable to find the resource: /META-INF/BenchmarkList

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -28,7 +28,6 @@
         <version>2.0.29.Final-SNAPSHOT</version>
     </parent>
 
-    <groupId>io.undertow</groupId>
     <artifactId>undertow-benchmarks</artifactId>
     <version>2.0.29.Final-SNAPSHOT</version>
 
@@ -49,6 +48,12 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
When build benchmarks module without `jmh-generator-annprocess` dependency I got
```
Exception in thread "main" java.lang.RuntimeException: ERROR: Unable to find the resource: /META-INF/BenchmarkList
        at org.openjdk.jmh.runner.AbstractResourceReader.getReaders(AbstractResourceReader.java:98)
        at org.openjdk.jmh.runner.BenchmarkList.find(BenchmarkList.java:122)
        at org.openjdk.jmh.runner.Runner.internalRun(Runner.java:263)
        at org.openjdk.jmh.runner.Runner.run(Runner.java:209)
        at org.openjdk.jmh.Main.main(Main.java:71)
```
This is fix request.
