### PR TITLE
[UNDERTOW-1821] Path template matched parameters should keep order

### DIFF
--- a/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
+++ b/core/src/main/java/io/undertow/util/PathTemplateMatcher.java
@@ -21,9 +21,9 @@ package io.undertow.util;
 import io.undertow.UndertowMessages;
 
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -51,7 +51,7 @@ public class PathTemplateMatcher<T> {
 
     public PathMatchResult<T> match(final String path) {
         String normalizedPath = "".equals(path) ? "/" : path;
-        final Map<String, String> params = new HashMap<>();
+        final Map<String, String> params = new LinkedHashMap<>();
         int length = normalizedPath.length();
         final int[] lengths = this.lengths;
         for (int i = 0; i < lengths.length; ++i) {

--- a/core/src/test/java/io/undertow/util/PathTemplateMatcherTestCase.java
+++ b/core/src/test/java/io/undertow/util/PathTemplateMatcherTestCase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.testutils.category.UnitTest;
+import io.undertow.util.PathTemplateMatcher.PathMatchResult;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@Category(UnitTest.class)
+public class PathTemplateMatcherTestCase {
+
+    @Test
+    public void pathTemplateMatchedShouldKeepOrder() {
+        PathTemplateMatcher<HttpHandler> matcher = new PathTemplateMatcher<>();
+        matcher.add("/{context}/{version}/{entity}/{id}", exchange -> {
+        });
+
+        PathMatchResult<HttpHandler> match = matcher.match("/api/v3/users/1");
+
+        assertNotNull("Not matched", match);
+        assertNotNull("Value", match.getValue());
+        assertEquals("Matched parameters should keep order of definition",
+                Arrays.asList("api", "v3", "users", "1"), new ArrayList<>(match.getParameters().values()));
+    }
+
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1821

Replace `HashMap` to `LinkedHashMap` in `PathTemplateMatcher`. Motivation: ordered matched paths look more natural e.g. in debugging:
![Screen Shot 2020-10-26 at 10 18 51](https://user-images.githubusercontent.com/2844909/97143947-abbf0580-1774-11eb-87f9-db782e761bb3.png)

Also in my case I needed to write a simple custom matcher: not Map (expected) equals Map (actual), but a List of matched values (cannot use `Set`, because values can be repeated).

Reference implementation: spring-core `org.springframework.util.AntPathMatcher` keeps original order:
```java
AntPathMatcher antPathMatcher = new AntPathMatcher();
Map<String, String> pathVariables = antPathMatcher.extractUriTemplateVariables(
        "/{context}/{version}/{controller}/{id}",
        "/api/v3/users/1"
);
// prints "{context=api, version=v3, controller=users, id=1}"
```

Cons: in theory, updated impl will take more nanoseconds in runtime and more nanobytes in memory, but I believe if there was an intention to micro-optimise it, these should be a custom Map implementation (like Netty `HttpHeaders`)