### PR TITLE
[UNDERTOW-1950] Fix NullPointerException in PreCompressedResourceSupplier

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/file/data1.json
+++ b/core/src/test/java/io/undertow/server/handlers/file/data1.json
@@ -1,0 +1,21 @@
+{
+  "undertow": {
+    "title": "compressed resource",
+    "subtype": {
+      "method": "test json compressed resource",
+      "listInfo": {
+        "test": {
+          "json": "js",
+          "compressed": "c",
+          "resource": "this file",
+          "type": "data",
+          "def": {
+            "thisFile": "Test purposes",
+            "seeAlso": ["data2", "json"]
+          },
+          "See": "compression"
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/io/undertow/server/handlers/file/data2.json
+++ b/core/src/test/java/io/undertow/server/handlers/file/data2.json
@@ -1,0 +1,21 @@
+{
+  "undertow": {
+    "title": "compressed resource",
+    "subtype": {
+      "method": "test json compressed resource",
+      "listInfo": {
+        "test": {
+          "json": "js",
+          "compressed": "c",
+          "resource": "this file",
+          "type": "data",
+          "def": {
+            "thisFile": "Test purposes",
+            "seeAlso": ["data1", "json"]
+          },
+          "See": "compression"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes a `NullPointerException` that can occur when using a `PreCompressedResourceSupplier` and trying to access a file where only the compressed version exists.

**For example:**
Currently, if there is a file `data.json.gz` without the uncompressed version `data.json`, then a GET request to that file `data.json` results in a NullPointerException and a `500`-response:
```
java.lang.NullPointerException: Cannot invoke "io.undertow.server.handlers.resource.Resource.getContentType(io.undertow.util.MimeMappings)" because "this.val$originalResource" is null
	at io.undertow.server.handlers.resource.PreCompressedResourceSupplier$1.getContentType(PreCompressedResourceSupplier.java:121)
	at io.undertow.server.handlers.resource.ResourceHandler$1.handleRequest(ResourceHandler.java:299)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:370)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:830)
```

With this PR, supplying a pre-compressed resource is no longed dependant on the original resource.

This is achieved by trying to resolve the MIME-Type on our own, instead of asking the original-resource. 
*This might introduce some minor assumptions on the type of the resource, so that would be something to look out for when reviewing this PR :)*