### PR TITLE
[UNDERTOW-1886] [master] Request dispatcher is returned when the path points to outside the servlet context

### DIFF
--- a/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
+++ b/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
@@ -33,17 +33,21 @@ public class CanonicalPathUtils {
 
 
     public static String canonicalize(final String path) {
+        return canonicalize(path, false);
+    }
+
+    public static String canonicalize(final String path, final boolean nullAllowed) {
         int state = START;
         for (int i = path.length() - 1; i >= 0; --i) {
             final char c = path.charAt(i);
             switch (c) {
                 case '/':
                     if (state == FIRST_SLASH) {
-                        return realCanonicalize(path, i + 1, FIRST_SLASH);
+                        return realCanonicalize(path, i + 1, FIRST_SLASH, nullAllowed);
                     } else if (state == ONE_DOT) {
-                        return realCanonicalize(path, i + 2, FIRST_SLASH);
+                        return realCanonicalize(path, i + 2, FIRST_SLASH, nullAllowed);
                     } else if (state == TWO_DOT) {
-                        return realCanonicalize(path, i + 3, FIRST_SLASH);
+                        return realCanonicalize(path, i + 3, FIRST_SLASH, nullAllowed);
                     }
                     state = FIRST_SLASH;
                     break;
@@ -59,11 +63,11 @@ public class CanonicalPathUtils {
                 case '\\':
                     if(!DONT_CANONICALIZE_BACKSLASH) {
                         if (state == FIRST_BACKSLASH) {
-                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH, nullAllowed);
                         } else if (state == ONE_DOT) {
-                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH, nullAllowed);
                         } else if (state == TWO_DOT) {
-                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH, nullAllowed);
                         }
                         state = FIRST_BACKSLASH;
                         break;
@@ -85,7 +89,7 @@ public class CanonicalPathUtils {
     static final int FIRST_BACKSLASH = 4;
 
 
-    private static String realCanonicalize(final String path, final int lastDot, final int initialState) {
+    private static String realCanonicalize(final String path, final int lastDot, final int initialState, final boolean nullAllowed) {
         int state = initialState;
         int eatCount = 0;
         int tokenEnd = path.length();
@@ -169,6 +173,10 @@ public class CanonicalPathUtils {
                     }
                 }
             }
+        }
+        if (eatCount > 0 && nullAllowed) {
+            // the relative path is outside the context and null allowed
+            return null;
         }
         final StringBuilder result = new StringBuilder();
         if (tokenEnd != 0) {

--- a/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
+++ b/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
@@ -33,21 +33,17 @@ public class CanonicalPathUtils {
 
 
     public static String canonicalize(final String path) {
-        return canonicalize(path, false);
-    }
-
-    public static String canonicalize(final String path, final boolean nullAllowed) {
         int state = START;
         for (int i = path.length() - 1; i >= 0; --i) {
             final char c = path.charAt(i);
             switch (c) {
                 case '/':
                     if (state == FIRST_SLASH) {
-                        return realCanonicalize(path, i + 1, FIRST_SLASH, nullAllowed);
+                        return realCanonicalize(path, i + 1, FIRST_SLASH);
                     } else if (state == ONE_DOT) {
-                        return realCanonicalize(path, i + 2, FIRST_SLASH, nullAllowed);
+                        return realCanonicalize(path, i + 2, FIRST_SLASH);
                     } else if (state == TWO_DOT) {
-                        return realCanonicalize(path, i + 3, FIRST_SLASH, nullAllowed);
+                        return realCanonicalize(path, i + 3, FIRST_SLASH);
                     }
                     state = FIRST_SLASH;
                     break;
@@ -63,11 +59,11 @@ public class CanonicalPathUtils {
                 case '\\':
                     if(!DONT_CANONICALIZE_BACKSLASH) {
                         if (state == FIRST_BACKSLASH) {
-                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH, nullAllowed);
+                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH);
                         } else if (state == ONE_DOT) {
-                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH, nullAllowed);
+                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH);
                         } else if (state == TWO_DOT) {
-                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH, nullAllowed);
+                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH);
                         }
                         state = FIRST_BACKSLASH;
                         break;
@@ -89,7 +85,7 @@ public class CanonicalPathUtils {
     static final int FIRST_BACKSLASH = 4;
 
 
-    private static String realCanonicalize(final String path, final int lastDot, final int initialState, final boolean nullAllowed) {
+    private static String realCanonicalize(final String path, final int lastDot, final int initialState) {
         int state = initialState;
         int eatCount = 0;
         int tokenEnd = path.length();
@@ -174,8 +170,8 @@ public class CanonicalPathUtils {
                 }
             }
         }
-        if (eatCount > 0 && nullAllowed) {
-            // the relative path is outside the context and null allowed
+        if (eatCount > 0) {
+            // the relative path is outside the context
             return null;
         }
         final StringBuilder result = new StringBuilder();

--- a/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
@@ -61,6 +61,11 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("/b", CanonicalPathUtils.canonicalize("/a/../b"));
         Assert.assertEquals("/b", CanonicalPathUtils.canonicalize("/a/../c/../e/../b"));
         Assert.assertEquals("/b", CanonicalPathUtils.canonicalize("/a/c/../../b"));
+
+        // out of servlet context
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../..", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../../foo", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/../../a/b/bar", true));
         Assert.assertEquals("/", CanonicalPathUtils.canonicalize("/a/../.."));
         Assert.assertEquals("/foo", CanonicalPathUtils.canonicalize("/a/../../foo"));
 
@@ -101,6 +106,11 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("\\b", CanonicalPathUtils.canonicalize("\\a\\..\\b"));
         Assert.assertEquals("\\b", CanonicalPathUtils.canonicalize("\\a\\..\\c\\..\\e\\..\\b"));
         Assert.assertEquals("\\b", CanonicalPathUtils.canonicalize("\\a\\c\\..\\..\\b"));
+
+         // out of servlet context
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\..\\..\\a\\b\\bar", true));
         Assert.assertEquals("/", CanonicalPathUtils.canonicalize("\\a\\..\\.."));
         Assert.assertEquals("\\foo", CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo"));
 

--- a/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
@@ -63,11 +63,9 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("/b", CanonicalPathUtils.canonicalize("/a/c/../../b"));
 
         // out of servlet context
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../..", true));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../../foo", true));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/../../a/b/bar", true));
-        Assert.assertEquals("/", CanonicalPathUtils.canonicalize("/a/../.."));
-        Assert.assertEquals("/foo", CanonicalPathUtils.canonicalize("/a/../../foo"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../.."));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../../foo"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/../../a/b/bar"));
 
         //preserve (single) trailing /
         Assert.assertEquals("/a/", CanonicalPathUtils.canonicalize("/a/"));
@@ -108,11 +106,9 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("\\b", CanonicalPathUtils.canonicalize("\\a\\c\\..\\..\\b"));
 
          // out of servlet context
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..", true));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo", true));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\..\\..\\a\\b\\bar", true));
-        Assert.assertEquals("/", CanonicalPathUtils.canonicalize("\\a\\..\\.."));
-        Assert.assertEquals("\\foo", CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\.."));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\..\\..\\a\\b\\bar"));
 
         //preserve (single) trailing \
         Assert.assertEquals("\\a\\", CanonicalPathUtils.canonicalize("\\a\\"));

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
@@ -232,4 +232,7 @@ public interface UndertowServletMessages {
 
     @Message(id = 10062, value = "No SecurityContext available")
     ServletException noSecurityContextAvailable();
+
+    @Message(id = 10063, value = "Path %s must start with a / to get the request dispatcher")
+    IllegalArgumentException pathMustStartWithSlashForRequestDispatcher(String path);
 }

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -41,7 +41,6 @@ import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.servlet.util.EmptyEnumeration;
 import io.undertow.servlet.util.IteratorEnumeration;
 import io.undertow.util.AttachmentKey;
-import io.undertow.util.CanonicalPathUtils;
 import io.undertow.util.DateUtils;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
@@ -985,18 +984,21 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
 
     @Override
     public RequestDispatcher getRequestDispatcher(final String path) {
+        if (path == null) {
+            return null;
+        }
         String realPath;
         if (path.startsWith("/")) {
-            realPath = CanonicalPathUtils.canonicalize(path);
+            realPath = path;
         } else {
             String current = exchange.getRelativePath();
             int lastSlash = current.lastIndexOf("/");
             if (lastSlash != -1) {
                 current = current.substring(0, lastSlash + 1);
             }
-            realPath = CanonicalPathUtils.canonicalize(current + path);
+            realPath = current + path;
         }
-        return new RequestDispatcherImpl(realPath, servletContext);
+        return servletContext.getRequestDispatcher(realPath);
     }
 
     @Override

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -109,11 +109,6 @@ import static io.undertow.servlet.core.ApplicationListeners.ListenerState.PROGRA
  */
 public class ServletContextImpl implements ServletContext {
 
-    /**
-     * System property to revert to previous behavior and not return null request dispatcher when out of servlet context
-     */
-    static final boolean REQUEST_DISPATCHER_NULL_ALLOWED = !Boolean.getBoolean("io.undertow.REQUEST_DISPATCHER_NULL_DISALLOWED");
-
     private final ServletContainer servletContainer;
     private final Deployment deployment;
     private volatile DeploymentInfo deploymentInfo;
@@ -349,7 +344,7 @@ public class ServletContextImpl implements ServletContext {
         if (!path.startsWith("/")) {
             throw UndertowServletMessages.MESSAGES.pathMustStartWithSlashForRequestDispatcher(path);
         }
-        final String realPath = CanonicalPathUtils.canonicalize(path, REQUEST_DISPATCHER_NULL_ALLOWED);
+        final String realPath = CanonicalPathUtils.canonicalize(path);
         if (realPath == null) {
             // path is outside the servlet context, return null per spec
             return null;

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherForwardTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherForwardTestCase.java
@@ -41,6 +41,8 @@ import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -154,6 +156,21 @@ public class DispatcherForwardTestCase {
             Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
             final String response = HttpClientUtils.readResponse(result);
             Assert.assertEquals("Name!forwarded", response);
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testNameBasedForwardOutServletContext() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/dispatch");
+            get.setHeader("forward", "../forward");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.INTERNAL_SERVER_ERROR, result.getStatusLine().getStatusCode());
+            final String response = HttpClientUtils.readResponse(result);
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("dispatcher was null!"));
         } finally {
             client.getConnectionManager().shutdown();
         }

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/ForwardServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/ForwardServlet.java
@@ -41,7 +41,11 @@ public class ForwardServlet extends HttpServlet {
         } else {
             dispatcher = req.getRequestDispatcher(req.getHeader("forward"));
         }
-        dispatcher.forward(req, resp);
+        if (dispatcher != null) {
+            dispatcher.forward(req, resp);
+        } else {
+            resp.sendError(500, "dispatcher was null!");
+        }
     }
 
     @Override


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1886

The `CanonicalPathUtils.canonicalize` now receives an optional boolean to return null when out of context. It's only used in the request dispatcher related methods. A system property `-Dio.undertow.REQUEST_DISPATCHER_NULL_DISALLOWED=true` restores the old behavior just in case. Tests addded.

PR for master.
PR for 2.1.x: https://github.com/undertow-io/undertow/pull/1118
PR for 2.0.x: https://github.com/undertow-io/undertow/pull/1119