### PR TITLE
[JBEAP-20391][JBEAP-20392][UNDERTOW-1796][UNDERTOW-1800] Default the io.undertow.protocols.alpn.jdk8 to true and change the order of preferred providers

### DIFF
--- a/core/src/main/java/io/undertow/protocols/alpn/JDK8HackAlpnProvider.java
+++ b/core/src/main/java/io/undertow/protocols/alpn/JDK8HackAlpnProvider.java
@@ -50,7 +50,7 @@ public class JDK8HackAlpnProvider implements ALPNProvider {
 
     @Override
     public int getPriority() {
-        return 200;
+        return 300;
     }
 
     @Override

--- a/core/src/main/java/io/undertow/protocols/alpn/JDK9AlpnProvider.java
+++ b/core/src/main/java/io/undertow/protocols/alpn/JDK9AlpnProvider.java
@@ -127,7 +127,7 @@ public class JDK9AlpnProvider implements ALPNProvider {
 
     @Override
     public int getPriority() {
-        return 300;
+        return 200;
     }
 
     @Override


### PR DESCRIPTION
Issue (7.3.z): https://issues.redhat.com/browse/JBEAP-20391 / https://issues.redhat.com/browse/JBEAP-20392
Upstream issue: https://issues.redhat.com/browse/UNDERTOW-1796 / https://issues.redhat.com/browse/UNDERTOW-1800
Upstream PR: https://github.com/undertow-io/undertow/pull/977