### PR TITLE
[UNDERTOW-1783] Add support for part specific charsets. Charset is captured during pa…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -326,7 +326,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                         }
                     }
 
-                    data.add(currentName, new String(contentBytes.toByteArray(), charset), headers);
+                    data.add(currentName, new String(contentBytes.toByteArray(), charset), charset, headers);
                 } catch (UnsupportedEncodingException e) {
                     throw new RuntimeException(e);
                 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/PartImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/PartImpl.java
@@ -62,8 +62,15 @@ public class PartImpl implements Part {
         if (formValue.isFileItem()) {
             return formValue.getFileItem().getInputStream();
         } else {
-            String requestedCharset = servletRequest.getCharacterEncoding();
-            String charset = requestedCharset != null ? requestedCharset : servletContext.getDeployment().getDefaultRequestCharset().name();
+            String charset;
+            if (formValue.getCharset() != null) {
+                charset = formValue.getCharset();
+            } else if (servletRequest.getCharacterEncoding() != null) {
+                charset = servletRequest.getCharacterEncoding();
+            } else {
+                charset = servletContext.getDeployment().getDefaultRequestCharset().name();
+            }
+
             return new ByteArrayInputStream(formValue.getValue().getBytes(charset));
         }
     }
@@ -88,6 +95,8 @@ public class PartImpl implements Part {
         try {
             if (formValue.isFileItem()) {
                 return formValue.getFileItem().getFileSize();
+            } else if (formValue.getCharset() != null) {
+                return formValue.getValue().getBytes(formValue.getCharset()).length;
             } else {
                 return formValue.getValue().length();
             }

--- a/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartServlet.java
@@ -41,6 +41,8 @@ public class MultiPartServlet extends HttpServlet {
     protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         try {
             Collection<Part> parts = req.getParts();
+            resp.setContentType("text/plain; charset=UTF-8");
+            resp.setCharacterEncoding("UTF-8");
             PrintWriter writer = resp.getWriter();
             writer.println("PARAMS:");
             writer.println("parameter count: " + req.getParameterMap().size());


### PR DESCRIPTION
…rt parsing and made available in FormData. The charset is then used in getSize() and getInputStream() to get the correct bytes for the encoded part.

Jira: https://issues.redhat.com/browse/UNDERTOW-1783