### PR TITLE
UNDERTOW-1717 Return 416 Range Not Satisfiable when first-byte-pos of…

### DIFF
--- a/core/src/main/java/io/undertow/util/ByteRange.java
+++ b/core/src/main/java/io/undertow/util/ByteRange.java
@@ -157,7 +157,7 @@ public class ByteRange {
         } else if(end == -1) {
             //prefix range
             long toWrite = resourceContentLength - start;
-            if(toWrite >= 0) {
+            if (toWrite > 0) {
                 rangeLength = toWrite;
             } else {
                 //ignore the range request

--- a/core/src/test/java/io/undertow/server/handlers/RangeRequestTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/RangeRequestTestCase.java
@@ -221,6 +221,14 @@ public class RangeRequestTestCase {
             Assert.assertEquals("bytes */10", result.getFirstHeader(Headers.CONTENT_RANGE_STRING).getValue());
 
             get = new HttpGet(DefaultServer.getDefaultServerURL() + path);
+            get.addHeader(Headers.RANGE_STRING, "bytes=10-");
+            result = client.execute(get);
+            Assert.assertEquals(StatusCodes.REQUEST_RANGE_NOT_SATISFIABLE, result.getStatusLine().getStatusCode());
+            response = EntityUtils.toString(result.getEntity());
+            Assert.assertEquals("", response);
+            Assert.assertEquals("bytes */10", result.getFirstHeader(Headers.CONTENT_RANGE_STRING).getValue());
+
+            get = new HttpGet(DefaultServer.getDefaultServerURL() + path);
             get.addHeader(Headers.RANGE_STRING, "bytes=2-3");
             get.addHeader(Headers.IF_RANGE_STRING, DateUtils.toDateString(new Date(System.currentTimeMillis() + 1000)));
             result = client.execute(get);

--- a/core/src/test/java/io/undertow/util/ByteRangeTestCase.java
+++ b/core/src/test/java/io/undertow/util/ByteRangeTestCase.java
@@ -107,6 +107,17 @@ public class ByteRangeTestCase {
                 new Date(1559820153000L), "foo").getContentRange());
         Assert.assertEquals(416, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getStatusCode());
+
+        Assert.assertEquals(0, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStart());
+        Assert.assertEquals(0, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getEnd());
+        Assert.assertEquals(0, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentLength());
+        Assert.assertEquals("bytes */6", byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentRange());
+        Assert.assertEquals(416, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStatusCode());
     }
 
     @Test
@@ -124,6 +135,17 @@ public class ByteRangeTestCase {
                 new Date(1559820153000L), "foo").getContentRange());
         Assert.assertEquals(416, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getStatusCode());
+
+        Assert.assertEquals(5, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStart());
+        Assert.assertEquals(5, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getEnd());
+        Assert.assertEquals(1, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentLength());
+        Assert.assertEquals("bytes 5-5/6", byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentRange());
+        Assert.assertEquals(206, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStatusCode());
     }
 
     @Test
@@ -133,13 +155,24 @@ public class ByteRangeTestCase {
 
         Assert.assertEquals(0, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getStart());
-        Assert.assertEquals(-1, byteRange.getResponseResult(0, null,
+        Assert.assertEquals(0, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getEnd());
         Assert.assertEquals(0, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getContentLength());
-        Assert.assertEquals("bytes 0--1/0", byteRange.getResponseResult(0, null,
+        Assert.assertEquals("bytes */0", byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getContentRange());
-        Assert.assertEquals(206, byteRange.getResponseResult(0, null,
+        Assert.assertEquals(416, byteRange.getResponseResult(0, null,
+                new Date(1559820153000L), "foo").getStatusCode());
+
+        Assert.assertEquals(0, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStart());
+        Assert.assertEquals(5, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getEnd());
+        Assert.assertEquals(6, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentLength());
+        Assert.assertEquals("bytes 0-5/6", byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentRange());
+        Assert.assertEquals(206, byteRange.getResponseResult(6, null,
                 new Date(1559820153000L), "foo").getStatusCode());
     }
 
@@ -158,7 +191,6 @@ public class ByteRangeTestCase {
                 new Date(1559820153000L), "foo").getContentRange());
         Assert.assertEquals(416, byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getStatusCode());
-
 
         Assert.assertEquals(3, byteRange.getResponseResult(6, null,
                 new Date(1559820153000L), "foo").getStart());
@@ -186,6 +218,17 @@ public class ByteRangeTestCase {
         Assert.assertEquals("bytes 0--1/0", byteRange.getResponseResult(0, null,
                 new Date(1559820153000L), "foo").getContentRange());
         Assert.assertEquals(206, byteRange.getResponseResult(0, null,
+                new Date(1559820153000L), "foo").getStatusCode());
+
+        Assert.assertEquals(1, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getStart());
+        Assert.assertEquals(5, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getEnd());
+        Assert.assertEquals(5, byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentLength());
+        Assert.assertEquals("bytes 1-5/6", byteRange.getResponseResult(6, null,
+                new Date(1559820153000L), "foo").getContentRange());
+        Assert.assertEquals(206, byteRange.getResponseResult(6, null,
                 new Date(1559820153000L), "foo").getStatusCode());
     }
 


### PR DESCRIPTION
… Range request header is equal to the content-length

Jira: https://issues.redhat.com/browse/UNDERTOW-1717
Master PR: #896 