### PR TITLE
[UNDERTOW-1771] APIs deprecated in JDK 9+ are in use

### DIFF
--- a/core/src/main/java/io/undertow/attribute/SslClientCertAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/SslClientCertAttribute.java
@@ -18,14 +18,15 @@
 
 package io.undertow.attribute;
 
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.RenegotiationRequiredException;
 import io.undertow.server.SSLSessionInfo;
 import io.undertow.util.Certificates;
-
-import javax.net.ssl.SSLPeerUnverifiedException;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.Certificate;
 
 /**
  * @author Stuart Douglas

--- a/core/src/main/java/io/undertow/server/BasicSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/BasicSSLSessionInfo.java
@@ -155,6 +155,7 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
         return peerCertificate;
     }
 
+    @Deprecated
     @Override
     public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
         if (certificate == null) {

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -99,6 +99,7 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
     }
 
     @Override
+    @Deprecated(since="2.2.3", forRemoval=false)
     public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException, RenegotiationRequiredException {
         if (unverified != null) {
             throw unverified;
@@ -115,7 +116,7 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
                   renegotiationRequiredException = RENEGOTIATION_REQUIRED_EXCEPTION;
                   throw renegotiationRequiredException;
               }
-            } catch (IOException e1) {
+            } catch (IOException ioe) {
             	// ignore, will not actually happen
             }
             unverified = PEER_UNVERIFIED_EXCEPTION;

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -18,26 +18,27 @@
 
 package io.undertow.server;
 
-import io.undertow.UndertowMessages;
-import io.undertow.UndertowOptions;
-import io.undertow.server.protocol.http.HttpServerConnection;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.cert.Certificate;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import javax.security.cert.X509Certificate;
 
 import org.xnio.ChannelListener;
 import org.xnio.IoUtils;
 import org.xnio.Options;
-import io.undertow.connector.PooledByteBuffer;
 import org.xnio.SslClientAuthMode;
 import org.xnio.channels.Channels;
 import org.xnio.channels.SslChannel;
 import org.xnio.channels.StreamSourceChannel;
 
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.security.cert.Certificate;
-import java.util.concurrent.TimeUnit;
+import io.undertow.UndertowMessages;
+import io.undertow.UndertowOptions;
+import io.undertow.connector.PooledByteBuffer;
+import io.undertow.server.protocol.http.HttpServerConnection;
 
 /**
  * SSL session information that is read directly from the SSL session of the
@@ -108,14 +109,14 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
         try {
             return channel.getSslSession().getPeerCertificateChain();
         } catch (SSLPeerUnverifiedException e) {
-            try {
-                SslClientAuthMode sslClientAuthMode = channel.getOption(Options.SSL_CLIENT_AUTH_MODE);
-                if (sslClientAuthMode == SslClientAuthMode.NOT_REQUESTED) {
-                    renegotiationRequiredException = RENEGOTIATION_REQUIRED_EXCEPTION;
-                    throw renegotiationRequiredException;
-                }
+          try {
+              SslClientAuthMode sslClientAuthMode = channel.getOption(Options.SSL_CLIENT_AUTH_MODE);
+              if (sslClientAuthMode == SslClientAuthMode.NOT_REQUESTED) {
+                  renegotiationRequiredException = RENEGOTIATION_REQUIRED_EXCEPTION;
+                  throw renegotiationRequiredException;
+              }
             } catch (IOException e1) {
-                // ignore, will not actually happen
+            	// ignore, will not actually happen
             }
             unverified = PEER_UNVERIFIED_EXCEPTION;
             throw unverified;

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -116,9 +116,9 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
                   renegotiationRequiredException = RENEGOTIATION_REQUIRED_EXCEPTION;
                   throw renegotiationRequiredException;
               }
-            } catch (IOException ioe) {
-            	// ignore, will not actually happen
-            }
+          } catch (IOException ioe) {
+              // ignore, will not actually happen
+          }
             unverified = PEER_UNVERIFIED_EXCEPTION;
             throw unverified;
         }

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -99,10 +99,10 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
 
     @Override
     public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException, RenegotiationRequiredException {
-        if(unverified != null) {
+        if (unverified != null) {
             throw unverified;
         }
-        if(renegotiationRequiredException != null) {
+        if (renegotiationRequiredException != null) {
             throw renegotiationRequiredException;
         }
         try {
@@ -115,13 +115,12 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
                     throw renegotiationRequiredException;
                 }
             } catch (IOException e1) {
-                //ignore, will not actually happen
+                // ignore, will not actually happen
             }
             unverified = PEER_UNVERIFIED_EXCEPTION;
             throw unverified;
         }
     }
-
 
     @Override
     public void renegotiate(HttpServerExchange exchange, SslClientAuthMode sslClientAuthMode) throws IOException {
@@ -144,6 +143,8 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
         return channel.getSslSession();
     }
 
+    //Suppress incorrect resource leak warning.
+    @SuppressWarnings("resource")
     public void renegotiateBufferRequest(HttpServerExchange exchange, SslClientAuthMode newAuthMode) throws IOException {
         int maxSize = exchange.getConnection().getUndertowOptions().get(UndertowOptions.MAX_BUFFERED_REQUEST_SIZE, UndertowOptions.DEFAULT_MAX_BUFFERED_REQUEST_SIZE);
         if (maxSize <= 0) {
@@ -178,6 +179,8 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
                         overflow = true;
                         break;
                     } else {
+                        //Not a leak here as old buffer has been captured in array and will
+                        //be closed if/when needed.
                         pooled = exchange.getConnection().getByteBufferPool().allocate();
                         poolArray[usedBuffers++] = pooled;
                     }

--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -233,6 +233,15 @@ public class DefaultByteBufferPool implements ByteBufferPool {
         }
     }
 
+    @Override
+    protected void finalize() throws Throwable {
+        try {
+            close();
+        } finally {
+            super.finalize();
+        }
+    }
+
     private static class DefaultPooledBuffer implements PooledByteBuffer {
 
         private final DefaultByteBufferPool pool;

--- a/core/src/main/java/io/undertow/server/handlers/SSLHeaderHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SSLHeaderHandler.java
@@ -18,6 +18,15 @@
 
 package io.undertow.server.handlers;
 
+import static io.undertow.util.Headers.SSL_CIPHER;
+import static io.undertow.util.Headers.SSL_CIPHER_USEKEYSIZE;
+import static io.undertow.util.Headers.SSL_CLIENT_CERT;
+import static io.undertow.util.Headers.SSL_SESSION_ID;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
 import io.undertow.UndertowLogger;
 import io.undertow.server.BasicSSLSessionInfo;
 import io.undertow.server.ExchangeCompletionListener;
@@ -28,15 +37,6 @@ import io.undertow.server.SSLSessionInfo;
 import io.undertow.server.handlers.builder.HandlerBuilder;
 import io.undertow.util.Certificates;
 import io.undertow.util.HeaderMap;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-
-import static io.undertow.util.Headers.SSL_CIPHER;
-import static io.undertow.util.Headers.SSL_CIPHER_USEKEYSIZE;
-import static io.undertow.util.Headers.SSL_CLIENT_CERT;
-import static io.undertow.util.Headers.SSL_SESSION_ID;
 
 /**
  * Handler that sets SSL information on the connection based on the following headers:

--- a/core/src/main/java/io/undertow/server/handlers/SSLHeaderHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/SSLHeaderHandler.java
@@ -29,16 +29,14 @@ import io.undertow.server.handlers.builder.HandlerBuilder;
 import io.undertow.util.Certificates;
 import io.undertow.util.HeaderMap;
 
-import javax.security.cert.CertificateException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import static io.undertow.util.Headers.SSL_CIPHER;
 import static io.undertow.util.Headers.SSL_CIPHER_USEKEYSIZE;
 import static io.undertow.util.Headers.SSL_CLIENT_CERT;
 import static io.undertow.util.Headers.SSL_SESSION_ID;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Handler that sets SSL information on the connection based on the following headers:
@@ -114,7 +112,7 @@ public class SSLHeaderHandler implements HttpHandler {
                 exchange.setRequestScheme(HTTPS);
                 exchange.getConnection().setSslSessionInfo(info);
                 exchange.addExchangeCompleteListener(CLEAR_SSL_LISTENER);
-            } catch (java.security.cert.CertificateException | CertificateException e) {
+            } catch (java.security.cert.CertificateException e) {
                 UndertowLogger.REQUEST_LOGGER.debugf(e, "Could not create certificate from header %s", clientCert);
             }
         }

--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
@@ -25,14 +25,15 @@ import java.net.SocketAddress;
 import java.nio.channels.Channel;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import java.security.cert.CertificateEncodingException;
+import java.util.stream.Collectors;
 
-import io.undertow.UndertowMessages;
-import io.undertow.server.handlers.ResponseCodeHandler;
+import javax.net.ssl.SSLPeerUnverifiedException;
+
 import org.jboss.logging.Logger;
 import org.xnio.ChannelExceptionHandler;
 import org.xnio.ChannelListener;
@@ -41,7 +42,9 @@ import org.xnio.IoUtils;
 import org.xnio.StreamConnection;
 import org.xnio.XnioExecutor;
 import org.xnio.channels.StreamSinkChannel;
+
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
 import io.undertow.attribute.ExchangeAttribute;
 import io.undertow.attribute.ExchangeAttributes;
 import io.undertow.client.ClientCallback;
@@ -62,6 +65,7 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.server.HttpUpgradeListener;
 import io.undertow.server.RenegotiationRequiredException;
 import io.undertow.server.SSLSessionInfo;
+import io.undertow.server.handlers.ResponseCodeHandler;
 import io.undertow.server.protocol.http.HttpAttachments;
 import io.undertow.server.protocol.http.HttpContinue;
 import io.undertow.util.Attachable;
@@ -77,8 +81,6 @@ import io.undertow.util.SameThreadExecutor;
 import io.undertow.util.StatusCodes;
 import io.undertow.util.Transfer;
 import io.undertow.util.WorkerUtils;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * An HTTP handler which proxies content to a remote server.
@@ -891,7 +893,6 @@ public final class ProxyHandler implements HttpHandler {
         private Predicate idempotentRequestPredicate = IdempotentPredicate.INSTANCE;
 
         Builder() {}
-
 
         public ProxyClient getProxyClient() {
             return proxyClient;

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
@@ -81,11 +81,12 @@ class Http2SslSessionInfo implements SSLSessionInfo {
                     throw new RenegotiationRequiredException();
                 }
             } catch (IOException e1) {
-                //ignore, will not actually happen
+              // ignore, will not actually happen
             }
             throw e;
         }
     }
+
     @Override
     public void renegotiate(HttpServerExchange exchange, SslClientAuthMode sslClientAuthMode) throws IOException {
         throw UndertowMessages.MESSAGES.renegotiationNotSupported();

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
@@ -71,7 +71,8 @@ class Http2SslSessionInfo implements SSLSessionInfo {
     }
 
     @Override
-    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException, RenegotiationRequiredException {
+    public X509Certificate[] getPeerCertificateChain()
+        throws SSLPeerUnverifiedException, RenegotiationRequiredException {
         try {
             return channel.getSslSession().getPeerCertificateChain();
         } catch (SSLPeerUnverifiedException e) {

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -56,6 +56,5 @@ public class Certificates {
     }
     
     private Certificates() {
-
     }
 }

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -54,7 +54,7 @@ public class Certificates {
         builder.append(END_CERT);
         return builder.toString();
     }
-    
+
     private Certificates() {
     }
 }

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -28,6 +28,7 @@ public class Certificates {
 
     public static final String END_CERT = "-----END CERTIFICATE-----";
 
+    @Deprecated (since = "2.3.0", forRemoval=true)
     public static String toPem(final javax.security.cert.X509Certificate certificate)
             throws javax.security.cert.CertificateEncodingException {
         return toPem(certificate.getEncoded());

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -34,6 +34,12 @@ public class Certificates {
         return toPem(certificate.getEncoded());
     }
 
+    /**
+     * Converts a certificate to PEM format.
+     * @param certificate the Certificate to recode
+     * @return The Certificate in PEM format.
+     * @throws java.security.cert.CertificateEncodingException thrown if an encoding error occurs.
+     */
     public static String toPem(final java.security.cert.Certificate certificate)
             throws java.security.cert.CertificateEncodingException {
         return toPem(certificate.getEncoded());
@@ -48,7 +54,7 @@ public class Certificates {
         builder.append(END_CERT);
         return builder.toString();
     }
-
+    
     private Certificates() {
 
     }

--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -18,16 +18,16 @@
 
 package io.undertow.util;
 
+import static java.lang.Integer.signum;
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.copyOfRange;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-
-import static java.lang.Integer.signum;
-import static java.lang.System.arraycopy;
-import static java.util.Arrays.copyOfRange;
 
 import io.undertow.UndertowMessages;
 

--- a/core/src/main/java/io/undertow/util/HttpString.java
+++ b/core/src/main/java/io/undertow/util/HttpString.java
@@ -344,7 +344,6 @@ public final class HttpString implements Comparable<HttpString>, Serializable {
      * @return the string
      */
     @Override
-    @SuppressWarnings("deprecation")
     public String toString() {
         if (string == null) {
             string = new String(bytes, java.nio.charset.StandardCharsets.US_ASCII);

--- a/servlet/src/main/java/io/undertow/servlet/handlers/security/SSLInformationAssociationHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/security/SSLInformationAssociationHandler.java
@@ -20,13 +20,13 @@ package io.undertow.servlet.handlers.security;
 
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import jakarta.servlet.ServletRequest;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.SSLSessionInfo;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.util.HexConverter;
+import jakarta.servlet.ServletRequest;
 
 /**
  * Handler that associates SSL metadata with request


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-1771
Updated from deprecated javax.security.cert Classes to current java.security.cert
Deprecated javax.security.cert APIs usage is limited to XNIO API Usage
Finalize methods not needed on (Auto)Closeables
super.finalize should always be called, and called last.

Signed-off-by: Steve Davidson <steve@j2eeguys.com>