### PR TITLE
[UNDERTOW-1742] Don't clear attributes in closeAndDrainRequest() method

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -694,17 +694,13 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
     }
 
     public void closeAndDrainRequest() throws IOException {
-        try {
-            if (reader != null) {
-                reader.close();
-            }
-            if (servletInputStream == null) {
-                servletInputStream = new ServletInputStreamImpl(this);
-            }
-            servletInputStream.close();
-        } finally {
-            clearAttributes();
+        if (reader != null) {
+            reader.close();
         }
+        if (servletInputStream == null) {
+            servletInputStream = new ServletInputStreamImpl(this);
+        }
+        servletInputStream.close();
     }
 
     /**


### PR DESCRIPTION
I successfully verified via sequence diagrams analysis that proposal fix in UNDERTOW-1742 really fixes the issue @fl4via .
Thanks @msfm for your feedback too.
Fixes:
https://issues.redhat.com/browse/UNDERTOW-1742
https://issues.redhat.com/browse/UNDERTOW-1743
https://issues.redhat.com/browse/UNDERTOW-1777