### PR TITLE
feat: added two getter methods in DeploymentInfo class

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -409,9 +409,17 @@ public class DeploymentInfo implements Cloneable {
         return this;
     }
 
+    public List<FilterMappingInfo> getFilterUrlMappings(){
+        return filterUrlMappings;
+    }
+
     public DeploymentInfo addFilterServletNameMapping(final String filterName, final String mapping, DispatcherType dispatcher) {
         filterServletNameMappings.add(new FilterMappingInfo(filterName, FilterMappingInfo.MappingType.SERVLET, mapping, dispatcher));
         return this;
+    }
+
+    public List<FilterMappingInfo> getFilterServletNameMappings(){
+        return filterServletNameMappings;
     }
 
     public DeploymentInfo insertFilterUrlMapping(final int pos, final String filterName, final String mapping, DispatcherType dispatcher) {


### PR DESCRIPTION
add to DeploymentInfo class the getter methods getFilterUrlMapping() and getFilterServletNameMapping() returning
lists with their corresponding data