### PR TITLE
[UNDERTOW-1732] Verify if we have a SecurityContext before making use of it.

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
@@ -229,4 +229,7 @@ public interface UndertowServletMessages {
 
     @Message(id = 10061, value = "Invalid method for push request %s")
     IllegalArgumentException invalidMethodForPushRequest(String method);
+
+    @Message(id = 10062, value = "No SecurityContext available")
+    ServletException noSecurityContextAvailable();
 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -318,7 +318,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
             return false;
         }
         SecurityContext sc = exchange.getSecurityContext();
-        Account account = sc.getAuthenticatedAccount();
+        Account account = sc != null ? sc.getAuthenticatedAccount() : null;
         if (account == null) {
             return false;
         }
@@ -458,6 +458,10 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
         }
 
         SecurityContext sc = exchange.getSecurityContext();
+        if (sc == null) {
+            throw UndertowServletMessages.MESSAGES.noSecurityContextAvailable();
+        }
+
         sc.setAuthenticationRequired();
         // TODO: this will set the status code and headers without going through any potential
         // wrappers, is this a problem?
@@ -482,7 +486,9 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
             throw UndertowServletMessages.MESSAGES.loginFailed();
         }
         SecurityContext sc = exchange.getSecurityContext();
-        if (sc.isAuthenticated()) {
+        if (sc == null) {
+            throw UndertowServletMessages.MESSAGES.noSecurityContextAvailable();
+        } else if (sc.isAuthenticated()) {
             throw UndertowServletMessages.MESSAGES.userAlreadyLoggedIn();
         }
         boolean login = false;
@@ -502,6 +508,9 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
     @Override
     public void logout() throws ServletException {
         SecurityContext sc = exchange.getSecurityContext();
+        if (sc == null) {
+            throw UndertowServletMessages.MESSAGES.noSecurityContextAvailable();
+        }
         sc.logout();
         if(servletContext.getDeployment().getDeploymentInfo().isInvalidateSessionOnLogout()) {
             HttpSession session = getSession(false);


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-1732

I did consider if some of these methods should silently complete if no SecurityContext is available but up until this point these methods would have resulted in a NullPointerException so I think we are safe to convert to a ServletException for now.