### PR TITLE
UNDERTOW-1873 Path is not canonicalized when Request.getRequestDispat…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -987,7 +987,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
     public RequestDispatcher getRequestDispatcher(final String path) {
         String realPath;
         if (path.startsWith("/")) {
-            realPath = path;
+            realPath = CanonicalPathUtils.canonicalize(path);
         } else {
             String current = exchange.getRelativePath();
             int lastSlash = current.lastIndexOf("/");


### PR DESCRIPTION
…cher() forwards to path that begins with "/"

https://issues.redhat.com/browse/UNDERTOW-1873