### PR TITLE
[UNDERTOW-1932] - unify SSLContext manipulation flow

### DIFF
--- a/core/src/main/java/io/undertow/UndertowMessages.java
+++ b/core/src/main/java/io/undertow/UndertowMessages.java
@@ -621,4 +621,11 @@ public interface UndertowMessages {
 
     @Message(id = 199, value = "Read timed out after %s milliseconds.")
     ReadTimeoutException readTimedOut(long timeoutMilliseconds);
+
+    @Message(id = 200, value = "Failed to replace hash output stream ")
+    SSLException failedToReplaceHashOutputStream(@Cause Exception e);
+
+    @Message(id = 201, value = "Failed to replace hash output stream ")
+    RuntimeException failedToReplaceHashOutputStreamOnWrite(@Cause Exception e);
+
 }

--- a/core/src/main/java/io/undertow/protocols/ssl/ALPNHackSSLEngine.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/ALPNHackSSLEngine.java
@@ -19,6 +19,7 @@
 package io.undertow.protocols.ssl;
 
 import io.undertow.UndertowLogger;
+import io.undertow.UndertowMessages;
 
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
@@ -408,7 +409,7 @@ public class ALPNHackSSLEngine extends SSLEngine {
     }
 
 
-    static ALPNHackServerByteArrayOutputStream replaceServerByteOutput(SSLEngine sslEngine, String selectedAlpnProtocol) {
+    static ALPNHackServerByteArrayOutputStream replaceServerByteOutput(SSLEngine sslEngine, String selectedAlpnProtocol) throws SSLException {
         try {
             Object handshaker = HANDSHAKER.get(sslEngine);
             Object hash = HANDSHAKE_HASH.get(handshaker);
@@ -418,12 +419,11 @@ public class ALPNHackSSLEngine extends SSLEngine {
             HANDSHAKE_HASH_DATA.set(hash, out);
             return out;
         } catch (Exception e) {
-            UndertowLogger.ROOT_LOGGER.debug("Failed to replace hash output stream ", e);
-            return null;
+            throw UndertowMessages.MESSAGES.failedToReplaceHashOutputStream(e);
         }
     }
 
-    static ALPNHackClientByteArrayOutputStream replaceClientByteOutput(SSLEngine sslEngine) {
+    static ALPNHackClientByteArrayOutputStream replaceClientByteOutput(SSLEngine sslEngine) throws SSLException {
         try {
             Object handshaker = HANDSHAKER.get(sslEngine);
             Object hash = HANDSHAKE_HASH.get(handshaker);
@@ -432,8 +432,7 @@ public class ALPNHackSSLEngine extends SSLEngine {
             HANDSHAKE_HASH_DATA.set(hash, out);
             return out;
         } catch (Exception e) {
-            UndertowLogger.ROOT_LOGGER.debug("Failed to replace hash output stream ", e);
-            return null;
+            throw UndertowMessages.MESSAGES.failedToReplaceHashOutputStream(e);
         }
     }
     static void regenerateHashes(SSLEngine sslEngineToHack, ByteArrayOutputStream data, byte[]... hashBytes) {
@@ -451,8 +450,7 @@ public class ALPNHackSSLEngine extends SSLEngine {
                 HANDSHAKE_HASH_UPDATE.invoke(hash, b, 0, b.length);
             }
         } catch (Exception e) {
-            e.printStackTrace(); //TODO: remove
-            throw new RuntimeException(e);
+            throw UndertowMessages.MESSAGES.failedToReplaceHashOutputStreamOnWrite(e);
         }
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1932

Decided to throw exceptions and not silently log as debug - since one of methods already failed like that. Maybe its wrong, but I cant see it.