### PR TITLE
version manage

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,7 +148,6 @@
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl</artifactId>
-            <version>${version.org.wildfly.openssl}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -115,7 +115,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>1.2.1</version>
                 <configuration>
                     <executable>java</executable>
                     <arguments>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,6 @@
             <plugin>
                 <groupId>org.zanata</groupId>
                 <artifactId>zanata-maven-plugin</artifactId>
-                <version>${version.zanata.plugin}</version>
                 <configuration>
                     <!-- Process sub-modules separately, sharing parent config -->
                     <enableModules>true</enableModules>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl</artifactId>
-            <version>${version.org.wildfly.openssl}</version>
             <scope>test</scope>
         </dependency>
 

--- a/websockets-jsr/pom.xml
+++ b/websockets-jsr/pom.xml
@@ -107,7 +107,6 @@
         <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl</artifactId>
-            <version>${version.org.wildfly.openssl}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
the version of `wildfly-openssl`, `exec-maven-plugin`,
`zanata-maven-plugin` is already defined in parent project,
there's no need defined it again.