### PR TITLE
[UNDERTOW-1872] fix ipv6 parsing with trailling empty block

### DIFF
--- a/core/src/main/java/io/undertow/util/NetworkUtils.java
+++ b/core/src/main/java/io/undertow/util/NetworkUtils.java
@@ -125,7 +125,7 @@ public class NetworkUtils {
                 data[i * 2 + partOffset + 1] = (byte) (num);
             }
         }
-        if (parts.length < 8 && !seenEmpty) {
+        if ((parts.length < 8 && !addressString.endsWith("::")) && !seenEmpty) {
             //address was too small
             throw UndertowMessages.MESSAGES.invalidIpAddress(addressString);
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1872
2.0.x PR: https://github.com/undertow-io/undertow/pull/1128