### PR TITLE
[UNDERTOW-1492] Respect rfc7230 section-3.3.2

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -328,6 +328,11 @@ public class Http2ServerConnection extends ServerConnection {
         DateUtils.addDateHeaderIfRequired(exchange);
         headers.add(STATUS, exchange.getStatusCode());
         Connectors.flattenCookies(exchange);
+        if(!Connectors.isEntityBodyAllowed(exchange)) {
+            //we are not allowed to send an entity body for some requests
+            exchange.getResponseHeaders().remove(Headers.CONTENT_LENGTH);
+            exchange.getResponseHeaders().remove(Headers.TRANSFER_ENCODING);
+        }
         return originalSinkConduit;
     }
 


### PR DESCRIPTION
Undertow send Content-Length header in 204 responses for HTTP/2, thus violating RFC 7230.
Note that for HTTP/1.X Undertow handles this correctly