### PR TITLE
UNDERTOW-1791: Migrate from getPeerCertificateChain to getPeerCertificates

### DIFF
--- a/core/src/main/java/io/undertow/attribute/SslClientCertAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/SslClientCertAttribute.java
@@ -24,8 +24,8 @@ import io.undertow.server.SSLSessionInfo;
 import io.undertow.util.Certificates;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.CertificateEncodingException;
-import javax.security.cert.X509Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.Certificate;
 
 /**
  * @author Stuart Douglas
@@ -40,18 +40,16 @@ public class SslClientCertAttribute implements ExchangeAttribute {
         if(ssl == null) {
             return null;
         }
-        X509Certificate[] certificates;
+        Certificate[] certificates;
         try {
-            certificates = ssl.getPeerCertificateChain();
+            certificates = ssl.getPeerCertificates();
             if(certificates.length > 0) {
                 return Certificates.toPem(certificates[0]);
             }
             return null;
-        } catch (SSLPeerUnverifiedException e) {
-            return null;
-        } catch (CertificateEncodingException e) {
-            return null;
-        } catch (RenegotiationRequiredException e) {
+        } catch (SSLPeerUnverifiedException
+                | CertificateEncodingException
+                | RenegotiationRequiredException e) {
             return null;
         }
     }

--- a/core/src/main/java/io/undertow/server/SSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/SSLSessionInfo.java
@@ -47,6 +47,13 @@ public interface SSLSessionInfo {
      */
     java.security.cert.Certificate[] getPeerCertificates() throws javax.net.ssl.SSLPeerUnverifiedException, RenegotiationRequiredException;
 
+    /**
+     * This method is no longer supported on java 15 and should be avoided.
+     * @deprecated in favor of {@link #getPeerCertificates()} because {@link SSLSession#getPeerCertificateChain()}
+     *             throws java 15.
+     * @see SSLSession#getPeerCertificateChain()
+     */
+    @Deprecated
     javax.security.cert.X509Certificate[] getPeerCertificateChain() throws javax.net.ssl.SSLPeerUnverifiedException, RenegotiationRequiredException;
 
     /**

--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
@@ -24,12 +24,12 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.Channel;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.security.cert.CertificateEncodingException;
-import javax.security.cert.X509Certificate;
+import java.security.cert.CertificateEncodingException;
 
 import io.undertow.UndertowMessages;
 import io.undertow.server.handlers.ResponseCodeHandler;
@@ -546,9 +546,9 @@ public final class ProxyHandler implements HttpHandler {
 
             SSLSessionInfo sslSessionInfo = exchange.getConnection().getSslSessionInfo();
             if (sslSessionInfo != null) {
-                X509Certificate[] peerCertificates;
+                Certificate[] peerCertificates;
                 try {
-                    peerCertificates = sslSessionInfo.getPeerCertificateChain();
+                    peerCertificates = sslSessionInfo.getPeerCertificates();
                     if (peerCertificates.length > 0) {
                         request.putAttachment(ProxiedRequestAttachments.SSL_CERT, Certificates.toPem(peerCertificates[0]));
                     }

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -18,24 +18,31 @@
 
 package io.undertow.util;
 
-import javax.security.cert.CertificateEncodingException;
-import javax.security.cert.X509Certificate;
-
 /**
  * Utility class for dealing with certificates
  *
  * @author Stuart Douglas
  */
 public class Certificates {
-    public static final java.lang.String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
+    public static final String BEGIN_CERT = "-----BEGIN CERTIFICATE-----";
 
-    public static final java.lang.String END_CERT = "-----END CERTIFICATE-----";
+    public static final String END_CERT = "-----END CERTIFICATE-----";
 
-    public static String toPem(final X509Certificate certificate) throws CertificateEncodingException {
+    public static String toPem(final javax.security.cert.X509Certificate certificate)
+            throws javax.security.cert.CertificateEncodingException {
+        return toPem(certificate.getEncoded());
+    }
+
+    public static String toPem(final java.security.cert.Certificate certificate)
+            throws java.security.cert.CertificateEncodingException {
+        return toPem(certificate.getEncoded());
+    }
+
+    private static String toPem(final byte[] encodedCertificate) {
         final StringBuilder builder = new StringBuilder();
         builder.append(BEGIN_CERT);
         builder.append('\n');
-        builder.append(FlexBase64.encodeString(certificate.getEncoded(), true));
+        builder.append(FlexBase64.encodeString(encodedCertificate, true));
         builder.append('\n');
         builder.append(END_CERT);
         return builder.toString();


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1791

Java 15 runtimes default jsse SSLSession implementation throws an
UnsupportedOperationException when getPeerCertificateChain is called.
https://www.oracle.com/java/technologies/javase/15-relnote-issues.html#JDK-8241039

In this PR I have replaced uses of getPeerCertificateChain with getPeerCertificates, however I have not provided an implementation of sslsessioninfo.getPeerCertificateChain which delegates to getPeerCertificates and converts to the javax variant. It's unclear if that would be desirable.
It appears unlikely that there are cases in which getPeerCertificates produces different results, but it's possible a SSLSession implementation is incorrect in a way that causes this change to introduce failures. We could flag this behavior behind a property.