### PR TITLE
[UNDERTOW-1820] Fix flaky test in SaveOriginalPostRequestTestCase

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/security/form/SaveOriginalPostRequestTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/security/form/SaveOriginalPostRequestTestCase.java
@@ -122,7 +122,8 @@ public class SaveOriginalPostRequestTestCase {
         HttpResponse result = executePostRequest(client, "/servletContext/dumpRequest", new BasicNameValuePair("param1", "param1Value"), new BasicNameValuePair("param2", "param2Value"));
         assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
         String response = HttpClientUtils.readResponse(result);
-        assertTrue(response.contains("param1=param1Value/param2=param2Value"));
+        assertTrue(response.contains("param1=param1Value"));
+        assertTrue(response.contains("param2=param2Value"));
 
         // this request should be saved and the client redirect to the login form.
         result = executePostRequest(client, "/servletContext/secured/dumpRequest", new BasicNameValuePair("securedParam1", "securedParam1Value"), new BasicNameValuePair("securedParam2", "securedParam2Value"));


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1820

I am trying to fix a flaky test detected by Nondex framework https://github.com/TestingResearchIllinois/NonDex

sometime the response String equals "param1=param1Value/param2=param2Value", and sometimes the response String equals "param2=param2Value/param1=param1Value" if we run the Nondex framework because order of the tests are changed, and the root cause might be 

https://github.com/undertow-io/undertow/blob/ff4c9cf37872cb96070ba6a2fcbbaa6df291e390/servlet/src/test/java/io/undertow/servlet/test/security/form/SaveOriginalPostRequestTestCase.java#L182

when the httpclient is trying to execute the request that is out of our control. 

I think the order of the parameter does not matter, we just need a response. So I changed line 125 to two lines, so we can pass the nondex check. 