### PR TITLE
[UNDERTOW-1635] Mark the javadoc plugin source code compatible with 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
                             <head>Implementation Note:</head>
                         </tag>
                     </tags>
+                    <source>1.8</source> 
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Jira:https://issues.redhat.com/browse/UNDERTOW-1635