### PR TITLE
Tests cycle through ports to avoid 'BindException: Address already in use'

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -239,7 +239,6 @@
                         <test.openssl>${openssl}</test.openssl>
                         <test.bufferSize>${bufferSize}</test.bufferSize>
                         <default.server.address>localhost</default.server.address>
-                        <default.server.port>7777</default.server.port>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <test.level>${test.level}</test.level>
                         <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
@@ -303,7 +302,6 @@
                                 <test.dump>${dump}</test.dump>
                                 <test.bufferSize>${bufferSize}</test.bufferSize>
                                 <default.server.address>localhost</default.server.address>
-                                <default.server.port>7777</default.server.port>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <test.level>${test.level}</test.level>
                                 <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
@@ -339,7 +337,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
                                         <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
@@ -362,7 +359,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -386,7 +382,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -410,7 +405,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -434,7 +428,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -459,7 +452,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -220,7 +220,6 @@
                         <test.dump>${dump}</test.dump>
                         <test.bufferSize>${bufferSize}</test.bufferSize>
                         <default.server.address>localhost</default.server.address>
-                        <default.server.port>7777</default.server.port>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <test.level>${test.level}</test.level>
                         <java.net.preferIPv6Addresses>${test.ipv6}</java.net.preferIPv6Addresses>
@@ -268,7 +267,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -292,7 +290,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -316,7 +313,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -340,7 +336,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -365,7 +360,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>
@@ -389,7 +383,6 @@
                                         <test.dump>${dump}</test.dump>
                                         <test.bufferSize>${bufferSize}</test.bufferSize>
                                         <default.server.address>localhost</default.server.address>
-                                        <default.server.port>7777</default.server.port>
                                         <java.util.logging.manager>org.jboss.logmanager.LogManager
                                         </java.util.logging.manager>
                                         <test.level>${test.level}</test.level>


### PR DESCRIPTION
Note: I don't have a great idea how internal infrastructure works, it's possible this will cause unforeseen issues.

Goal is to reduce test flakes when the server port isn't reset quickly enough for the next test, however it's possible this could mask problems if listeners are not shut down. This change would not fix flakes on test infrastructure that explicitly sets `default.server.port`.