### PR TITLE
UNDERTOW-1645: AbstractFramedStreamSourceChannel.lastFrame invokes close

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
@@ -329,7 +329,7 @@ public abstract class AbstractFramedStreamSourceChannel<C extends AbstractFramed
         waitingForFrame = false;
         if(data == null && pendingFrameData.isEmpty() && frameDataRemaining == 0) {
             synchronized (lock) {
-                state |= STATE_DONE | STATE_CLOSED;
+                state |= STATE_DONE;
             }
             getFramedChannel().notifyFrameReadComplete(this);
             IoUtils.safeClose(this);


### PR DESCRIPTION
Previously STATE_CLOSED was set prior to invoking close, causing
close to return without cleaning up resources.