### PR TITLE
Http session to request/response references

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpSessionImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpSessionImpl.java
@@ -18,6 +18,7 @@
 
 package io.undertow.servlet.spec;
 
+import java.lang.ref.WeakReference;
 import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -49,13 +50,13 @@ public class HttpSessionImpl implements HttpSession {
     private final ServletContext servletContext;
     private final boolean newSession;
     private volatile boolean invalid;
-    private final ServletRequestContext servletRequestContext;
+    private final WeakReference<ServletRequestContext> servletRequestContextRef;
 
     private HttpSessionImpl(final Session session, final ServletContext servletContext, final boolean newSession, ServletRequestContext servletRequestContext) {
         this.session = session;
         this.servletContext = servletContext;
         this.newSession = newSession;
-        this.servletRequestContext = servletRequestContext;
+        this.servletRequestContextRef = new WeakReference<>(servletRequestContext);
     }
 
     public static HttpSessionImpl forSession(final Session session, final ServletContext servletContext, final boolean newSession) {
@@ -191,6 +192,7 @@ public class HttpSessionImpl implements HttpSession {
     @Override
     public void invalidate() {
         invalid = true;
+        ServletRequestContext servletRequestContext = servletRequestContextRef.get();
         if (servletRequestContext == null) {
             session.invalidate(null);
         } else {


### PR DESCRIPTION
Since 0c0abf2, http sessions keep reference to request and response via servletRequestContext.
Because an http session can be kept as a reference by the webapp for some time or for a long time after the end of the request, it would be better for memory that an http session does not keep references to request and response.