### PR TITLE
[UNDERTOW-1852] Add OSGi manifest headers to 3 Undertow modules

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -175,6 +175,32 @@
 
         <plugins>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>
+                                    io.undertow.*;version=${project.version};-noimport:=true
+                                </Export-Package>
+                                <Import-Package>
+                                    org.eclipse.jetty.*;resolution:=optional;version="[1,2)",
+                                    !org.xnio._private,
+                                    org.xnio.*;version="[3.8,4)",
+                                    !., !sun.*,
+                                    *
+                                </Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -188,6 +214,11 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.bitstrings.maven.plugins</groupId>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.undertow</groupId>
+        <artifactId>undertow-parent</artifactId>
+        <version>2.2.5.Final-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.undertow</groupId>
+    <artifactId>karaf</artifactId>
+    <version>2.2.5.Final-SNAPSHOT</version>
+
+    <name>Undertow Karaf feature</name>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <version.karaf.plugin>4.2.10</version.karaf.plugin>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.apache.karaf.features</groupId>
+            <artifactId>framework</artifactId>
+            <type>kar</type>
+            <scope>provided</scope>
+            <version>${version.karaf.plugin}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>${version.karaf.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>resources</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>verify</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>mvn:org.apache.karaf.features/framework/${version.karaf.plugin}/xml/features</descriptor>
+                                <descriptor>mvn:org.apache.karaf.features/standard/${version.karaf.plugin}/xml/features</descriptor>
+                                <descriptor>file:${project.build.directory}/classes/features.xml</descriptor>
+                            </descriptors>
+                            <distribution>org.apache.karaf.features:framework</distribution>
+                            <javase>1.8</javase>
+                            <framework>
+                                <feature>framework</feature>
+                            </framework>
+                            <features>
+                                <feature>undertow</feature>
+                            </features>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/classes/features.xml</file>
+                                    <type>xml</type>
+                                    <classifier>features</classifier>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/karaf/src/main/resources/features.xml
+++ b/karaf/src/main/resources/features.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<features name="io.undertow-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">
+
+    <feature name="undertow" version="${project.version}">
+        <bundle dependency="true">mvn:org.jboss.spec.javax.annotation/jboss-annotations-api_1.3_spec/${version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec}</bundle>
+        <bundle dependency="true">mvn:org.jboss.spec.javax.servlet/jboss-servlet-api_4.0_spec/${version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec}</bundle>
+        <bundle dependency="true">mvn:org.jboss.spec.javax.websocket/jboss-websocket-api_1.1_spec/${version.org.jboss.spec.javax.websockets}</bundle>
+
+        <bundle>mvn:org.jboss.xnio/xnio-api/${version.xnio}</bundle>
+        <bundle>mvn:org.jboss.xnio/xnio-nio/${version.xnio}</bundle>
+        <bundle>mvn:io.undertow/undertow-core/${project.version}</bundle>
+        <bundle>mvn:io.undertow/undertow-servlet/${project.version}</bundle>
+        <bundle>mvn:io.undertow/undertow-websockets-jsr/${project.version}</bundle>
+
+        <bundle dependency="true">wrap:mvn:org.jboss.threads/jboss-threads/${version.org.jboss.threads}</bundle>
+        <bundle dependency="true">wrap:mvn:org.wildfly.common/wildfly-common/${version.org.wildfly.common}$Export-Package=org.wildfly.common.*;-noimport:=true;version="${version.org.wildfly.common}"</bundle>
+        <bundle dependency="true">mvn:org.wildfly.client/wildfly-client-config/${version.org.wildfly.client-config}</bundle>
+    </feature>
+
+</features>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
         <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
+        <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
 
         <!-- jacoco -->
         <version.org.jacoco>0.7.9</version.org.jacoco>
@@ -99,6 +100,7 @@
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.wildfly.openssl>1.0.4.Final</version.org.wildfly.openssl>
         <version.checkstyle>7.1</version.checkstyle>
+        <version.bundle.plugin>5.1.1</version.bundle.plugin>
 
         <version.jmh>1.21</version.jmh>
 
@@ -266,6 +268,11 @@
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${version.bundle.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -650,6 +657,18 @@
             <properties>
                 <test.categories>NOT io.undertow.testutils.category.UnitTest</test.categories>
             </properties>
+        </profile>
+
+        <profile>
+            <id>osgi</id>
+            <activation>
+                <property>
+                    <name>osgi</name>
+                </property>
+            </activation>
+            <modules>
+                <module>karaf</module>
+            </modules>
         </profile>
     </profiles>
 

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -155,6 +155,30 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>
+                                    io.undertow.servlet*;version=${project.version};-noimport:=true
+                                </Export-Package>
+                                <Import-Package>
+                                    javax.annotation.security;version="[1.2,3)",
+                                    !sun.*,
+                                    *
+                                </Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -168,6 +192,11 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/websockets-jsr/pom.xml
+++ b/websockets-jsr/pom.xml
@@ -129,6 +129,38 @@
 
         <plugins>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-manifest</id>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                        <configuration>
+                            <instructions>
+                                <Export-Package>
+                                    io.undertow.websockets.jsr*;version=${project.version};-noimport:=true
+                                </Export-Package>
+                                <Import-Package>
+                                    !sun.*,
+                                    *
+                                </Import-Package>
+                            </instructions>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1852

There's also "karaf" Maven module, enabled only with `osgi` Maven
profile. This is not to provide any additional artifact, but only to
verify the Manifest headers.

I also removed io.undertow.servlet.core.ServletExtensionHolder which was
supposed to provide a static way to add ServletExtensions in OSGi
environment. It's no longer needed and even in OSGi ServletExtensions
are now added normally to DeploymentInfo.