### PR TITLE
UNDERTOW-1849 NPE happens at StoredResponseStreamSinkConduit.terminateWrites() when StoredResponseHandler (store-response) is enabled

### DIFF
--- a/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
@@ -145,8 +145,10 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
 
     @Override
     public void terminateWrites() throws IOException {
-        exchange.putAttachment(RESPONSE, outputStream.toByteArray());
-        outputStream = null;
+        if (outputStream != null) {
+            exchange.putAttachment(RESPONSE, outputStream.toByteArray());
+            outputStream = null;
+        }
         super.terminateWrites();
     }
 }

--- a/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
+++ b/core/src/main/java/io/undertow/conduits/StoredResponseStreamSinkConduit.java
@@ -75,8 +75,10 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
     public int write(ByteBuffer src) throws IOException {
         int start = src.position();
         int ret = super.write(src);
-        for (int i = start; i < start + ret; ++i) {
-            outputStream.write(src.get(i));
+        if (outputStream != null) {
+            for (int i = start; i < start + ret; ++i) {
+                outputStream.write(src.get(i));
+            }
         }
         return ret;
     }
@@ -90,13 +92,15 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
         long ret = super.write(srcs, offs, len);
         long rem = ret;
 
-        for (int i = 0; i < len; ++i) {
-            ByteBuffer buf = srcs[i + offs];
-            int pos = starts[i];
-            while (rem > 0 && pos < buf.position()) {
-                outputStream.write(buf.get(pos));
-                pos++;
-                rem--;
+        if (outputStream != null) {
+            for (int i = 0; i < len; ++i) {
+                ByteBuffer buf = srcs[i + offs];
+                int pos = starts[i];
+                while (rem > 0 && pos < buf.position()) {
+                    outputStream.write(buf.get(pos));
+                    pos++;
+                    rem--;
+                }
             }
         }
         return ret;
@@ -106,12 +110,14 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
     public int writeFinal(ByteBuffer src) throws IOException {
         int start = src.position();
         int ret = super.writeFinal(src);
-        for (int i = start; i < start + ret; ++i) {
-            outputStream.write(src.get(i));
-        }
-        if (!src.hasRemaining()) {
-            exchange.putAttachment(RESPONSE, outputStream.toByteArray());
-            outputStream = null;
+        if (outputStream != null) {
+            for (int i = start; i < start + ret; ++i) {
+                outputStream.write(src.get(i));
+            }
+            if (!src.hasRemaining()) {
+                exchange.putAttachment(RESPONSE, outputStream.toByteArray());
+                outputStream = null;
+            }
         }
         return ret;
     }
@@ -127,18 +133,20 @@ public final class StoredResponseStreamSinkConduit extends AbstractStreamSinkCon
         long ret = super.write(srcs, offs, len);
         long rem = ret;
 
-        for (int i = 0; i < len; ++i) {
-            ByteBuffer buf = srcs[i + offs];
-            int pos = starts[i];
-            while (rem > 0 && pos < buf.position()) {
-                outputStream.write(buf.get(pos));
-                pos++;
-                rem--;
+        if (outputStream != null) {
+            for (int i = 0; i < len; ++i) {
+                ByteBuffer buf = srcs[i + offs];
+                int pos = starts[i];
+                while (rem > 0 && pos < buf.position()) {
+                    outputStream.write(buf.get(pos));
+                    pos++;
+                    rem--;
+                }
             }
-        }
-        if (toWrite == ret) {
-            exchange.putAttachment(RESPONSE, outputStream.toByteArray());
-            outputStream = null;
+            if (toWrite == ret) {
+                exchange.putAttachment(RESPONSE, outputStream.toByteArray());
+                outputStream = null;
+            }
         }
         return ret;
     }


### PR DESCRIPTION
Undertow JIRA: https://issues.redhat.com/browse/UNDERTOW-1849
JBEAP JIRA (7.3.z): https://issues.redhat.com/browse/JBEAP-21072
JBEAP JIRA (7.4.z): https://issues.redhat.com/browse/JBEAP-21269

This PR for the master branch.
PR for 2.0.x branch: https://github.com/undertow-io/undertow/pull/1056