### PR TITLE
[UNDERTOW-1710] Update the Netty version to 4.1.50.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <version.com.h2database>1.4.200</version.com.h2database>
         <version.easymock>4.2</version.easymock>
         <version.junit>4.13</version.junit>
-        <version.netty>4.1.48.Final</version.netty>
+        <version.netty>4.1.50.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>
         <version.org.jboss.classfilewriter>1.2.4.Final</version.org.jboss.classfilewriter>


### PR DESCRIPTION
Update the Netty version to [4.1.50.Final](https://repo1.maven.org/maven2/io/netty/netty-all/4.1.50.Final/)
Jira: https://issues.redhat.com/browse/UNDERTOW-1710