### PR TITLE
[UNDERTOW-1783] Add support for part specific charsets. Charset is ca…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -326,7 +326,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                         }
                     }
 
-                    data.add(currentName, new String(contentBytes.toByteArray(), charset), headers);
+                    data.add(currentName, new String(contentBytes.toByteArray(), charset), charset, headers);
                 } catch (UnsupportedEncodingException e) {
                     throw new RuntimeException(e);
                 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/PartImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/PartImpl.java
@@ -62,8 +62,15 @@ public class PartImpl implements Part {
         if (formValue.isFileItem()) {
             return formValue.getFileItem().getInputStream();
         } else {
-            String requestedCharset = servletRequest.getCharacterEncoding();
-            String charset = requestedCharset != null ? requestedCharset : servletContext.getDeployment().getDefaultRequestCharset().name();
+            String charset;
+            if (formValue.getCharset() != null) {
+                charset = formValue.getCharset();
+            } else if (servletRequest.getCharacterEncoding() != null) {
+                charset = servletRequest.getCharacterEncoding();
+            } else {
+                charset = servletContext.getDeployment().getDefaultRequestCharset().name();
+            }
+
             return new ByteArrayInputStream(formValue.getValue().getBytes(charset));
         }
     }
@@ -88,6 +95,8 @@ public class PartImpl implements Part {
         try {
             if (formValue.isFileItem()) {
                 return formValue.getFileItem().getFileSize();
+            } else if (formValue.getCharset() != null) {
+                return formValue.getValue().getBytes(formValue.getCharset()).length;
             } else {
                 return formValue.getValue().length();
             }

--- a/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartServlet.java
@@ -41,6 +41,8 @@ public class MultiPartServlet extends HttpServlet {
     protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
         try {
             Collection<Part> parts = req.getParts();
+            resp.setContentType("text/plain; charset=UTF-8");
+            resp.setCharacterEncoding("UTF-8");
             PrintWriter writer = resp.getWriter();
             writer.println("PARAMS:");
             writer.println("parameter count: " + req.getParameterMap().size());

--- a/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/multipart/MultiPartTestCase.java
@@ -37,6 +37,7 @@ import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
@@ -217,4 +218,37 @@ public class MultiPartTestCase {
             client.getConnectionManager().shutdown();
         }
     }
+
+    @Test
+    public void testMultiPartRequestUtf8CharsetInPart() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            String uri = DefaultServer.getDefaultServerURL() + "/servletContext/1";
+            HttpPost post = new HttpPost(uri);
+
+            MultipartEntity entity = new MultipartEntity();
+
+            entity.addPart("formValue", new StringBody("myValue\u00E5", ContentType.create("text/plain", StandardCharsets.UTF_8)));
+
+            post.setEntity(entity);
+            HttpResponse result = client.execute(post);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            final String response = HttpClientUtils.readResponse(result);
+
+            Assert.assertEquals("PARAMS:\r\n" +
+                    "parameter count: 1\r\n" +
+                    "parameter name count: 1\r\n" +
+                    "name: formValue\r\n" +
+                    "filename: null\r\n" +
+                    "content-type: text/plain; charset=UTF-8\r\n" +
+                    "Content-Disposition: form-data; name=\"formValue\"\r\n" +
+                    "Content-Transfer-Encoding: 8bit\r\n" +
+                    "Content-Type: text/plain; charset=UTF-8\r\n" +
+                    "size: 9\r\n" +
+                    "content: myValue\u00E5\r\n", response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
 }


### PR DESCRIPTION
…ptured during part parsing and made available in FormData. The charset is then used in getSize() and getInputStream() to get the correct bytes for the encoded part.
Issue: https://issues.redhat.com/browse/UNDERTOW-1680
Upstream PR: https://github.com/undertow-io/undertow/pull/1105