### PR TITLE
[UNDERTOW-1755] - remove doubled definitions of some variables

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -37,7 +37,6 @@ import io.undertow.util.ConduitFactory;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
-import io.undertow.util.HttpString;
 import io.undertow.util.ImmediatePooledByteBuffer;
 import io.undertow.util.Methods;
 import io.undertow.util.ParameterLimitException;
@@ -57,6 +56,11 @@ import java.util.function.Supplier;
 
 import javax.net.ssl.SSLSession;
 
+import static io.undertow.protocols.http2.Http2Channel.AUTHORITY;
+import static io.undertow.protocols.http2.Http2Channel.METHOD;
+import static io.undertow.protocols.http2.Http2Channel.PATH;
+import static io.undertow.protocols.http2.Http2Channel.SCHEME;
+
 /**
  * The recieve listener for a Http2 connection.
  * <p>
@@ -65,11 +69,6 @@ import javax.net.ssl.SSLSession;
  * @author Stuart Douglas
  */
 public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
-
-    static final HttpString METHOD = new HttpString(":method");
-    static final HttpString PATH = new HttpString(":path");
-    static final HttpString SCHEME = new HttpString(":scheme");
-    static final HttpString AUTHORITY = new HttpString(":authority");
 
     private final HttpHandler rootHandler;
     private final long maxEntitySize;

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -73,6 +73,11 @@ import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
 import io.undertow.util.StatusCodes;
 
+import static io.undertow.protocols.http2.Http2Channel.AUTHORITY;
+import static io.undertow.protocols.http2.Http2Channel.METHOD;
+import static io.undertow.protocols.http2.Http2Channel.PATH;
+import static io.undertow.protocols.http2.Http2Channel.SCHEME;
+
 /**
  * A server connection. There is one connection per request
  *
@@ -411,10 +416,10 @@ public class Http2ServerConnection extends ServerConnection {
     public boolean pushResource(String path, HttpString method, HeaderMap requestHeaders, final HttpHandler handler) {
         HeaderMap responseHeaders = new HeaderMap();
         try {
-            requestHeaders.put(Http2ReceiveListener.METHOD, method.toString());
-            requestHeaders.put(Http2ReceiveListener.PATH, path.toString());
-            requestHeaders.put(Http2ReceiveListener.AUTHORITY, exchange.getHostAndPort());
-            requestHeaders.put(Http2ReceiveListener.SCHEME, exchange.getRequestScheme());
+            requestHeaders.put(METHOD, method.toString());
+            requestHeaders.put(PATH, path.toString());
+            requestHeaders.put(AUTHORITY, exchange.getHostAndPort());
+            requestHeaders.put(SCHEME, exchange.getRequestScheme());
 
             Http2HeadersStreamSinkChannel sink = channel.sendPushPromise(responseChannel.getStreamId(), requestHeaders, responseHeaders);
             Http2ServerConnection newConnection = new Http2ServerConnection(channel, sink, getUndertowOptions(), getBufferSize(), rootHandler);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1755
2.0.x PR: https://github.com/undertow-io/undertow/pull/914