### PR TITLE
[UNDERTOW-1941] At Http2ClientTestCase.afterClass(), check if server …

### DIFF
--- a/core/src/test/java/io/undertow/client/http/Http2ClientTestCase.java
+++ b/core/src/test/java/io/undertow/client/http/Http2ClientTestCase.java
@@ -147,8 +147,10 @@ public class Http2ClientTestCase {
 
     @AfterClass
     public static void afterClass() {
-        server.stop();
-        worker.shutdown();
+        if (server != null)
+            server.stop();
+        if (worker != null)
+            worker.shutdown();
     }
 
     static UndertowClient createClient() {


### PR DESCRIPTION
…and worker are not null before stopping and shutting down

Jira: https://issues.redhat.com/browse/UNDERTOW-1941