### PR TITLE
UNDERTOW-1661 Fix Exchange already complete while rendering a JSP

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -937,7 +937,7 @@ public final class HttpServerExchange extends AbstractAttachable {
 
 
     public HttpServerExchange addExchangeCompleteListener(final ExchangeCompletionListener listener) {
-        if(isComplete() || this.exchangeCompletionListenersCount == -1) {
+        if(isComplete() || hasListenersBeenInvoked()) {
             throw UndertowMessages.MESSAGES.exchangeAlreadyComplete();
         }
         final int exchangeCompletionListenersCount = this.exchangeCompletionListenersCount++;
@@ -951,6 +951,10 @@ public final class HttpServerExchange extends AbstractAttachable {
         }
         exchangeCompleteListeners[exchangeCompletionListenersCount] = listener;
         return this;
+    }
+
+    public boolean hasListenersBeenInvoked() {
+        return this.exchangeCompletionListenersCount == -1;
     }
 
     public HttpServerExchange addDefaultResponseListener(final DefaultResponseListener listener) {

--- a/core/src/main/java/io/undertow/server/handlers/MetricsHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/MetricsHandler.java
@@ -50,7 +50,7 @@ public class MetricsHandler implements HttpHandler {
 
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        if(!exchange.isComplete()) {
+        if(!exchange.isComplete() && !exchange.hasListenersBeenInvoked()) {
             final long start = System.currentTimeMillis();
             exchange.addExchangeCompleteListener(new ExchangeCompletionListener() {
                 @Override


### PR DESCRIPTION
We now test in MetricsHandler that all conditions are met before adding an ExchangeCompletionListener to avoid an unwanted failure.