### PR TITLE
Reset flag in UnavailableServlet after each test in UnavailableServletTestCase

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/spec/UnavailableServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/spec/UnavailableServlet.java
@@ -45,4 +45,8 @@ public class UnavailableServlet implements Servlet {
     public void destroy() {
 
     }
+
+    public static void reset() {
+        first = true;
+    }
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/spec/UnavailableServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/spec/UnavailableServletTestCase.java
@@ -1,5 +1,6 @@
 package io.undertow.servlet.test.spec;
 
+import io.undertow.servlet.api.ServletInfo;
 import io.undertow.servlet.test.util.DeploymentUtils;
 import io.undertow.testutils.DefaultServer;
 import io.undertow.testutils.HttpClientUtils;
@@ -7,16 +8,15 @@ import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.junit.Before;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.servlet.ServletException;
 
 import java.io.IOException;
-
-import static io.undertow.servlet.Servlets.servlet;
 
 /**
  * @author Stuart Douglas
@@ -25,15 +25,20 @@ import static io.undertow.servlet.Servlets.servlet;
 public class UnavailableServletTestCase {
 
 
-    @BeforeClass
-    public static void setup() throws ServletException {
+    @Before
+    public void setup() throws ServletException {
         DeploymentUtils.setupServlet(
-                servlet("p", UnavailableServlet.class)
+                new ServletInfo("p", UnavailableServlet.class)
                         .addInitParam(UnavailableServlet.PERMANENT, "1")
                         .addMapping("/p"),
-                servlet("t", UnavailableServlet.class)
+                new ServletInfo("t", UnavailableServlet.class)
                         .addMapping("/t"));
 
+    }
+
+    @After
+    public void teardown() {
+        UnavailableServlet.reset();
     }
 
     @Test


### PR DESCRIPTION
The test `io.undertow.servlet.test.spec.UnavailableServletTestCase.testTempUnavailableServlet` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

Details
---
When running `UnavailableServletTestCase.testTempUnavailableServlet` twice, the second run would fail with the following assertion:
```
HttpResponse result = client.execute(get);
Assert.assertEquals(StatusCodes.SERVICE_UNAVAILABLE, result.getStatusLine().getStatusCode());
```
The reason for this is that the static`UnavailableServlet.first` is set to false during the first test run. As a result,   during the second run, the HTTP response would return a `StatusCodes.OK` instead of `StatusCodes.SERVICE_UNAVAILABLE`. The fix is to reset the `UnavailableServlet.first` to true after each test run of `UnavailableServletTestCase.testTempUnavailableServlet`.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).