### PR TITLE
[UNDERTOW-1886] Add back non-null option to CanonicalPathUtils, while…

### DIFF
--- a/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
+++ b/core/src/main/java/io/undertow/util/CanonicalPathUtils.java
@@ -33,17 +33,21 @@ public class CanonicalPathUtils {
 
 
     public static String canonicalize(final String path) {
+        return canonicalize(path, false);
+    }
+
+    public static String canonicalize(final String path, final boolean nullAllowed) {
         int state = START;
         for (int i = path.length() - 1; i >= 0; --i) {
             final char c = path.charAt(i);
             switch (c) {
                 case '/':
                     if (state == FIRST_SLASH) {
-                        return realCanonicalize(path, i + 1, FIRST_SLASH);
+                        return realCanonicalize(path, i + 1, FIRST_SLASH, nullAllowed);
                     } else if (state == ONE_DOT) {
-                        return realCanonicalize(path, i + 2, FIRST_SLASH);
+                        return realCanonicalize(path, i + 2, FIRST_SLASH, nullAllowed);
                     } else if (state == TWO_DOT) {
-                        return realCanonicalize(path, i + 3, FIRST_SLASH);
+                        return realCanonicalize(path, i + 3, FIRST_SLASH, nullAllowed);
                     }
                     state = FIRST_SLASH;
                     break;
@@ -59,11 +63,11 @@ public class CanonicalPathUtils {
                 case '\\':
                     if(!DONT_CANONICALIZE_BACKSLASH) {
                         if (state == FIRST_BACKSLASH) {
-                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 1, FIRST_BACKSLASH, nullAllowed);
                         } else if (state == ONE_DOT) {
-                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 2, FIRST_BACKSLASH, nullAllowed);
                         } else if (state == TWO_DOT) {
-                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH);
+                            return realCanonicalize(path, i + 3, FIRST_BACKSLASH, nullAllowed);
                         }
                         state = FIRST_BACKSLASH;
                         break;
@@ -85,7 +89,7 @@ public class CanonicalPathUtils {
     static final int FIRST_BACKSLASH = 4;
 
 
-    private static String realCanonicalize(final String path, final int lastDot, final int initialState) {
+    private static String realCanonicalize(final String path, final int lastDot, final int initialState, final boolean nullAllowed) {
         int state = initialState;
         int eatCount = 0;
         int tokenEnd = path.length();
@@ -170,8 +174,8 @@ public class CanonicalPathUtils {
                 }
             }
         }
-        if (eatCount > 0) {
-            // the relative path is outside the context
+        if (eatCount > 0 && nullAllowed) {
+            // the relative path is outside the context and null allowed
             return null;
         }
         final StringBuilder result = new StringBuilder();

--- a/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
+++ b/core/src/test/java/io/undertow/util/CanonicalPathUtilsTestCase.java
@@ -63,9 +63,11 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("/b", CanonicalPathUtils.canonicalize("/a/c/../../b"));
 
         // out of servlet context
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../.."));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../../foo"));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("/../../a/b/bar"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../..", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/a/../../foo", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("/../../a/b/bar", true));
+        Assert.assertEquals("/", CanonicalPathUtils.canonicalize("/a/../.."));
+        Assert.assertEquals("/foo", CanonicalPathUtils.canonicalize("/a/../../foo"));
 
         //preserve (single) trailing /
         Assert.assertEquals("/a/", CanonicalPathUtils.canonicalize("/a/"));
@@ -106,9 +108,11 @@ public class CanonicalPathUtilsTestCase {
         Assert.assertEquals("\\b", CanonicalPathUtils.canonicalize("\\a\\c\\..\\..\\b"));
 
          // out of servlet context
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\.."));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo"));
-        Assert.assertNull(CanonicalPathUtils.canonicalize("\\..\\..\\a\\b\\bar"));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo", true));
+        Assert.assertNull(CanonicalPathUtils.canonicalize("\\..\\..\\a\\b\\bar", true));
+        Assert.assertEquals("/", CanonicalPathUtils.canonicalize("\\a\\..\\.."));
+        Assert.assertEquals("\\foo", CanonicalPathUtils.canonicalize("\\a\\..\\..\\foo"));
 
         //preserve (single) trailing \
         Assert.assertEquals("\\a\\", CanonicalPathUtils.canonicalize("\\a\\"));

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -344,7 +344,7 @@ public class ServletContextImpl implements ServletContext {
         if (!path.startsWith("/")) {
             throw UndertowServletMessages.MESSAGES.pathMustStartWithSlashForRequestDispatcher(path);
         }
-        final String realPath = CanonicalPathUtils.canonicalize(path);
+        final String realPath = CanonicalPathUtils.canonicalize(path, true);
         if (realPath == null) {
             // path is outside the servlet context, return null per spec
             return null;


### PR DESCRIPTION
… still keeping the system property out.

This partially reverts commit 66c6252073075e7c37703545160a162c3b0a6fed.

Jira https://issues.redhat.com/browse/UNDERTOW-1886
2.1.x PR: #1152 
2.0.x PR: #1153 