### PR TITLE
[UNDERTOW-1703] Checking isSymbolicLink should be in doPrivileged block

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/PathResourceManager.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/PathResourceManager.java
@@ -306,7 +306,7 @@ public class PathResourceManager implements ResourceManager  {
         int rootCount = root.getNameCount();
         Path f = file;
         for (int i = nameCount - 1; i>=0; i--) {
-            if (Files.isSymbolicLink(f)) {
+            if (SecurityActions.isSymbolicLink(f)) {
                 return new SymlinkResult(i+1 > rootCount, f);
             }
             f = f.getParent();

--- a/core/src/main/java/io/undertow/server/handlers/resource/SecurityActions.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/SecurityActions.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.server.handlers.resource;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+class SecurityActions {
+
+    static Boolean isSymbolicLink(Path file) {
+        if (System.getSecurityManager() == null) {
+            return Files.isSymbolicLink(file);
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                @Override
+                public Boolean run() {
+                    return Files.isSymbolicLink(file);
+                }
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1703

This is the PR to `2.0.x` branch, cherry-picked from https://github.com/undertow-io/undertow/pull/882