### PR TITLE
[UNDERTOW-1630] RewriteHandler rewite url env lost

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
@@ -29,6 +29,8 @@ import io.undertow.util.Headers;
 import io.undertow.util.QueryParameterUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
@@ -157,8 +159,16 @@ public class RewriteHandler implements HttpHandler {
             }
             // - env (note: this sets a request attribute)
             if (rules[i].isEnv() && newtest != null) {
+                Map<String, String> attrs = exchange.getAttachment(HttpServerExchange.REQUEST_ATTRIBUTES);
+                if (attrs == null) {
+                    attrs = new HashMap<>();
+                    exchange.putAttachment(HttpServerExchange.REQUEST_ATTRIBUTES, attrs);
+                }
                 for (int j = 0; j < rules[i].getEnvSize(); j++) {
-                    request.setAttribute(rules[i].getEnvName(j), rules[i].getEnvResult(j));
+                    final String envName = rules[i].getEnvName(j);
+                    final String envResult = rules[i].getEnvResult(j);
+                    attrs.put(envName, envResult);
+                    request.setAttribute(envName, envResult);
                 }
             }
             // - content type (note: this will not force the content type, use a filter


### PR DESCRIPTION
change save the env attributes to REQUEST_ATTRIBUTES

i use rewritehandler to rewrite my front path to index.html, it work prefect when i have login in the system, but when i direct request my front resource without login, it rewrite to index.html, my authentication filter intecept the request and redirect to login page and pass current location as a 
returnUrl parameter, when i login in from login page, it redirect to index.html, that was not correct,
when i digged into undertow rewrite, i found the rewrite env, my test code is here
RewriteCond %{REQUEST_METHOD} GET [NC]
RewriteRule ^/index.html/ent$ /ent [NE,R,E=original-path:%{REQUEST_PATH}]
when i config it, RewriteHandler set the attribute correct in the request attributes, but i can't get that attributes from my filter code, so i can't set the correct url as returnUrl, the issure appear agin, i following the code step by step, finaly i found the request and exchange property override by ServletInitialHandler, and did not set the env property

1. origin rewrite url env stored in the exchange ATTACHMENT_KEY request object attributes property
2.ServletInitialHandler override the request and ATTACHMENT_KEY by following code
    ```
final HttpServletResponseImpl oResponse = new HttpServletResponseImpl(exchange, servletContext);
        final HttpServletRequestImpl oRequest = new HttpServletRequestImpl(exchange, servletContext);
        final ServletRequestContext servletRequestContext = new ServletRequestContext(servletContext.getDeployment(), oRequest, oResponse, info);
        servletRequestContext.setServletRequest(request);
        servletRequestContext.setServletResponse(response);
        //set the max request size if applicable
        if (info.getServletChain().getManagedServlet().getMaxRequestSize() > 0) {
            exchange.setMaxEntitySize(info.getServletChain().getManagedServlet().getMaxRequestSize());
        }
        exchange.putAttachment(ServletRequestContext.ATTACHMENT_KEY, servletRequestContext);
```
   this cause i can't touch the env variable anymore

in the ServletInitialHandler, i saw the follow code, so i put it in REQUEST_ATTRIBUTES
```
private void handleFirstRequest(final HttpServerExchange exchange, ServletRequestContext servletRequestContext) throws Exception {
        ServletRequest request = servletRequestContext.getServletRequest();
        ServletResponse response = servletRequestContext.getServletResponse();
        //set request attributes from the connector
        //generally this is only applicable if apache is sending AJP_ prefixed environment variables
        Map<String, String> attrs = exchange.getAttachment(HttpServerExchange.REQUEST_ATTRIBUTES);
        if(attrs != null) {
            for(Map.Entry<String, String> entry : attrs.entrySet()) {
                request.setAttribute(entry.getKey(), entry.getValue());
            }
        }
        servletRequestContext.setRunningInsideHandler(true);
```