### PR TITLE
UNDERTOW-1792 ServletPrintWriter.println uses LF instead of CRLF

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
@@ -338,52 +338,52 @@ public class ServletPrintWriter {
     }
 
     public void println() {
-        print('\n');
+        print("\r\n");
     }
 
     public void println(final boolean b) {
         print(b);
-        print('\n');
+        println();
     }
 
     public void println(final char c) {
         print(c);
-        print('\n');
+        println();
     }
 
     public void println(final int i) {
         print(i);
-        print('\n');
+        println();
     }
 
     public void println(final long l) {
         print(l);
-        print('\n');
+        println();
     }
 
     public void println(final float f) {
         print(f);
-        print('\n');
+        println();
     }
 
     public void println(final double d) {
         print(d);
-        print('\n');
+        println();
     }
 
     public void println(final char[] s) {
         print(s);
-        print('\n');
+        println();
     }
 
     public void println(final String s) {
         print(s);
-        print('\n');
+        println();
     }
 
     public void println(final Object obj) {
         print(obj);
-        print('\n');
+        println();
     }
 
     public void printf(final String format, final Object... args) {

--- a/servlet/src/test/java/io/undertow/servlet/test/crosscontext/CrossContextClassLoaderTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/crosscontext/CrossContextClassLoaderTestCase.java
@@ -96,10 +96,10 @@ public class CrossContextClassLoaderTestCase {
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             final String response = HttpClientUtils.readResponse(result);
             Assert.assertEquals(
-                    "Including Servlet Class Loader: IncluderClassLoader\n" +
-                            "Including Servlet Context Path: /includer\n" +
-                            "Included Servlet Class Loader: IncludedClassLoader\n" +
-                            "Including Servlet Context Path: /included\n",
+                    "Including Servlet Class Loader: IncluderClassLoader\r\n" +
+                            "Including Servlet Context Path: /includer\r\n" +
+                            "Included Servlet Class Loader: IncludedClassLoader\r\n" +
+                            "Including Servlet Context Path: /included\r\n",
                     response);
         } finally {
             client.getConnectionManager().shutdown();

--- a/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartTestCase.java
@@ -118,22 +118,22 @@ public class MultiPartTestCase {
             HttpResponse result = client.execute(post);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             final String response = HttpClientUtils.readResponse(result);
-            Assert.assertEquals("PARAMS:\n" +
-                    "parameter count: 1\n" +
-                    "parameter name count: 1\n" +
-                    "name: formValue\n" +
-                    "filename: null\n" +
-                    "content-type: null\n" +
-                    "Content-Disposition: form-data; name=\"formValue\"\n" +
-                    "size: 7\n" +
-                    "content: myValue\n" +
-                    "name: file\n" +
-                    "filename: uploadfile.txt\n" +
-                    "content-type: application/octet-stream\n" +
-                    "Content-Disposition: form-data; name=\"file\"; filename=\"uploadfile.txt\"\n" +
-                    "Content-Type: application/octet-stream\n" +
-                    "size: 13\n" +
-                    "content: file contents\n", response);
+            Assert.assertEquals("PARAMS:\r\n" +
+                    "parameter count: 1\r\n" +
+                    "parameter name count: 1\r\n" +
+                    "name: formValue\r\n" +
+                    "filename: null\r\n" +
+                    "content-type: null\r\n" +
+                    "Content-Disposition: form-data; name=\"formValue\"\r\n" +
+                    "size: 7\r\n" +
+                    "content: myValue\r\n" +
+                    "name: file\r\n" +
+                    "filename: uploadfile.txt\r\n" +
+                    "content-type: application/octet-stream\r\n" +
+                    "Content-Disposition: form-data; name=\"file\"; filename=\"uploadfile.txt\"\r\n" +
+                    "Content-Type: application/octet-stream\r\n" +
+                    "size: 13\r\n" +
+                    "content: file contents\r\n", response);
         } finally {
             client.getConnectionManager().shutdown();
         }
@@ -155,22 +155,22 @@ public class MultiPartTestCase {
             HttpResponse result = client.execute(post);
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             final String response = HttpClientUtils.readResponse(result);
-            Assert.assertEquals("PARAMS:\n" +
-                    "parameter count: 1\n" +
-                    "parameter name count: 1\n" +
-                    "name: formValue\n" +
-                    "filename: null\n" +
-                    "content-type: null\n" +
-                    "Content-Disposition: form-data; name=\"formValue\"\n" +
-                    "size: 7\n" +
-                    "content: myValue\n" +
-                    "name: file\n" +
-                    "filename: uploadfile.txt\n" +
-                    "content-type: application/octet-stream\n" +
-                    "Content-Disposition: form-data; name=\"file\"; filename=\"uploadfile.txt\"\n" +
-                    "Content-Type: application/octet-stream\n" +
-                    "size: 13\n" +
-                    "content: file contents\n", response);
+            Assert.assertEquals("PARAMS:\r\n" +
+                    "parameter count: 1\r\n" +
+                    "parameter name count: 1\r\n" +
+                    "name: formValue\r\n" +
+                    "filename: null\r\n" +
+                    "content-type: null\r\n" +
+                    "Content-Disposition: form-data; name=\"formValue\"\r\n" +
+                    "size: 7\r\n" +
+                    "content: myValue\r\n" +
+                    "name: file\r\n" +
+                    "filename: uploadfile.txt\r\n" +
+                    "content-type: application/octet-stream\r\n" +
+                    "Content-Disposition: form-data; name=\"file\"; filename=\"uploadfile.txt\"\r\n" +
+                    "Content-Type: application/octet-stream\r\n" +
+                    "size: 13\r\n" +
+                    "content: file contents\r\n", response);
         } finally {
             client.getConnectionManager().shutdown();
         }

--- a/servlet/src/test/java/io/undertow/servlet/test/multipart/forward/MultiPartForwardTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/multipart/forward/MultiPartForwardTestCase.java
@@ -62,7 +62,7 @@ public class MultiPartForwardTestCase {
 
         String response = sendRequest("/multipart", createUrlEncodedFormPostEntity());
 
-        Assert.assertEquals("Params:\n"
+        Assert.assertEquals("Params:\r\n"
             + "foo: bar", response);
 
     }
@@ -72,7 +72,7 @@ public class MultiPartForwardTestCase {
 
         String response = sendRequest("/forward", createUrlEncodedFormPostEntity());
 
-        Assert.assertEquals("Params:\n"
+        Assert.assertEquals("Params:\r\n"
             + "foo: bar", response);
 
     }
@@ -82,7 +82,7 @@ public class MultiPartForwardTestCase {
 
         String response = sendRequest("/multipart", createMultiPartFormPostEntity());
 
-        Assert.assertEquals("Params:\n"
+        Assert.assertEquals("Params:\r\n"
             + "foo: bar", response);
 
     }
@@ -92,7 +92,7 @@ public class MultiPartForwardTestCase {
 
         String response = sendRequest("/forward", createMultiPartFormPostEntity());
 
-        Assert.assertEquals("Params:\n"
+        Assert.assertEquals("Params:\r\n"
             + "foo: bar", response);
 
     }


### PR DESCRIPTION
Upstream issue: https://issues.redhat.com/browse/UNDERTOW-1792
Upstream PR: https://github.com/undertow-io/undertow/pull/972, https://github.com/undertow-io/undertow/pull/974
Issue: https://issues.redhat.com/browse/JBEAP-20289