### PR TITLE
UNDERTOW-1902 Undertow allows session creation and session ID change after response is committed.

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -135,4 +135,12 @@ public interface UndertowServletLogger extends BasicLogger {
 
     @Message(id = 15023, value = "This Context has been already destroyed")
     IllegalStateException contextDestroyed();
+
+    @LogMessage(level = WARN)
+    @Message(id = 15024, value = "Servlet container configured to permit session creation after response was committed. This can result in a memory leak if session has no timeout.")
+    void sessionCreationAfterResponseCommitted();
+
+    @LogMessage(level = WARN)
+    @Message(id = 15025, value = "Servlet container configured to permit session identifier changes after response was committed. This can result in a memory leak if session has no timeout.")
+    void sessionIdChangeAfterResponseCommitted();
 }

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletLogger.java
@@ -135,12 +135,4 @@ public interface UndertowServletLogger extends BasicLogger {
 
     @Message(id = 15023, value = "This Context has been already destroyed")
     IllegalStateException contextDestroyed();
-
-    @LogMessage(level = WARN)
-    @Message(id = 15024, value = "Servlet container configured to permit session creation after response was committed. This can result in a memory leak if session has no timeout.")
-    void sessionCreationAfterResponseCommitted();
-
-    @LogMessage(level = WARN)
-    @Message(id = 15025, value = "Servlet container configured to permit session identifier changes after response was committed. This can result in a memory leak if session has no timeout.")
-    void sessionIdChangeAfterResponseCommitted();
 }

--- a/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
+++ b/servlet/src/main/java/io/undertow/servlet/UndertowServletMessages.java
@@ -244,4 +244,10 @@ public interface UndertowServletMessages {
 
     //@Message(id = 10066, value = "Can not set invoke 'declareRoles' from dynamic listener in servlet context for context path '%s' in deployment '%s' ")
     //UnsupportedOperationException cantCallFromDynamicListener(String deploymentName, String contextPath);
+
+    @Message(id = 10067, value = "Servlet container does not permit session creation after response was committed.")
+    IllegalStateException sessionCreationAfterResponseCommittedNotAllowed();
+
+    @Message(id = 10068, value = "Servlet container does not permit session identifier change after response was committed.")
+    IllegalStateException sessionIdChangeAfterResponseCommittedNotAllowed();
 }

--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -111,6 +111,7 @@ public class DeploymentInfo implements Cloneable {
     private boolean sendCustomReasonPhraseOnError = false;
     private boolean useCachedAuthenticationMechanism = true;
     private boolean preservePathOnForward = true;
+    private boolean allowOrphanSession = false;
     private AuthenticationMode authenticationMode = AuthenticationMode.PRO_ACTIVE;
     private ExceptionHandler exceptionHandler;
     private final Map<String, ServletInfo> servlets = new HashMap<>();
@@ -1406,6 +1407,14 @@ public class DeploymentInfo implements Cloneable {
         return deploymentCompleteListeners;
     }
 
+    public boolean isOrphanSessionAllowed() {
+        return this.allowOrphanSession;
+    }
+
+    public void setOrphanSessionAllowed(boolean allowOrphanSession) {
+        this.allowOrphanSession = allowOrphanSession;
+    }
+
     @Override
     public DeploymentInfo clone() {
         final DeploymentInfo info = new DeploymentInfo()
@@ -1502,6 +1511,7 @@ public class DeploymentInfo implements Cloneable {
         info.containerMinorVersion = containerMinorVersion;
         info.deploymentCompleteListeners.addAll(deploymentCompleteListeners);
         info.preservePathOnForward = preservePathOnForward;
+        info.allowOrphanSession = allowOrphanSession;
         return info;
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -381,7 +381,7 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
             if (!this.servletContext.getDeployment().getDeploymentInfo().isOrphanSessionAllowed()) {
                 throw UndertowServletMessages.MESSAGES.sessionIdChangeAfterResponseCommittedNotAllowed();
             }
-            UndertowServletLogger.REQUEST_LOGGER.sessionIdChangeAfterResponseCommitted();
+            UndertowServletLogger.REQUEST_LOGGER.debug("Servlet container configured to permit session identifier changes after response was committed. This can result in a memory leak if session has no timeout.");
         }
         String oldId = session.getId();
         Session underlyingSession;

--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletRequestImpl.java
@@ -28,6 +28,7 @@ import io.undertow.server.handlers.form.MultiPartParserDefinition;
 import io.undertow.server.protocol.http.HttpAttachments;
 import io.undertow.server.session.Session;
 import io.undertow.server.session.SessionConfig;
+import io.undertow.servlet.UndertowServletLogger;
 import io.undertow.servlet.UndertowServletMessages;
 import io.undertow.servlet.api.AuthorizationManager;
 import io.undertow.servlet.api.Deployment;
@@ -375,6 +376,12 @@ public final class HttpServletRequestImpl implements HttpServletRequest {
         HttpSessionImpl session = servletContext.getSession(originalServletContext, exchange, false);
         if (session == null) {
             throw UndertowServletMessages.MESSAGES.noSession();
+        }
+        if (this.exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY).getServletResponse().isCommitted()) {
+            if (!this.servletContext.getDeployment().getDeploymentInfo().isOrphanSessionAllowed()) {
+                throw UndertowServletMessages.MESSAGES.sessionIdChangeAfterResponseCommittedNotAllowed();
+            }
+            UndertowServletLogger.REQUEST_LOGGER.sessionIdChangeAfterResponseCommitted();
         }
         String oldId = session.getId();
         Session underlyingSession;

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -885,7 +885,7 @@ public class ServletContextImpl implements ServletContext {
                     if (!this.deployment.getDeploymentInfo().isOrphanSessionAllowed()) {
                         throw UndertowServletMessages.MESSAGES.sessionCreationAfterResponseCommittedNotAllowed();
                     }
-                    UndertowServletLogger.REQUEST_LOGGER.sessionCreationAfterResponseCommitted();
+                    UndertowServletLogger.REQUEST_LOGGER.debug("Servlet container configured to permit session creation after response was committed. This can result in a memory leak if session has no timeout.");
                 }
 
                 String existing = c.findSessionId(exchange);

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -881,6 +881,13 @@ public class ServletContextImpl implements ServletContext {
                 exchange.putAttachment(sessionAttachmentKey, httpSession);
             } else if (create) {
 
+                if (exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY).getServletResponse().isCommitted()) {
+                    if (!this.deployment.getDeploymentInfo().isOrphanSessionAllowed()) {
+                        throw UndertowServletMessages.MESSAGES.sessionCreationAfterResponseCommittedNotAllowed();
+                    }
+                    UndertowServletLogger.REQUEST_LOGGER.sessionCreationAfterResponseCommitted();
+                }
+
                 String existing = c.findSessionId(exchange);
                 Boolean isRequestedSessionIdSaved = exchange.getAttachment(HttpServletRequestImpl.REQUESTED_SESSION_ID_SET);
                 if (isRequestedSessionIdSaved == null || !isRequestedSessionIdSaved) {


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-1902

@fl4via Please review.  I can backport to the relevant branches once you are satisfied.

When integrating into WildFly, we will want to expose this configuration via the ServletContainer management model.