### PR TITLE
UNDERTOW-1873 Path is not canonicalized when Request.getRequestDispat…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -976,7 +976,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
     public RequestDispatcher getRequestDispatcher(final String path) {
         String realPath;
         if (path.startsWith("/")) {
-            realPath = path;
+            realPath = CanonicalPathUtils.canonicalize(path);
         } else {
             String current = exchange.getRelativePath();
             int lastSlash = current.lastIndexOf("/");


### PR DESCRIPTION
…cher() forwards to path that begins with "/"

(cherry picked from commit 10a514ed812390adad4157d144366ae4b73b72a5)
Issue: https://issues.redhat.com/browse/UNDERTOW-1873
Master PR: https://github.com/undertow-io/undertow/pull/1064
2.0.x PR: https://github.com/undertow-io/undertow/pull/1068