### PR TITLE
UNDERTOW-1846 Configurable SSLEngine delegated task executor

### DIFF
--- a/core/src/main/java/io/undertow/UndertowLogger.java
+++ b/core/src/main/java/io/undertow/UndertowLogger.java
@@ -43,6 +43,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 
 import static org.jboss.logging.Logger.Level.DEBUG;
 import static org.jboss.logging.Logger.Level.ERROR;
@@ -434,4 +435,8 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = DEBUG)
     @Message(id = 5094, value = "Blocking write timed out")
     void blockingWriteTimedOut(@Cause WriteTimeoutException rte);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = 5095, value = "SSLEngine delegated task was rejected")
+    void sslEngineDelegatedTaskRejected(@Cause RejectedExecutionException ree);
 }

--- a/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
@@ -25,6 +25,8 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
@@ -132,6 +134,7 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
 
     private final UndertowSslConnection connection;
     private final StreamConnection delegate;
+    private final Executor delegatedTaskExecutor;
     private SSLEngine engine;
     private final StreamSinkConduit sink;
     private final StreamSourceConduit source;
@@ -196,13 +199,14 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
         }
     };
 
-    SslConduit(UndertowSslConnection connection, StreamConnection delegate, SSLEngine engine, ByteBufferPool bufferPool, Runnable handshakeCallback) {
+    SslConduit(UndertowSslConnection connection, StreamConnection delegate, SSLEngine engine, Executor delegatedTaskExecutor, ByteBufferPool bufferPool, Runnable handshakeCallback) {
         this.connection = connection;
         this.delegate = delegate;
         this.handshakeCallback = handshakeCallback;
         this.sink = delegate.getSinkChannel().getConduit();
         this.source = delegate.getSourceChannel().getConduit();
         this.engine = engine;
+        this.delegatedTaskExecutor = delegatedTaskExecutor;
         this.bufferPool = bufferPool;
         delegate.getSourceChannel().getConduit().setReadReadyHandler(readReadyHandler = new SslReadReadyHandler(null));
         delegate.getSinkChannel().getConduit().setWriteReadyHandler(writeReadyHandler = new SslWriteReadyHandler(null));
@@ -594,6 +598,10 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
     @Override
     public XnioWorker getWorker() {
         return delegate.getWorker();
+    }
+
+    private Executor getDelegatedTaskExecutor() {
+        return delegatedTaskExecutor == null ? getWorker() : delegatedTaskExecutor;
     }
 
     void notifyWriteClosed() {
@@ -1084,11 +1092,11 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
     }
 
     /**
-     * Execute all the tasks in the worker
+     * Execute all the delegated tasks on an executor which allows blocking, the worker executor by default.
      *
      * Once they are complete we notify any waiting threads and wakeup reads/writes as appropriate
      */
-    private void runTasks() {
+    private void runTasks() throws IOException {
         //don't run anything in the IO thread till the tasks are done
         delegate.getSinkChannel().suspendWrites();
         delegate.getSourceChannel().suspendReads();
@@ -1102,7 +1110,7 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
         synchronized (this) {
             outstandingTasks += tasks.size();
             for (final Runnable task : tasks) {
-                getWorker().execute(new Runnable() {
+                Runnable wrappedTask = new Runnable() {
                     @Override
                     public void run() {
                         try {
@@ -1137,10 +1145,43 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
                                 }
                             }
                         }
-
                     }
-                });
+                };
+                try {
+                    getDelegatedTaskExecutor().execute(wrappedTask);
+                } catch (RejectedExecutionException e) {
+                    UndertowLogger.REQUEST_IO_LOGGER.sslEngineDelegatedTaskRejected(e);
+                    IoUtils.safeClose(connection);
+                    throw DelegatedTaskRejectedClosedChannelException.INSTANCE;
+                }
             }
+        }
+    }
+
+    /**
+     * A specialized {@link ClosedChannelException} which does not provide a stack trace. Tasks may be rejected
+     * when the server is overloaded, so it's important not to create more work than necessary.
+     */
+    private static final class DelegatedTaskRejectedClosedChannelException extends ClosedChannelException {
+
+        private static final DelegatedTaskRejectedClosedChannelException INSTANCE =
+                new DelegatedTaskRejectedClosedChannelException();
+
+        @Override
+        public Throwable fillInStackTrace() {
+            // Avoid the most expensive part of exception creation.
+            return this;
+        }
+
+        // Ignore mutations
+        @Override
+        public Throwable initCause(Throwable ignored) {
+            return this;
+        }
+
+        @Override
+        public void setStackTrace(StackTraceElement[] ignored) {
+            // no-op
         }
     }
 

--- a/core/src/main/java/io/undertow/protocols/ssl/UndertowAcceptingSslChannel.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/UndertowAcceptingSslChannel.java
@@ -208,7 +208,7 @@ class UndertowAcceptingSslChannel implements AcceptingChannel<SslConnection> {
     }
 
     protected UndertowSslConnection accept(StreamConnection tcpServer, SSLEngine sslEngine) throws IOException {
-        return new UndertowSslConnection(tcpServer, sslEngine, applicationBufferPool);
+        return new UndertowSslConnection(tcpServer, sslEngine, applicationBufferPool, ssl.getDelegatedTaskExecutor());
     }
 
     public ChannelListener.Setter<? extends AcceptingChannel<SslConnection>> getCloseSetter() {

--- a/core/src/main/java/io/undertow/protocols/ssl/UndertowSslConnection.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/UndertowSslConnection.java
@@ -32,6 +32,7 @@ import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 /**
  * @author Stuart Douglas
@@ -50,11 +51,11 @@ class UndertowSslConnection extends SslConnection {
      *
      * @param delegate the underlying connection
      */
-    UndertowSslConnection(StreamConnection delegate, SSLEngine engine, ByteBufferPool bufferPool) {
+    UndertowSslConnection(StreamConnection delegate, SSLEngine engine, ByteBufferPool bufferPool, Executor delegatedTaskExecutor) {
         super(delegate.getIoThread());
         this.delegate = delegate;
         this.engine = engine;
-        sslConduit = new SslConduit(this, delegate, engine, bufferPool, new HandshakeCallback());
+        sslConduit = new SslConduit(this, delegate, engine, delegatedTaskExecutor, bufferPool, new HandshakeCallback());
         setSourceConduit(sslConduit);
         setSinkConduit(sslConduit);
     }

--- a/core/src/test/java/io/undertow/server/ssl/DelegatedTaskExecutorTestCase.java
+++ b/core/src/test/java/io/undertow/server/ssl/DelegatedTaskExecutorTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.ssl;
+
+
+import io.undertow.Undertow;
+import io.undertow.server.handlers.ResponseCodeHandler;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Test;
+
+import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Carter Kozak
+ */
+public class DelegatedTaskExecutorTestCase {
+
+    @Test
+    public void testDelegatedTaskExecutorIsUsed() throws Exception {
+        ExecutorService delegatedTaskExecutor = Executors.newSingleThreadExecutor();
+        AtomicInteger counter = new AtomicInteger();
+        Undertow undertow = Undertow.builder()
+                .addHttpsListener(0, null, DefaultServer.getServerSslContext())
+                .setSslEngineDelegatedTaskExecutor(task -> {
+                    counter.getAndIncrement();
+                    delegatedTaskExecutor.execute(task);
+                })
+                .setHandler(ResponseCodeHandler.HANDLE_200)
+                .build();
+
+        TestHttpClient client = new TestHttpClient();
+        client.setSSLContext(DefaultServer.getClientSSLContext());
+        undertow.start();
+        int port = port(undertow);
+        try(CloseableHttpResponse response = client.execute(new HttpGet("https://localhost:" + port))) {
+            assertEquals(200, response.getStatusLine().getStatusCode());
+            assertTrue("expected interactions with the delegated task executor", counter.get() > 0);
+        } finally {
+            undertow.stop();
+            client.getConnectionManager().shutdown();
+            delegatedTaskExecutor.shutdownNow();
+            assertTrue(
+                    "ExecutorService did not shut down in time",
+                    delegatedTaskExecutor.awaitTermination(1, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void testRejection() {
+        Undertow undertow = Undertow.builder()
+                .addHttpsListener(0, null, DefaultServer.getServerSslContext())
+                .setSslEngineDelegatedTaskExecutor(ignoredTask -> {
+                    throw new RejectedExecutionException();
+                })
+                .setHandler(ResponseCodeHandler.HANDLE_200)
+                .build();
+
+        TestHttpClient client = new TestHttpClient();
+        client.setSSLContext(DefaultServer.getClientSSLContext());
+        undertow.start();
+        try {
+            int port = port(undertow);
+            HttpGet request = new HttpGet("https://localhost:" + port);
+            try {
+                client.execute(request);
+                fail("Expected an exception");
+            } catch (SSLHandshakeException handshakeException) {
+                // expected one of:
+                // - Remote host closed connection during handshake
+                // - Remote host terminated the handshake
+                // This exception comes from the jvm and may change in future
+                // releases so we don't verify an exact match.
+                String message = handshakeException.getMessage();
+                System.out.println(message);
+                assertTrue(
+                        "message was: " + message,
+                        message != null && (message.contains("closed") || message.contains("terminated")));
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        } finally {
+            undertow.stop();
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    private static int port(Undertow undertow) {
+        if (undertow.getListenerInfo().size() != 1) {
+            throw new IllegalStateException("Expected exactly one listener");
+        }
+        InetSocketAddress address = (InetSocketAddress) undertow.getListenerInfo().get(0).getAddress();
+        return address.getPort();
+    }
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1846

This provides a relatively simple mechanism to control concurrency
of the delegated task portion of a handshake. The work done by
these tasks doesn't necessarily match the type of work that the
worker pool is configured for and may be controlled separately.

The connection is immediately closed when a delegated task executor
rejects a task.