### PR TITLE
[UNDERTOW-1959] Last attempt to increase the timeout for DefaultServl…

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletCachingListenerTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletCachingListenerTestCase.java
@@ -67,8 +67,8 @@ import org.xnio.BufferAllocator;
 public class DefaultServletCachingListenerTestCase {
 
     private static final int MAX_FILE_SIZE = 20;
-    private static final int MAX_WAIT_TIME = 30000;
-    private static final int WAIT_TIME = 1000;
+    private static final int MAX_WAIT_TIME = 300000;
+    private static final int WAIT_TIME = 10000;
     public static final String DIR_NAME = "cacheTest";
 
     private static Path tmpDir;


### PR DESCRIPTION
…etCachingListenerTestCase and solve the test failure.

If the failure reoccurs on CI, it means it is probably not a problem with a short timeout.

Jira: https://issues.redhat.com/browse/UNDERTOW-1959