### PR TITLE
[UNDERTOW-1882] allow HTTP2 to take advantage of UndertowOptions.ALLO…

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -82,6 +82,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
     private final int bufferSize;
     private final int maxParameters;
     private final boolean recordRequestStartTime;
+    private final boolean allowUnescapedCharactersInUrl;
 
     private final ConnectorStatisticsImpl connectorStatistics;
 
@@ -100,6 +101,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         } else {
             this.encoding = null;
         }
+        this.allowUnescapedCharactersInUrl = undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, false);
     }
 
     @Override
@@ -320,7 +322,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         // verify content of request pseudo-headers. Each header should only have a single value.
         if (headers.contains(PATH)) {
             for (byte b: headers.get(PATH).getFirst().getBytes(ISO_8859_1)) {
-                if (!HttpRequestParser.isTargetCharacterAllowed((char)b)){
+                if (!allowUnescapedCharactersInUrl && !HttpRequestParser.isTargetCharacterAllowed((char)b)){
                     return false;
                 }
             }

--- a/core/src/test/java/io/undertow/server/protocol/http2/HTTP2ViaUpgradeTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http2/HTTP2ViaUpgradeTestCase.java
@@ -232,6 +232,10 @@ public class HTTP2ViaUpgradeTestCase {
                     new UserEventLogger());
         }
 
+        protected String fetchUpgradeHandlerURL() {
+            return "/sdf";
+        }
+
         /**
          * A handler that triggers the cleartext upgrade to HTTP/2 by sending an initial HTTP request.
          */
@@ -239,7 +243,7 @@ public class HTTP2ViaUpgradeTestCase {
             @Override
             public void channelActive(ChannelHandlerContext ctx) throws Exception {
                 DefaultFullHttpRequest upgradeRequest =
-                        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/sdf");
+                        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, fetchUpgradeHandlerURL());
                 upgradeRequest.headers().add(Headers.HOST_STRING, "default");
                 ctx.writeAndFlush(upgradeRequest);
 

--- a/core/src/test/java/io/undertow/server/protocol/http2/HTTP2ViaUpgradeWithUnEncodedURLCharactersTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http2/HTTP2ViaUpgradeWithUnEncodedURLCharactersTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.protocol.http2;
+
+import java.net.URISyntaxException;
+
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.xnio.Options;
+
+import io.undertow.Handlers;
+import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.session.SessionCookieConfig;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.util.Headers;
+import io.undertow.util.HttpString;
+
+/**
+ * Tests the load balancing proxy
+ *
+ * @author Stuart Douglas
+ * @author baranowb
+ */
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+public class HTTP2ViaUpgradeWithUnEncodedURLCharactersTestCase extends HTTP2ViaUpgradeTestCase{
+
+    @BeforeClass
+    public static void setup() throws URISyntaxException {
+        final SessionCookieConfig sessionConfig = new SessionCookieConfig();
+        int port = DefaultServer.getHostPort("default");
+        server = Undertow.builder()
+                .addHttpListener(port + 1, DefaultServer.getHostAddress("default"))
+                .setServerOption(UndertowOptions.ENABLE_HTTP2, true)
+                .setServerOption(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, true)
+                .setSocketOption(Options.REUSE_ADDRESSES, true)
+                .setHandler(Handlers.header(new Http2UpgradeHandler(new HttpHandler() {
+                    @Override
+                    public void handleRequest(HttpServerExchange exchange) throws Exception {
+                        if (!(exchange.getConnection() instanceof Http2ServerConnection)) {
+                            throw new RuntimeException("Not HTTP2");
+                        }
+                        exchange.getResponseHeaders().add(new HttpString("X-Custom-Header"), "foo");
+                        exchange.getResponseSender().send(message);
+                    }
+                }, "h2c", "h2c-17"), Headers.SEC_WEB_SOCKET_ACCEPT_STRING, "fake")) //work around Netty bug, it assumes that every upgrade request that does not have this header is an old style websocket upgrade
+                .build();
+
+        server.start();
+    }
+
+    protected String fetchUpgradeHandlerURL() {
+        return "/^?query=^";
+    }
+}


### PR DESCRIPTION
…W_UNESCAPED_CHARACTERS_IN_URL
Issue: https://issues.redhat.com/browse/UNDERTOW-1882
Upstream PR: https://github.com/undertow-io/undertow/pull/1107
2.0.x PR: #1109 