### PR TITLE
[UNDERTOW-1834] Fix for IBM JDK and HTTP2/ALPN.

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/ALPNLimitingSSLEngine.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ALPNLimitingSSLEngine.java
@@ -31,7 +31,7 @@ import javax.net.ssl.SSLSession;
 /**
  * SSLEngine that will limit the cipher selection to HTTP/2 suitable protocols if the client is offering h2 as an option.
  * <p>
- * In theory this is not a perfect solution to the HTTP/2 cipher strength issue, but in practice it should be sufficent
+ * In theory this is not a perfect solution to the HTTP/2 cipher strength issue, but in practice it should be sufficient
  * as any RFC compliant implementation should be able to negotiate TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
  *
  * @author Stuart Douglas

--- a/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/AlpnOpenListener.java
@@ -70,6 +70,12 @@ public class AlpnOpenListener implements ChannelListener<StreamConnection>, Open
      * HTTP/2 required cipher. Not strictly part of ALPN but it can live here for now till we have a better solution.
      */
     public static final String REQUIRED_CIPHER = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+    /**
+     * Names of ciphers in IBM JVM are prefixed with `SSL` instead of `TLS`, see e.g.:
+     * https://www.ibm.com/support/knowledgecenter/SSFKSJ_9.0.0/com.ibm.mq.dev.doc/q113210_.htm.
+     * Thus let's have IBM alternative for the REQUIRED_CIPHER variable too.
+     */
+    public static final String IBM_REQUIRED_CIPHER = "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
     private static final Set<String> REQUIRED_PROTOCOLS = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList("TLSv1.2","TLSv1.3")));
 
@@ -325,7 +331,7 @@ public class AlpnOpenListener implements ChannelListener<StreamConnection>, Open
 
         String[] ciphers = engine.getEnabledCipherSuites();
         for (String i : ciphers) {
-            if (i.equals(REQUIRED_CIPHER)) {
+            if (i.equals(REQUIRED_CIPHER) || i.equals(IBM_REQUIRED_CIPHER)) {
                 return true;
             }
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-1834

There is a difference in IBM JDK TLS ciphersuite names versus their
Oracle JDK counterparts, see e.g. [1].

This discrepancy causes issue in usage of HTTP2 with IBM JDK since
we check enabled ciphersuite based on the name in Oracle JDK variant
only. So if there is an incomming connection from client that offers
IBM names of the ciphersuite, we simply fail to use ALPN and HTTP2
with it consequently.

This change should fix such issue.

[1] https://www.ibm.com/support/knowledgecenter/SSFKSJ_9.0.0/com.ibm.mq.dev.doc/q113210_.htm