### PR TITLE
UNDERTOW-1747 - Provide a mechanism for a predicate in return a servlet error page

### DIFF
--- a/core/src/main/java/io/undertow/Handlers.java
+++ b/core/src/main/java/io/undertow/Handlers.java
@@ -25,6 +25,7 @@ import io.undertow.predicate.PredicatesHandler;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.JvmRouteHandler;
 import io.undertow.server.RoutingHandler;
+import io.undertow.server.handlers.SetErrorHandler;
 import io.undertow.server.handlers.AccessControlListHandler;
 import io.undertow.server.handlers.LearningPushHandler;
 import io.undertow.server.handlers.DateHandler;
@@ -560,6 +561,18 @@ public class Handlers {
      */
     public static LearningPushHandler learningPushHandler(int maxEntries, int maxAge, HttpHandler next) {
         return new LearningPushHandler(maxEntries, maxAge, next);
+    }
+
+    /**
+     * A handler that sets response code but continues the exchange so the servlet's
+     * error page can be returned.
+     *
+     * @param responseCode The response code to set
+     * @param next The next handler
+     * @return A Set Error handler
+     */
+    public static SetErrorHandler setErrorHandler(int responseCode, HttpHandler next) {
+        return new SetErrorHandler(next, responseCode);
     }
 
     /**

--- a/core/src/main/java/io/undertow/server/handlers/SetErrorHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SetErrorHandler.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.builder.HandlerBuilder;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A handler that sets response code but continues the exchange so the servlet's
+ * error page can be returned.
+ *
+ * @author Brad Wood
+ */
+public class SetErrorHandler implements HttpHandler {
+
+    private final int responseCode;
+    private final HttpHandler next;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param responseCode the response code to set
+     */
+    public  SetErrorHandler(HttpHandler next, final int responseCode) {
+        this.next = next;
+        this.responseCode = responseCode;
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        exchange.setStatusCode(responseCode);
+        next.handleRequest(exchange);
+    }
+
+    @Override
+    public String toString() {
+        return "set-error( " + responseCode + " )";
+    }
+
+
+    public static class Builder implements HandlerBuilder {
+
+        @Override
+        public String name() {
+            return "set-error";
+        }
+
+        @Override
+        public Map<String, Class<?>> parameters() {
+            Map<String, Class<?>> params = new HashMap<>();
+            params.put("response-code", Integer.class);
+            return params;
+        }
+
+        @Override
+        public Set<String> requiredParameters() {
+            final Set<String> req = new HashSet<>();
+            req.add("response-code");
+            return req;
+        }
+
+        @Override
+        public String defaultParameter() {
+            return "response-code";
+        }
+
+        @Override
+        public HandlerWrapper build(Map<String, Object> config) {
+            return new Wrapper((Integer) config.get("response-code"));
+        }
+
+    }
+
+    private static class Wrapper implements HandlerWrapper {
+
+        private final Integer responseCode;
+
+        private Wrapper(Integer responseCode) {
+            this.responseCode = responseCode;
+        }
+
+        @Override
+        public HttpHandler wrap(HttpHandler handler) {
+            return new  SetErrorHandler(handler, responseCode);
+        }
+    }
+
+}

--- a/core/src/main/resources/META-INF/services/io.undertow.server.handlers.builder.HandlerBuilder
+++ b/core/src/main/resources/META-INF/services/io.undertow.server.handlers.builder.HandlerBuilder
@@ -40,3 +40,4 @@ io.undertow.server.handlers.SecureCookieHandler$Builder
 io.undertow.server.handlers.ForwardedHandler$Builder
 io.undertow.server.handlers.HttpContinueAcceptingHandler$Builder
 io.undertow.server.handlers.form.EagerFormParsingHandler$Builder
+io.undertow.server.handlers.SetErrorHandler$Builder

--- a/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/DeploymentManagerImpl.java
@@ -72,6 +72,7 @@ import io.undertow.servlet.api.ThreadSetupHandler;
 import io.undertow.servlet.api.WebResourceCollection;
 import io.undertow.servlet.handlers.CrawlerSessionManagerHandler;
 import io.undertow.servlet.handlers.RedirectDirHandler;
+import io.undertow.servlet.handlers.SendErrorPageHandler;
 import io.undertow.servlet.handlers.ServletDispatchingHandler;
 import io.undertow.servlet.handlers.ServletHandler;
 import io.undertow.servlet.handlers.ServletInitialHandler;
@@ -225,6 +226,7 @@ public class DeploymentManagerImpl implements DeploymentManager {
                         wrappedHandlers = new PredicateHandler(DispatcherTypePredicate.REQUEST, securityHandler, wrappedHandlers);
                     }
                     HttpHandler outerHandlers = wrapHandlers(wrappedHandlers, deploymentInfo.getOuterHandlerChainWrappers());
+                    outerHandlers = new SendErrorPageHandler(outerHandlers);
                     wrappedHandlers = new PredicateHandler(DispatcherTypePredicate.REQUEST, outerHandlers, wrappedHandlers);
                     wrappedHandlers = handleDevelopmentModePersistentSessions(wrappedHandlers, deploymentInfo, deployment.getSessionManager(), servletContext);
 

--- a/servlet/src/main/java/io/undertow/servlet/handlers/SendErrorPageHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/SendErrorPageHandler.java
@@ -46,7 +46,7 @@ public class SendErrorPageHandler implements HttpHandler {
         ServletRequestContext src = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
 
         // If the servlet is available and the status code has been set to an error, return the error page
-        if( src != null && exchange.getStatusCode() > 399 && exchange.getResponseContentLength() == -1 ) {
+        if( src != null && exchange.getStatusCode() > 399 && !exchange.isResponseStarted() ) {
             ((HttpServletResponse)src.getServletResponse()).sendError(exchange.getStatusCode());
         } else {
             next.handleRequest(exchange);

--- a/servlet/src/main/java/io/undertow/servlet/handlers/SendErrorPageHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/SendErrorPageHandler.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.handlers;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A handler that sends the servlet's error page if the status code is greater than 399
+ *
+ * @author Brad Wood
+ */
+public class SendErrorPageHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    /**
+     * Construct a new instance.
+     *
+     * @param next The next handler to call if there is no error response
+     */
+    public SendErrorPageHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(final HttpServerExchange exchange) throws Exception {
+        ServletRequestContext src = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+
+        // If the servlet is available and the status code has been set to an error, return the error page
+        if( src != null && exchange.getStatusCode() > 399 && exchange.getResponseContentLength() == -1 ) {
+            ((HttpServletResponse)src.getServletResponse()).sendError(exchange.getStatusCode());
+        } else {
+            next.handleRequest(exchange);
+        }
+    }
+
+}


### PR DESCRIPTION
Using the predicate language in Undertow, there is no way to return the error pages configured in the servlet from the handler chain that runs first in the XNIO worker thread.  For example, if the response-code() handler is used, the exchange is simply ended and no response body is sent which is not a very useful behavior.

A solution provided by Stuart on the mailing list was to set the response code but not end the exchange.  Then configure the servlet handler to check for a status code above 399 and call the servlet sendError() routine.  