### PR TITLE
[UNDERTOW-1670] DefaultServer test utility waits for the worker to shut down

### DIFF
--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -33,6 +33,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import javax.net.ssl.KeyManager;
@@ -430,7 +431,10 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 public void testRunFinished(final Result result) throws Exception {
                     server.close();
                     stopSSLServer();
-                    worker.shutdown();
+                    worker.shutdownNow();
+                    if (!worker.awaitTermination(10, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Worker failed to shutdown within ten seconds");
+                    }
                 }
             });
         }


### PR DESCRIPTION
Attempt to isolate tests a bit better, we don't want threads from completed tests to create noise in subsequent tests.
Possible downside: Some tests may submit work that doesn't terminate gracefully, it's possible this will cause tests to take longer to complete.