### PR TITLE
[UNDERTOW-1903] Upgrade XNIO to 3.8.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>2.0.1.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.3_spec>
         <version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>2.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_4.0_spec>
         <version.org.jboss.spec.javax.websockets>2.0.0.Final</version.org.jboss.spec.javax.websockets>
-        <version.xnio>3.8.0.Final</version.xnio>
+        <version.xnio>3.8.4.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
         <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>


### PR DESCRIPTION
Per details at [UNDERTOW-1903](https://issues.redhat.com/browse/UNDERTOW-1903) the current version `3.8.0.Final` is subject to CVE-2020-14340 and could do with being addressed, requiring XNIO >= `3.8.2.Final`.

Tests seem to run fine on this version - not sure what else needs to be done to further validate this or meet contributor guidelines. (Note duplicate/redundant ticket at [UNDERTOW-1861](https://issues.redhat.com/browse/UNDERTOW-1861))