### PR TITLE
[UNDERTOW-1802] Improve FormEncodedDataDefinition to handle chars in configured encoding

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/FormEncodedDataDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/FormEncodedDataDefinition.java
@@ -148,9 +148,9 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
                                         addPair(builder.toString(), "");
                                         builder.setLength(0);
                                         state = 0;
-                                    } else if (n == '%' || n == '+') {
+                                    } else if (n == '%' || n == '+' || n < 0) {
                                         state = 1;
-                                        builder.append((char) n);
+                                        builder.append((char) (n & 0xFF));
                                     } else {
                                         builder.append((char) n);
                                     }
@@ -166,7 +166,7 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
                                         builder.setLength(0);
                                         state = 0;
                                     } else {
-                                        builder.append((char) n);
+                                        builder.append((char) (n & 0xFF));
                                     }
                                     break;
                                 }
@@ -175,9 +175,9 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
                                         addPair(name, builder.toString());
                                         builder.setLength(0);
                                         state = 0;
-                                    } else if (n == '%' || n == '+') {
+                                    } else if (n == '%' || n == '+' || n < 0) {
                                         state = 3;
-                                        builder.append((char) n);
+                                        builder.append((char) (n & 0xFF));
                                     } else {
                                         builder.append((char) n);
                                     }
@@ -189,7 +189,7 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
                                         builder.setLength(0);
                                         state = 0;
                                     } else {
-                                        builder.append((char) n);
+                                        builder.append((char) (n & 0xFF));
                                     }
                                     break;
                                 }

--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -204,11 +204,11 @@ public class URLUtils {
                                 bytes[pos++] = (byte) c;
                             } else {
                                 bytes[pos++] = (byte) c;
-                                if (i < numChars) {
-                                    c = s.charAt(i);
-                                }
                             }
 
+                            if (i < numChars) {
+                                c = s.charAt(i);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1802

The FormEncodedDataParser has been modified to also perform a decode if a non-ascii (n < 0) character is found. The URLUtils.decode method was already prepared to handle those bytes.

The test now uses the payload instead of the headers to return the data (because now strange chars can be returned). Finally a method that sends direct UTF-8 characters is added to include a test for this specific use-case.

PR for branch 2.0.x.

Master PR: #980 
2.1.x PR: #979 