### PR TITLE
Null-safe writes termination in the StoredResponseStreamSinkConduit

### DIFF
--- a/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
@@ -145,8 +145,10 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
 
     @Override
     public void terminateWrites() throws IOException {
-        exchange.putAttachment(RESPONSE, outputStream.toByteArray());
-        outputStream = null;
+        if (outputStream != null) {
+            exchange.putAttachment(RESPONSE, outputStream.toByteArray());
+            outputStream = null;
+        }
         super.terminateWrites();
     }
 }


### PR DESCRIPTION
Please correct me if I am wrong. There is a high probability of `outputStream` being `null` here as `terminateWrites()` succeeds after `writeFinal()`. Both methods set the `outputStream` with `null`.

I have an actual use case when `BlockingSenderImpl` does `send()` with finalization of the `Exchange`. The effective `UndertowOutputStream` is closed which sequentially calls both methods `writeBufferBlocking()` and `shutdownWrites()` in the `close()` method.

```
java.lang.NullPointerException: null
	at io.undertow.conduits.StoredResponseStreamSinkConduit.terminateWrites(StoredResponseStreamSinkConduit.java:148) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at org.xnio.conduits.ConduitStreamSinkChannel.shutdownWrites(ConduitStreamSinkChannel.java:178) ~[xnio-api-3.8.0.Final.jar:3.8.0.Final]
	at io.undertow.channels.DetachableStreamSinkChannel.shutdownWrites(DetachableStreamSinkChannel.java:79) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.UndertowOutputStream.close(UndertowOutputStream.java:347) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.BlockingSenderImpl.close(BlockingSenderImpl.java:219) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.DefaultIoCallback.onComplete(DefaultIoCallback.java:54) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.BlockingSenderImpl.invokeOnComplete(BlockingSenderImpl.java:276) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.BlockingSenderImpl.send(BlockingSenderImpl.java:132) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
	at io.undertow.io.BlockingSenderImpl.send(BlockingSenderImpl.java:166) ~[undertow-core-2.1.0.Final.jar:2.1.0.Final]
```