### PR TITLE
UNDERTOW-1746 - Max and Min content size predicates are implemented backwards

### DIFF
--- a/core/src/main/java/io/undertow/predicate/MinContentSizePredicate.java
+++ b/core/src/main/java/io/undertow/predicate/MinContentSizePredicate.java
@@ -29,8 +29,11 @@ import io.undertow.util.Headers;
  * Predicate that returns true if the Content-Size of a request is below a
  * given value.
  *
+ * Use {@link RequestSmallerThanPredicate} instead.
+ *
  * @author Stuart Douglas
  */
+@Deprecated
 public class MinContentSizePredicate implements Predicate {
 
     private final long minSize;

--- a/core/src/main/java/io/undertow/predicate/Predicates.java
+++ b/core/src/main/java/io/undertow/predicate/Predicates.java
@@ -119,8 +119,9 @@ public class Predicates {
      * Predicate that returns true if the Content-Size of a request is above a
      * given value.
      *
-     * @author Stuart Douglas
+     * Use {@link #requestLargerThan(long)} instead.
      */
+    @Deprecated
     public static Predicate maxContentSize(final long size) {
         return new MaxContentSizePredicate(size);
     }
@@ -128,9 +129,29 @@ public class Predicates {
     /**
      * Predicate that returns true if the Content-Size of a request is below a
      * given value.
+     *
+     * Use {@link #requestSmallerThan(long)} instead.
      */
+    @Deprecated
     public static Predicate minContentSize(final long size) {
         return new MinContentSizePredicate(size);
+    }
+
+
+    /**
+     * Predicate that returns true if the Content-Size of a request is smaller than a
+     * given size.
+     */
+    public static Predicate requestSmallerThan(final long size) {
+        return new RequestSmallerThanPredicate(size);
+    }
+
+    /**
+     * Predicate that returns true if the Content-Size of a request is larger than a
+     * given size.
+     */
+    public static Predicate requestLargerThan(final long size) {
+        return new RequestLargerThanPredicate(size);
     }
 
     /**

--- a/core/src/main/java/io/undertow/predicate/RequestLargerThanPredicate.java
+++ b/core/src/main/java/io/undertow/predicate/RequestLargerThanPredicate.java
@@ -26,57 +26,54 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 
 /**
- * Predicate that returns true if the Content-Size of a request is above a
- * given value.
+ * Predicate that returns true if the Content-Size of a request is larger than a
+ * given size.
  *
- * Use {@link RequestLargerThanPredicate} instead.
- *
- * @author Stuart Douglas
+ * @author Brad Wood
  */
-@Deprecated
-public class MaxContentSizePredicate implements Predicate {
+public class RequestLargerThanPredicate implements Predicate {
 
-    private final long maxSize;
+    private final long size;
 
-    MaxContentSizePredicate(final long maxSize) {
-        this.maxSize = maxSize;
+    RequestLargerThanPredicate(final long size) {
+        this.size = size;
     }
 
     @Override
-    public boolean resolve(final HttpServerExchange value) {
-        final String length = value.getResponseHeaders().getFirst(Headers.CONTENT_LENGTH);
+    public boolean resolve(final HttpServerExchange exchange) {
+        final String length = exchange.getResponseHeaders().getFirst(Headers.CONTENT_LENGTH);
         if (length == null) {
             return false;
         }
-        return Long.parseLong(length) > maxSize;
+        return Long.parseLong(length) > size;
     }
 
     public static class Builder implements PredicateBuilder {
 
         @Override
         public String name() {
-            return "max-content-size";
+            return "request-larger-than";
         }
 
         @Override
         public Map<String, Class<?>> parameters() {
-            return Collections.<String, Class<?>>singletonMap("value", Long.class);
+            return Collections.<String, Class<?>>singletonMap("size", Long.class);
         }
 
         @Override
         public Set<String> requiredParameters() {
-            return Collections.singleton("value");
+            return Collections.singleton("size");
         }
 
         @Override
         public String defaultParameter() {
-            return "value";
+            return "size";
         }
 
         @Override
         public Predicate build(final Map<String, Object> config) {
-            Long max = (Long) config.get("value");
-            return new MaxContentSizePredicate(max);
+            Long size = (Long) config.get("size");
+            return new RequestLargerThanPredicate(size);
         }
     }
 }

--- a/core/src/main/java/io/undertow/predicate/RequestSmallerThanPredicate.java
+++ b/core/src/main/java/io/undertow/predicate/RequestSmallerThanPredicate.java
@@ -26,57 +26,54 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 
 /**
- * Predicate that returns true if the Content-Size of a request is above a
- * given value.
+ * Predicate that returns true if the Content-Size of a request is smaller than a
+ * given size.
  *
- * Use {@link RequestLargerThanPredicate} instead.
- *
- * @author Stuart Douglas
+ * @author Brad Wood
  */
-@Deprecated
-public class MaxContentSizePredicate implements Predicate {
+public class RequestSmallerThanPredicate implements Predicate {
 
-    private final long maxSize;
+    private final long size;
 
-    MaxContentSizePredicate(final long maxSize) {
-        this.maxSize = maxSize;
+    RequestSmallerThanPredicate(final long size) {
+        this.size = size;
     }
 
     @Override
-    public boolean resolve(final HttpServerExchange value) {
-        final String length = value.getResponseHeaders().getFirst(Headers.CONTENT_LENGTH);
+    public boolean resolve(final HttpServerExchange exchange) {
+        final String length = exchange.getResponseHeaders().getFirst(Headers.CONTENT_LENGTH);
         if (length == null) {
             return false;
         }
-        return Long.parseLong(length) > maxSize;
+        return Long.parseLong(length) < size;
     }
 
     public static class Builder implements PredicateBuilder {
 
         @Override
         public String name() {
-            return "max-content-size";
+            return "request-smaller-than";
         }
 
         @Override
         public Map<String, Class<?>> parameters() {
-            return Collections.<String, Class<?>>singletonMap("value", Long.class);
+            return Collections.<String, Class<?>>singletonMap("size", Long.class);
         }
 
         @Override
         public Set<String> requiredParameters() {
-            return Collections.singleton("value");
+            return Collections.singleton("size");
         }
 
         @Override
         public String defaultParameter() {
-            return "value";
+            return "size";
         }
 
         @Override
         public Predicate build(final Map<String, Object> config) {
-            Long max = (Long) config.get("value");
-            return new MaxContentSizePredicate(max);
+            Long size = (Long) config.get("size");
+            return new RequestSmallerThanPredicate(size);
         }
     }
 }

--- a/core/src/main/resources/META-INF/services/io.undertow.predicate.PredicateBuilder
+++ b/core/src/main/resources/META-INF/services/io.undertow.predicate.PredicateBuilder
@@ -12,3 +12,5 @@ io.undertow.predicate.MaxContentSizePredicate$Builder
 io.undertow.predicate.MinContentSizePredicate$Builder
 io.undertow.predicate.SecurePredicate$Builder
 io.undertow.predicate.IdempotentPredicate$Builder
+io.undertow.predicate.RequestLargerThanPredicate$Builder
+io.undertow.predicate.RequestSmallerThanPredicate$Builder


### PR DESCRIPTION
The MinContentSizePredicate and MaxContentSizePredicate predicates from are named/implemented backwards.  In order to avoid a breaking change, deprecate these, and replace them with 'request-larger-than' and 'request-smaller-than' to make it clearer exactly what is being tested 