### PR TITLE
[UNDERTOW-1678] Some tests do not respect value of 'default.server.ad…

### DIFF
--- a/core/src/test/java/io/undertow/server/HttpServerExchangeTestCase.java
+++ b/core/src/test/java/io/undertow/server/HttpServerExchangeTestCase.java
@@ -65,11 +65,11 @@ public class HttpServerExchangeTestCase {
             HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/somepath");
             HttpResponse result = client.execute(get);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            Assert.assertEquals("localhost:" + protocol + ":GET:" + port + ":/somepath:/somepath:", HttpClientUtils.readResponse(result));
+            Assert.assertEquals(DefaultServer.getHostAddress() + ":" + protocol + ":GET:" + port + ":/somepath:/somepath:", HttpClientUtils.readResponse(result));
             get = new HttpGet(DefaultServer.getDefaultServerURL() + "/somepath?a=b");
             result = client.execute(get);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            Assert.assertEquals("localhost:" + protocol + ":GET:" + port + ":/somepath:/somepath:a=b", HttpClientUtils.readResponse(result));
+            Assert.assertEquals(DefaultServer.getHostAddress() + ":" + protocol + ":GET:" + port + ":/somepath:/somepath:a=b", HttpClientUtils.readResponse(result));
             get = new HttpGet(DefaultServer.getDefaultServerURL() + "/somepath?a=b");
             get.addHeader("Host", "[::1]:8080");
             result = client.execute(get);

--- a/core/src/test/java/io/undertow/server/handlers/proxy/ProxyHandlerXForwardedForTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/proxy/ProxyHandlerXForwardedForTestCase.java
@@ -89,7 +89,7 @@ public class ProxyHandlerXForwardedForTestCase {
 
             Assert.assertEquals(port, Integer.parseInt(result.getFirstHeader(Headers.X_FORWARDED_PORT.toString()).getValue()));
             Assert.assertEquals("http", result.getFirstHeader(Headers.X_FORWARDED_PROTO.toString()).getValue());
-            Assert.assertEquals("localhost", result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
+            Assert.assertEquals(DefaultServer.getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
             Assert.assertEquals(DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_FOR.toString()).getValue());
 
         } finally {
@@ -111,7 +111,7 @@ public class ProxyHandlerXForwardedForTestCase {
 
             Assert.assertEquals(sslPort, Integer.parseInt(result.getFirstHeader(Headers.X_FORWARDED_PORT.toString()).getValue()));
             Assert.assertEquals("https", result.getFirstHeader(Headers.X_FORWARDED_PROTO.toString()).getValue());
-            Assert.assertEquals("localhost", result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
+            Assert.assertEquals(DefaultServer.getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
             Assert.assertEquals(DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_FOR.toString()).getValue());
 
         } finally {
@@ -132,7 +132,7 @@ public class ProxyHandlerXForwardedForTestCase {
 
             Assert.assertEquals(port, Integer.parseInt(result.getFirstHeader(Headers.X_FORWARDED_PORT.toString()).getValue()));
             Assert.assertEquals("http", result.getFirstHeader(Headers.X_FORWARDED_PROTO.toString()).getValue());
-            Assert.assertEquals("localhost", result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
+            Assert.assertEquals(DefaultServer.getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
             Assert.assertEquals("50.168.245.32," + DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_FOR.toString()).getValue());
 
         } finally {
@@ -141,7 +141,7 @@ public class ProxyHandlerXForwardedForTestCase {
     }
 
     @Test
-    public void testReqriteHostHeader() throws Exception {
+    public void testRewriteHostHeader() throws Exception {
         setProxyHandler(true, false);
         TestHttpClient client = new TestHttpClient();
 
@@ -153,7 +153,7 @@ public class ProxyHandlerXForwardedForTestCase {
 
             Assert.assertEquals(port, Integer.parseInt(result.getFirstHeader(Headers.X_FORWARDED_PORT.toString()).getValue()));
             Assert.assertEquals("http", result.getFirstHeader(Headers.X_FORWARDED_PROTO.toString()).getValue());
-            Assert.assertEquals(String.format("localhost:%d", port), result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
+            Assert.assertEquals(String.format("%s:%d", DefaultServer.getHostAddress(), port), result.getFirstHeader(Headers.X_FORWARDED_HOST.toString()).getValue());
             Assert.assertEquals(DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), result.getFirstHeader(Headers.X_FORWARDED_FOR.toString()).getValue());
 
         } finally {

--- a/servlet/src/test/java/io/undertow/servlet/test/request/HttpHostValuesTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/request/HttpHostValuesTestCase.java
@@ -22,7 +22,6 @@ import io.undertow.server.handlers.PathHandler;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import io.undertow.servlet.api.ServletContainer;
-import io.undertow.servlet.test.SimpleServletTestCase;
 import io.undertow.servlet.test.util.TestClassIntrospector;
 import io.undertow.testutils.DefaultServer;
 import io.undertow.testutils.HttpClientUtils;
@@ -48,13 +47,13 @@ import static io.undertow.servlet.Servlets.servlet;
 public class HttpHostValuesTestCase {
 
     @BeforeClass
-    public static void setup() throws ServletException {
+    public static void setup() {
 
 
         final PathHandler pathHandler = new PathHandler();
         final ServletContainer container = ServletContainer.Factory.newInstance();
         DeploymentInfo builder = new DeploymentInfo()
-                .setClassLoader(SimpleServletTestCase.class.getClassLoader())
+                .setClassLoader(HttpHostValuesTestCase.class.getClassLoader())
                 .setContextPath("/servletContext")
                 .setClassIntrospecter(TestClassIntrospector.INSTANCE)
                 .setDeploymentName("servletContext.war")

--- a/servlet/src/test/java/io/undertow/servlet/test/request/RedirectTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/request/RedirectTestCase.java
@@ -78,8 +78,12 @@ public class RedirectTestCase {
     public void testServletRedirect() throws Exception {
         int port = DefaultServer.getHostPort("default");
         //test redirects
-        runtest("/servletContext/redirect/foo?redirect=../bar", "null", "/bar", "http://localhost:" + port + "/servletContext/bar", "/servletContext/bar", "");
-        runtest("/servletContext/redirect/foo/?redirect=../../bar", "null", "/bar", "http://localhost:" + port + "/servletContext/bar", "/servletContext/bar", "");
+        runtest("/servletContext/redirect/foo?redirect=../bar", "null", "/bar",
+                "http://" + DefaultServer.getHostAddress() + ":" + port + "/servletContext/bar", "/servletContext/bar"
+                , "");
+        runtest("/servletContext/redirect/foo/?redirect=../../bar", "null", "/bar",
+                "http://" + DefaultServer.getHostAddress() + ":" + port + "/servletContext/bar", "/servletContext/bar"
+                , "");
     }
 
     private void runtest(String request, String... expectedBody) throws Exception {

--- a/servlet/src/test/java/io/undertow/servlet/test/request/RequestPathTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/request/RequestPathTestCase.java
@@ -94,33 +94,35 @@ public class RequestPathTestCase {
     @Test
     public void testRequestPaths() throws Exception {
         int port = DefaultServer.getHostPort("default");
+        final String hostAddress = DefaultServer.getHostAddress();
+
         //test default servlet mappings
-        runtest("/servletContext/somePath", false, "null", "/somePath", "http://localhost:" + port + "/servletContext/somePath", "/servletContext/somePath", "");
-        runtest("/servletContext/somePath?foo=bar", false, "null", "/somePath", "http://localhost:" + port + "/servletContext/somePath", "/servletContext/somePath", "foo=bar");
-        runtest("/servletContext/somePath?foo=b+a+r", false, "null", "/somePath", "http://localhost:" + port + "/servletContext/somePath", "/servletContext/somePath", "foo=b+a+r");
-        runtest("/servletContext/some%20path?foo=b+a+r", false, "null", "/some path", "http://localhost:" + port + "/servletContext/some%20path", "/servletContext/some%20path", "foo=b+a+r");
-        runtest("/servletContext/somePath.txt", true, "null", "/somePath.txt", "http://localhost:" + port + "/servletContext/somePath.txt", "/servletContext/somePath.txt", "");
-        runtest("/servletContext/somePath.txt?foo=bar", true, "null", "/somePath.txt", "http://localhost:" + port + "/servletContext/somePath.txt", "/servletContext/somePath.txt", "foo=bar");
+        runtest("/servletContext/somePath", false, "null", "/somePath", "http://"+ hostAddress + ":" + port + "/servletContext/somePath", "/servletContext/somePath", "");
+        runtest("/servletContext/somePath?foo=bar", false, "null", "/somePath", "http://" + hostAddress + ":" + port + "/servletContext/somePath", "/servletContext/somePath", "foo=bar");
+        runtest("/servletContext/somePath?foo=b+a+r", false, "null", "/somePath", "http://" + hostAddress + ":" + port + "/servletContext/somePath", "/servletContext/somePath", "foo=b+a+r");
+        runtest("/servletContext/some%20path?foo=b+a+r", false, "null", "/some path", "http://" + hostAddress + ":" + port + "/servletContext/some%20path", "/servletContext/some%20path", "foo=b+a+r");
+        runtest("/servletContext/somePath.txt", true, "null", "/somePath.txt", "http://" + hostAddress + ":" + port + "/servletContext/somePath.txt", "/servletContext/somePath.txt", "");
+        runtest("/servletContext/somePath.txt?foo=bar", true, "null", "/somePath.txt", "http://" + hostAddress + ":" + port + "/servletContext/somePath.txt", "/servletContext/somePath.txt", "foo=bar");
 
         //test non-default mappings
-        runtest("/servletContext/req/somePath", false, "/somePath", "/req", "http://localhost:" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "");
-        runtest("/servletContext/req/somePath?foo=bar", false, "/somePath", "/req", "http://localhost:" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "foo=bar");
-        runtest("/servletContext/req/somePath?foo=b+a+r", false, "/somePath", "/req", "http://localhost:" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "foo=b+a+r");
-        runtest("/servletContext/req/some%20path?foo=b+a+r", false, "/some path", "/req", "http://localhost:" + port + "/servletContext/req/some%20path", "/servletContext/req/some%20path", "foo=b+a+r");
-        runtest("/servletContext/req/somePath.txt", true, "/somePath.txt", "/req", "http://localhost:" + port + "/servletContext/req/somePath.txt", "/servletContext/req/somePath.txt", "");
-        runtest("/servletContext/req/somePath.txt?foo=bar", true, "/somePath.txt", "/req", "http://localhost:" + port + "/servletContext/req/somePath.txt", "/servletContext/req/somePath.txt", "foo=bar");
+        runtest("/servletContext/req/somePath", false, "/somePath", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "");
+        runtest("/servletContext/req/somePath?foo=bar", false, "/somePath", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "foo=bar");
+        runtest("/servletContext/req/somePath?foo=b+a+r", false, "/somePath", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/somePath", "/servletContext/req/somePath", "foo=b+a+r");
+        runtest("/servletContext/req/some%20path?foo=b+a+r", false, "/some path", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/some%20path", "/servletContext/req/some%20path", "foo=b+a+r");
+        runtest("/servletContext/req/somePath.txt", true, "/somePath.txt", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/somePath.txt", "/servletContext/req/somePath.txt", "");
+        runtest("/servletContext/req/somePath.txt?foo=bar", true, "/somePath.txt", "/req", "http://" + hostAddress + ":" + port + "/servletContext/req/somePath.txt", "/servletContext/req/somePath.txt", "foo=bar");
 
         //test exact path mappings
-        runtest("/servletContext/exact", false, "null", "/exact", "http://localhost:" + port + "/servletContext/exact", "/servletContext/exact", "");
-        runtest("/servletContext/exact?foo=bar", false, "null", "/exact", "http://localhost:" + port + "/servletContext/exact", "/servletContext/exact", "foo=bar");
+        runtest("/servletContext/exact", false, "null", "/exact", "http://" + hostAddress + ":" + port + "/servletContext/exact", "/servletContext/exact", "");
+        runtest("/servletContext/exact?foo=bar", false, "null", "/exact", "http://" + hostAddress + ":" + port + "/servletContext/exact", "/servletContext/exact", "foo=bar");
 
         //test exact path mappings with a filer
-        runtest("/servletContext/exact.txt", true, "null", "/exact.txt", "http://localhost:" + port + "/servletContext/exact.txt", "/servletContext/exact.txt", "");
-        runtest("/servletContext/exact.txt?foo=bar", true, "null", "/exact.txt", "http://localhost:" + port + "/servletContext/exact.txt", "/servletContext/exact.txt", "foo=bar");
+        runtest("/servletContext/exact.txt", true, "null", "/exact.txt", "http://" + hostAddress + ":" + port + "/servletContext/exact.txt", "/servletContext/exact.txt", "");
+        runtest("/servletContext/exact.txt?foo=bar", true, "null", "/exact.txt", "http://" + hostAddress + ":" + port + "/servletContext/exact.txt", "/servletContext/exact.txt", "foo=bar");
 
         //test servlet extension matches
-        runtest("/servletContext/file.html", false, "null", "/file.html", "http://localhost:" + port + "/servletContext/file.html", "/servletContext/file.html", "");
-        runtest("/servletContext/file.html?foo=bar", false, "null", "/file.html", "http://localhost:" + port + "/servletContext/file.html", "/servletContext/file.html", "foo=bar");
+        runtest("/servletContext/file.html", false, "null", "/file.html", "http://" + hostAddress + ":" + port + "/servletContext/file.html", "/servletContext/file.html", "");
+        runtest("/servletContext/file.html?foo=bar", false, "null", "/file.html", "http://" + hostAddress + ":" + port + "/servletContext/file.html", "/servletContext/file.html", "foo=bar");
     }
 
     private void runtest(String request, boolean filterHeader, String... expectedBody) throws Exception {


### PR DESCRIPTION
…dress' property

Use hostname specified via 'default.server.address'.

Currently there is a bunch of tests that expect that server hostname
is always 'localhost'. This change modifies those so that they respect
actual value in 'default.server.address' property which is respected
by io.undertow.testutils.DefaultServer#getHostAddress().

https://issues.redhat.com/browse/UNDERTOW-1678