### PR TITLE
[UNDERTOW-1682] Use the normalized path when comparing the resource p…

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/file/PathResourceManagerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/file/PathResourceManagerTestCase.java
@@ -154,7 +154,7 @@ public class PathResourceManagerTestCase {
                 Assert.assertTrue(dir.isDirectory());
                 List<Resource> list = dir.list();
                 Assert.assertEquals(1, list.size());
-                Assert.assertEquals(resource.getFilePath(), list.get(0).getFilePath());
+                Assert.assertEquals(resource.getFilePath().normalize(), list.get(0).getFilePath().normalize());
 
                 Resource outside = resourceManager.getResource("../root_resource.txt");
                 Assert.assertNull(outside);


### PR DESCRIPTION
…aths.

https://issues.redhat.com/browse/UNDERTOW-1682

@fl4via If we need this fix in other branches just let me know and I'll open up PR's.