### PR TITLE
[UNDERTOW-1810] Dynamically determine the major servlet version at ru…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -63,15 +63,27 @@ import io.undertow.util.ImmediateAuthenticationMechanismFactory;
  */
 public class DeploymentInfo implements Cloneable {
 
+    private static final int DEFAULT_MAJOR_VERSION;
+
+    static {
+        // UNDERTOW-1810. It is possible at runtime that the class executing this logic has been bytecode
+        // transformed to use a different variant of the Servlet API than it was compiled against,
+        // i.e. EE 9's Servlet 5 instead of EE 8's Servlet 4. Since 4 and 5 are functionally equivalent
+        // except for the package rename, support such a scenario by setting the default major spec
+        // version that is supported based on the package name of a Servlet API class.
+        Package servletPackage = ServletContextListener.class.getPackage();
+        DEFAULT_MAJOR_VERSION = servletPackage.getName().startsWith("jakarta.") ? 5 : 4;
+    }
+
     private String deploymentName;
     private String displayName;
     private String contextPath;
     private ClassLoader classLoader;
     private ResourceManager resourceManager = ResourceManager.EMPTY_RESOURCE_MANAGER;
     private ClassIntrospecter classIntrospecter = DefaultClassIntrospector.INSTANCE;
-    private int majorVersion = 4;
+    private int majorVersion = DEFAULT_MAJOR_VERSION;
     private int minorVersion = 0;
-    private int containerMajorVersion = 4;
+    private int containerMajorVersion = DEFAULT_MAJOR_VERSION;
     private int containerMinorVersion = 0;
     private Executor executor;
     private Executor asyncExecutor;


### PR DESCRIPTION
…ntime based on the name of the ServletContextListener package.

https://issues.redhat.com/browse/UNDERTOW-1810


This is a hack so I won't be offended if it's rejected.

The obvious alternative is to produce a native jakarta.* variant of undertow but that's a substantial undertaking and it would be nice to be able to use Undertow in a compliant EE 9 impl soon.

Another alternative is to provide a mechanism for the container using undertow-servlet to control what undertow-servlet reports (system property, some interface loadable via ServiceLoader, ...). But that's harder for WildFly and seems a bit more fragile. Such a hook also becomes a form of API.