### PR TITLE
UNDERTOW-1622: Implement blocking IO timeouts

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -31,6 +31,8 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.xnio.channels.ReadTimeoutException;
+import org.xnio.channels.WriteTimeoutException;
 import org.xnio.ssl.SslConnection;
 
 import java.io.IOException;
@@ -423,4 +425,12 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 5092, value = "Failed to free direct buffer")
     void directBufferDeallocationFailed(@Cause Throwable t);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 5093, value = "Blocking read timed out")
+    void blockingReadTimedOut(@Cause ReadTimeoutException rte);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 5094, value = "Blocking write timed out")
+    void blockingWriteTimedOut(@Cause WriteTimeoutException rte);
 }

--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -39,6 +39,8 @@ import io.undertow.server.handlers.builder.HandlerBuilder;
 import io.undertow.util.HttpString;
 import io.undertow.util.ParameterLimitException;
 import io.undertow.util.BadRequestException;
+import org.xnio.channels.ReadTimeoutException;
+import org.xnio.channels.WriteTimeoutException;
 
 /**
  * @author Stuart Douglas
@@ -610,4 +612,10 @@ public interface UndertowMessages {
 
     @Message(id = 196, value = "Session with id %s already exists")
     IllegalStateException sessionWithIdAlreadyExists(String sessionID);
+
+    @Message(id = 197, value = "Blocking read timed out after %s nanoseconds.")
+    ReadTimeoutException blockingReadTimedOut(long timeoutNanoseconds);
+
+    @Message(id = 198, value = "Blocking write timed out after %s nanoseconds.")
+    WriteTimeoutException blockingWriteTimedOut(long timeoutNanoseconds);
 }

--- a/core/src/main/java/io/undertow/server/handlers/BlockingReadTimeoutHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/BlockingReadTimeoutHandler.java
@@ -1,0 +1,238 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
+import io.undertow.util.ConduitFactory;
+import org.xnio.IoUtils;
+import org.xnio.XnioIoThread;
+import org.xnio.XnioWorker;
+import org.xnio.channels.ReadTimeoutException;
+import org.xnio.channels.StreamSinkChannel;
+import org.xnio.conduits.ReadReadyHandler;
+import org.xnio.conduits.StreamSourceConduit;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * {@link BlockingReadTimeoutHandler} allows configurable blocking I/O timeouts
+ * for read operations within an exchange.
+ * <p>
+ * Unlike Options.READ_TIMEOUT this only applies to blocking operations which
+ * can be helpful to prevent the worker pool from becoming saturated when
+ * clients stop responding.
+ * <p>
+ * When a timeout occurs, a {@link ReadTimeoutException} is thrown, and the
+ * {@link ServerConnection} is closed.
+ *
+ * @author Carter Kozak
+ */
+public final class BlockingReadTimeoutHandler implements HttpHandler {
+
+    private final HttpHandler next;
+    private final ConduitWrapper<StreamSourceConduit> streamSourceConduitWrapper;
+
+    private BlockingReadTimeoutHandler(HttpHandler next, Duration readTimeout) {
+        this.next = next;
+        this.streamSourceConduitWrapper = new TimeoutStreamSourceConduitWrapper(readTimeout);
+    }
+
+    private static final class TimeoutStreamSourceConduitWrapper implements ConduitWrapper<StreamSourceConduit> {
+
+        private final long timeoutNanoseconds;
+
+        TimeoutStreamSourceConduitWrapper(Duration readTimeout) {
+            this.timeoutNanoseconds = readTimeout.toNanos();
+        }
+
+        @Override
+        public StreamSourceConduit wrap(ConduitFactory<StreamSourceConduit> factory, HttpServerExchange exchange) {
+            return new TimeoutStreamSourceConduit(factory.create(), exchange.getConnection(), timeoutNanoseconds);
+        }
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        exchange.addRequestWrapper(streamSourceConduitWrapper);
+        next.handleRequest(exchange);
+    }
+
+    private static final class TimeoutStreamSourceConduit implements StreamSourceConduit {
+        private final StreamSourceConduit delegate;
+        private final ServerConnection serverConnection;
+        private final long timeoutNanos;
+        private long remaining;
+
+        TimeoutStreamSourceConduit(
+                StreamSourceConduit delegate,
+                ServerConnection serverConnection,
+                long timeoutNanos) {
+            this.delegate = delegate;
+            this.serverConnection = serverConnection;
+            this.timeoutNanos = timeoutNanos;
+            this.remaining = timeoutNanos;
+        }
+
+        @Override
+        public long transferTo(long position, long count, FileChannel fileChannel) throws IOException {
+            return resetTimeoutIfReadSucceeded(delegate.transferTo(position, count, fileChannel));
+        }
+
+        @Override
+        public long transferTo(long count, ByteBuffer byteBuffer, StreamSinkChannel streamSinkChannel) throws IOException {
+            return resetTimeoutIfReadSucceeded(delegate.transferTo(count, byteBuffer, streamSinkChannel));
+        }
+
+        @Override
+        public int read(ByteBuffer byteBuffer) throws IOException {
+            return resetTimeoutIfReadSucceeded(delegate.read(byteBuffer));
+        }
+
+        @Override
+        public long read(ByteBuffer[] byteBuffers, int offset, int length) throws IOException {
+            return resetTimeoutIfReadSucceeded(delegate.read(byteBuffers, offset, length));
+        }
+
+        @Override
+        public void terminateReads() throws IOException {
+            delegate.terminateReads();
+        }
+
+        @Override
+        public boolean isReadShutdown() {
+            return delegate.isReadShutdown();
+        }
+
+        @Override
+        public void resumeReads() {
+            delegate.resumeReads();
+        }
+
+        @Override
+        public void suspendReads() {
+            delegate.suspendReads();
+        }
+
+        @Override
+        public void wakeupReads() {
+            delegate.wakeupReads();
+        }
+
+        @Override
+        public boolean isReadResumed() {
+            return delegate.isReadResumed();
+        }
+
+        @Override
+        public void awaitReadable() throws IOException {
+            awaitReadable(remaining, TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        public void awaitReadable(long duration, TimeUnit unit) throws IOException {
+            long startTime = System.nanoTime();
+            long requestedNanos = unit.toNanos(duration);
+            try {
+                delegate.awaitReadable(Math.min(requestedNanos, remaining), TimeUnit.NANOSECONDS);
+            } finally {
+                remaining -= System.nanoTime() - startTime;
+            }
+            if (remaining < 0) {
+                ReadTimeoutException rte = UndertowMessages.MESSAGES.blockingReadTimedOut(timeoutNanos);
+                UndertowLogger.REQUEST_IO_LOGGER.blockingReadTimedOut(rte);
+                IoUtils.safeClose(serverConnection);
+                throw rte;
+            }
+        }
+
+        @Override
+        public XnioIoThread getReadThread() {
+            return delegate.getReadThread();
+        }
+
+        @Override
+        public void setReadReadyHandler(ReadReadyHandler readReadyHandler) {
+            delegate.setReadReadyHandler(readReadyHandler);
+        }
+
+        @Override
+        public XnioWorker getWorker() {
+            return delegate.getWorker();
+        }
+
+        private long resetTimeoutIfReadSucceeded(long value) {
+            if (value != 0) {
+                // Reset the timeout
+                remaining = timeoutNanos;
+            }
+            return value;
+        }
+
+        private int resetTimeoutIfReadSucceeded(int value) {
+            if (value != 0) {
+                // Reset the timeout
+                remaining = timeoutNanos;
+            }
+            return value;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private HttpHandler nextHandler;
+        private Duration readTimeout;
+
+        private Builder() {}
+
+        public Builder readTimeout(Duration readTimeout) {
+            this.readTimeout = Objects.requireNonNull(readTimeout, "A read timeout is required");
+            return this;
+        }
+
+        public Builder nextHandler(HttpHandler nextHandler) {
+            this.nextHandler = Objects.requireNonNull(nextHandler, "HttpHandler is required");
+            return this;
+        }
+
+        public HttpHandler build() {
+            HttpHandler next = Objects.requireNonNull(nextHandler, "HttpHandler is required");
+            if (readTimeout == null) {
+                throw new IllegalArgumentException("A read timeout is required");
+            }
+            if (readTimeout.isZero() || readTimeout.isNegative()) {
+                throw new IllegalArgumentException("Read timeout must be positive: " + readTimeout);
+            }
+            return new BlockingReadTimeoutHandler(next, readTimeout);
+        }
+    }
+}

--- a/core/src/main/java/io/undertow/server/handlers/BlockingWriteTimeoutHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/BlockingWriteTimeoutHandler.java
@@ -1,0 +1,270 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
+import io.undertow.server.ConduitWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
+import io.undertow.util.ConduitFactory;
+import org.xnio.IoUtils;
+import org.xnio.XnioIoThread;
+import org.xnio.XnioWorker;
+import org.xnio.channels.StreamSourceChannel;
+import org.xnio.channels.WriteTimeoutException;
+import org.xnio.conduits.StreamSinkConduit;
+import org.xnio.conduits.WriteReadyHandler;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * BlockingTimeoutHandler allows configurable blocking I/O timeouts for write
+ * operations within an exchange.
+ * <p>
+ * Unlike Options.WRITE_TIMEOUT this only applies to blocking operations which
+ * can be helpful to prevent the worker pool from becoming saturated when
+ * clients stop responding.
+ * <p>
+ * When a timeout occurs, a {@link WriteTimeoutException} is thrown, and the
+ * {@link ServerConnection} is closed.
+ *
+ * @author Carter Kozak
+ */
+public final class BlockingWriteTimeoutHandler implements HttpHandler {
+
+    private final HttpHandler next;
+    private final ConduitWrapper<StreamSinkConduit> streamSinkConduitWrapper;
+
+    private BlockingWriteTimeoutHandler(HttpHandler next, Duration writeTimeout) {
+        this.next = next;
+        this.streamSinkConduitWrapper = new TimeoutStreamSinkConduitWrapper(writeTimeout);
+    }
+
+    private static final class TimeoutStreamSinkConduitWrapper implements ConduitWrapper<StreamSinkConduit> {
+
+        private final long timeoutNanoseconds;
+
+        TimeoutStreamSinkConduitWrapper(Duration writeTimeout) {
+            this.timeoutNanoseconds = writeTimeout.toNanos();
+        }
+
+        @Override
+        public StreamSinkConduit wrap(ConduitFactory<StreamSinkConduit> factory, HttpServerExchange exchange) {
+            return new TimeoutStreamSinkConduit(factory.create(), exchange.getConnection(), timeoutNanoseconds);
+        }
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        exchange.addResponseWrapper(streamSinkConduitWrapper);
+        next.handleRequest(exchange);
+    }
+
+    private static final class TimeoutStreamSinkConduit implements StreamSinkConduit {
+
+        private final StreamSinkConduit delegate;
+        private final ServerConnection serverConnection;
+        private final long timeoutNanos;
+        private long remaining;
+
+        TimeoutStreamSinkConduit(
+                StreamSinkConduit delegate,
+                ServerConnection serverConnection,
+                long timeoutNanos) {
+            this.delegate = delegate;
+            this.serverConnection = serverConnection;
+            this.timeoutNanos = timeoutNanos;
+            this.remaining = timeoutNanos;
+        }
+
+        @Override
+        public long transferFrom(FileChannel fileChannel, long position, long count) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.transferFrom(fileChannel, position, count));
+        }
+
+        @Override
+        public long transferFrom(
+                StreamSourceChannel streamSourceChannel,
+                long count,
+                ByteBuffer byteBuffer) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.transferFrom(streamSourceChannel, count, byteBuffer));
+        }
+
+        @Override
+        public int write(ByteBuffer byteBuffer) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.write(byteBuffer));
+        }
+
+        @Override
+        public long write(ByteBuffer[] byteBuffers, int offset, int length) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.write(byteBuffers, offset, length));
+        }
+
+        @Override
+        public int writeFinal(ByteBuffer byteBuffer) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.writeFinal(byteBuffer));
+        }
+
+        @Override
+        public long writeFinal(ByteBuffer[] byteBuffers, int offset, int length) throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.writeFinal(byteBuffers, offset, length));
+        }
+
+        @Override
+        public void terminateWrites() throws IOException {
+            delegate.terminateWrites();
+        }
+
+        @Override
+        public boolean isWriteShutdown() {
+            return delegate.isWriteShutdown();
+        }
+
+        @Override
+        public void resumeWrites() {
+            delegate.resumeWrites();
+        }
+
+        @Override
+        public void suspendWrites() {
+            delegate.suspendWrites();
+        }
+
+        @Override
+        public void wakeupWrites() {
+            delegate.wakeupWrites();
+        }
+
+        @Override
+        public boolean isWriteResumed() {
+            return delegate.isWriteResumed();
+        }
+
+        @Override
+        public void awaitWritable() throws IOException {
+            awaitWritable(remaining, TimeUnit.NANOSECONDS);
+        }
+
+        @Override
+        public void awaitWritable(long duration, TimeUnit unit) throws IOException {
+            long startTime = System.nanoTime();
+            long requestedNanos = unit.toNanos(duration);
+            try {
+                delegate.awaitWritable(Math.min(requestedNanos, remaining), TimeUnit.NANOSECONDS);
+            } finally {
+                remaining -= System.nanoTime() - startTime;
+            }
+            if (remaining < 0) {
+                WriteTimeoutException wte = UndertowMessages.MESSAGES.blockingWriteTimedOut(timeoutNanos);
+                UndertowLogger.REQUEST_IO_LOGGER.blockingWriteTimedOut(wte);
+                IoUtils.safeClose(serverConnection);
+                throw wte;
+            }
+        }
+
+        @Override
+        public XnioIoThread getWriteThread() {
+            return delegate.getWriteThread();
+        }
+
+        @Override
+        public void setWriteReadyHandler(WriteReadyHandler writeReadyHandler) {
+            delegate.setWriteReadyHandler(writeReadyHandler);
+        }
+
+        @Override
+        public void truncateWrites() throws IOException {
+            delegate.truncateWrites();
+        }
+
+        @Override
+        public boolean flush() throws IOException {
+            return resetTimeoutIfWriteSucceeded(delegate.flush());
+        }
+
+        @Override
+        public XnioWorker getWorker() {
+            return delegate.getWorker();
+        }
+
+        private long resetTimeoutIfWriteSucceeded(long value) {
+            if (value != 0) {
+                // Reset the timeout
+                remaining = timeoutNanos;
+            }
+            return value;
+        }
+
+        private int resetTimeoutIfWriteSucceeded(int value) {
+            if (value != 0) {
+                // Reset the timeout
+                remaining = timeoutNanos;
+            }
+            return value;
+        }
+
+        private boolean resetTimeoutIfWriteSucceeded(boolean value) {
+            if (value) {
+                // Reset the timeout
+                remaining = timeoutNanos;
+            }
+            return value;
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private HttpHandler nextHandler;
+        private Duration writeTimeout;
+
+        private Builder() {}
+
+        public Builder writeTimeout(Duration writeTimeout) {
+            this.writeTimeout =  Objects.requireNonNull(writeTimeout, "A write timeout is required");
+            return this;
+        }
+
+        public Builder nextHandler(HttpHandler nextHandler) {
+            this.nextHandler = Objects.requireNonNull(nextHandler, "HttpHandler is required");
+            return this;
+        }
+
+        public HttpHandler build() {
+            HttpHandler next = Objects.requireNonNull(nextHandler, "HttpHandler is required");
+            if (writeTimeout == null) {
+                throw new IllegalArgumentException("A write timeout is required");
+            }
+            if (writeTimeout.isZero() || writeTimeout.isNegative()) {
+                throw new IllegalArgumentException("Write timeout must be positive: " + writeTimeout);
+            }
+            return new BlockingWriteTimeoutHandler(next, writeTimeout);
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/server/handlers/BlockingReadTimeoutHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/BlockingReadTimeoutHandlerTestCase.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.AbstractHttpEntity;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.channels.ReadTimeoutException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * Tests blocking read timeout with a slow request
+ *
+ * @author Carter Kozak
+ */
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+public class BlockingReadTimeoutHandlerTestCase {
+
+    private static final OutputStream STUB_OUTPUT_STREAM = new OutputStream() {
+        @Override
+        public void write(byte[] var1, int var2, int var3) throws IOException {
+
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+
+        }
+    };
+
+    private volatile Exception exception;
+    private static final CountDownLatch errorLatch = new CountDownLatch(1);
+
+    @Test
+    public void testReadTimeout() throws InterruptedException {
+        DefaultServer.setRootHandler(BlockingReadTimeoutHandler.builder().nextHandler(new BlockingHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                try {
+                    IOUtils.copyLarge(exchange.getInputStream(), STUB_OUTPUT_STREAM);
+                    exchange.getOutputStream().write("COMPLETED".getBytes(StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    exception = e;
+                    errorLatch.countDown();
+                }
+            }
+        })).readTimeout(Duration.ofMillis(1)).build());
+
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL());
+            post.setEntity(new AbstractHttpEntity() {
+
+                @Override
+                public InputStream getContent() throws IOException, IllegalStateException {
+                    return null;
+                }
+
+                @Override
+                public void writeTo(final OutputStream outstream) throws IOException {
+                    for (int i = 0; i < 5; ++i) {
+                        outstream.write('*');
+                        outstream.flush();
+                        try {
+                            Thread.sleep(200);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+
+                @Override
+                public boolean isStreaming() {
+                    return true;
+                }
+
+                @Override
+                public boolean isRepeatable() {
+                    return false;
+                }
+
+                @Override
+                public long getContentLength() {
+                    return 5;
+                }
+            });
+            post.addHeader(Headers.CONNECTION_STRING, "close");
+            try {
+                client.execute(post);
+            } catch (IOException e) {
+
+            }
+            if (errorLatch.await(5, TimeUnit.SECONDS)) {
+                Assert.assertEquals(ReadTimeoutException.class, exception.getClass());
+            } else {
+                Assert.fail("Read did not time out");
+            }
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/core/src/test/java/io/undertow/server/handlers/BlockingWriteTimeoutHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/BlockingWriteTimeoutHandlerTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.ProxyIgnore;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.channels.WriteTimeoutException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests blocking write timeout with a client that is slow to read the response
+ *
+ * @author Carter Kozak
+ */
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+@ProxyIgnore
+public class BlockingWriteTimeoutHandlerTestCase {
+
+    private volatile Exception exception;
+    private static final CountDownLatch errorLatch = new CountDownLatch(1);
+
+    @Test
+    public void testWriteTimeout() throws InterruptedException {
+        DefaultServer.setRootHandler(BlockingWriteTimeoutHandler.builder().nextHandler(new BlockingHandler(new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                final int capacity = 1 * 1024 * 1024; // 1mb
+
+                final byte[] data = new byte[capacity];
+                for (int i = 0; i < capacity; ++i) {
+                    data[i] = (byte) '*';
+                }
+
+                try {
+                    // Must write enough data that it's not buffered
+                    for (int i = 0; i < 20; i++) {
+                        exchange.getOutputStream().write(data);
+                    }
+                } catch (IOException e) {
+                    exception = e;
+                    errorLatch.countDown();
+                }
+            }
+        })).writeTimeout(Duration.ofMillis(1)).build());
+
+        final TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            try {
+                HttpResponse result = client.execute(get);
+                Assert.assertFalse("The result entity is buffered", result.getEntity().isRepeatable());
+                InputStream content = result.getEntity().getContent();
+                byte[] buffer = new byte[512];
+                int r = 0;
+                while ((r = content.read(buffer)) > 0) {
+                    Thread.sleep(200);
+                    if (exception != null) {
+                        Assert.assertEquals(WriteTimeoutException.class, exception.getClass());
+                        return;
+                    }
+                }
+                Assert.fail("Write did not time out");
+            } catch (IOException e) {
+                if (errorLatch.await(5, TimeUnit.SECONDS)) {
+                    Assert.assertEquals(WriteTimeoutException.class, exception.getClass());
+                } else {
+                    Assert.fail("Write did not time out");
+                }
+            }
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Implemented a new BlockingTimeoutHandler which can be configured
with I/O timeouts for blocking read and write operations.

This approach limits the time that may be spent in awaitReadable
or awaitWritable to apply to only blocking operations without requiring
invasive code change.