### PR TITLE
[UNDERTOW-1910] Remove UndertowOptions.DEFAULT_WRITE_TIMEOUT, and add…

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -24,12 +24,6 @@ import org.xnio.Option;
  * @author Stuart Douglas
  */
 public class UndertowOptions {
-
-    /**
-     * The maximum timeout to wait on awaitWritable in milisseconds when not specified.
-     */
-    public static final int DEFAULT_WRITE_TIMEOUT = 600000;
-
     /**
      * The maximum size in bytes of a http request header.
      */


### PR DESCRIPTION
… system property io.undertow.await_writable_timeout

Jira: https://issues.redhat.com/browse/UNDERTOW-1910
follows up #1217 #1192 
2.0.x PR: #1247 