### PR TITLE
UNDERTOW-1700: Prevent resource leaks when exchanges aren't closed cleanly

### DIFF
--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -1727,6 +1727,8 @@ public final class HttpServerExchange extends AbstractAttachable {
                                 channel.getWriteSetter().set(null);
                                 //defensive programming, should never happen
                                 if (anyAreClear(state, FLAG_RESPONSE_TERMINATED)) {
+                                    //make sure the listeners have been invoked
+                                    invokeExchangeCompleteListeners();
                                     UndertowLogger.ROOT_LOGGER.responseWasNotTerminated(connection, HttpServerExchange.this);
                                     IoUtils.safeClose(connection);
                                 }
@@ -1745,6 +1747,8 @@ public final class HttpServerExchange extends AbstractAttachable {
             } else {
                 //defensive programming, should never happen
                 if (anyAreClear(state, FLAG_RESPONSE_TERMINATED)) {
+                    //make sure the listeners have been invoked
+                    invokeExchangeCompleteListeners();
                     UndertowLogger.ROOT_LOGGER.responseWasNotTerminated(connection, this);
                     IoUtils.safeClose(connection);
                 }


### PR DESCRIPTION
This does not solve the linked ticket, but prevents the described
scenario from causing additional problems.

While the modified blocks are commented suggesting that they
should never be called, UNDERTOW-1664 describes when they occur
with a reproducer.