### PR TITLE
UNDERTOW-1770 HttpString uses obsolete String Constructor

### DIFF
--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -343,7 +343,7 @@ public final class HttpString implements Comparable<HttpString>, Serializable {
     @SuppressWarnings("deprecation")
     public String toString() {
         if (string == null) {
-            string = new String(bytes, 0);
+            string = new String(bytes, java.nio.charset.Charset.forName("ISO-8859-1"));
         }
         return string;
     }

--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -343,7 +343,7 @@ public final class HttpString implements Comparable<HttpString>, Serializable {
     @SuppressWarnings("deprecation")
     public String toString() {
         if (string == null) {
-            string = new String(bytes, java.nio.charset.Charset.forName("ISO-8859-1"));
+            string = new String(bytes, java.nio.charset.StandardCharsets.US_ASCII);
         }
         return string;
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-1770
Automatically updated
https://j2eeguys.com/updater

Signed-off-by: Steve Davidson <steve@j2eeguys.com>