### PR TITLE
UNDERTOW-1643: Prevent deadlock in AbstractFramedStreamSinkChannel

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSinkChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSinkChannel.java
@@ -527,12 +527,16 @@ public abstract class AbstractFramedStreamSinkChannel<C extends AbstractFramedCh
     }
 
     @Override
-    public synchronized void close() throws IOException {
+    public void close() throws IOException {
         if(fullyFlushed || anyAreSet(state, STATE_CLOSED)) {
             return;
         }
         try {
             synchronized (lock) {
+                // Double check to avoid executing the the rest of this method multiple times
+                if(fullyFlushed || anyAreSet(state, STATE_CLOSED)) {
+                    return;
+                }
                 state |= STATE_CLOSED;
             }
             if(writeBuffer != null) {

--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedStreamSourceChannel.java
@@ -622,11 +622,15 @@ public abstract class AbstractFramedStreamSourceChannel<C extends AbstractFramed
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         if(anyAreSet(state, STATE_CLOSED)) {
             return;
         }
         synchronized (lock) {
+            // Double check to avoid executing the the rest of this method multiple times
+            if(anyAreSet(state, STATE_CLOSED)) {
+                return;
+            }
             state |= STATE_CLOSED;
             if (allAreClear(state, STATE_DONE | STATE_LAST_FRAME)) {
                 state |= STATE_STREAM_BROKEN;


### PR DESCRIPTION
Close uses double-check locking with the encapsulated lock object
instead of relying on the object level lock which risks deadlocks.