### PR TITLE
handle http2 statistics based on ENABLE_STATISTICS flag

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2OpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2OpenListener.java
@@ -134,7 +134,7 @@ public final class Http2OpenListener implements ChannelListener<StreamConnection
                 connections.remove(channel);
             }
         });
-        http2Channel.getReceiveSetter().set(new Http2ReceiveListener(rootHandler, getUndertowOptions(), bufferSize, connectorStatistics));
+        http2Channel.getReceiveSetter().set(new Http2ReceiveListener(rootHandler, getUndertowOptions(), bufferSize, statisticsEnabled ? connectorStatistics : null));
         http2Channel.resumeReceives();
 
     }


### PR DESCRIPTION
handle http2 statistics consistently with HTTP and AJP listener, and reduce unnecessary overhead if ENABLE_STATISTICS is disabled