### PR TITLE
UNDERTOW-1964 IPAddressAccessControlHandler stops working when ProxyPeerAddressHandler is enabled and X-Forwarded-For request header contains multiple IP addresses

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/ProxyPeerAddressHandler.java
@@ -70,9 +70,9 @@ public class ProxyPeerAddressHandler implements HttpHandler {
         if (forwardedFor != null) {
             String remoteClient = mostRecent(forwardedFor);
             //we have no way of knowing the port
-            if(IP4_EXACT.matcher(forwardedFor).matches()) {
+            if (IP4_EXACT.matcher(remoteClient).matches()) {
                 exchange.setSourceAddress(new InetSocketAddress(NetworkUtils.parseIpv4Address(remoteClient), 0));
-            } else if(IP6_EXACT.matcher(forwardedFor).matches()) {
+            } else if (IP6_EXACT.matcher(remoteClient).matches()) {
                 exchange.setSourceAddress(new InetSocketAddress(NetworkUtils.parseIpv6Address(remoteClient), 0));
             } else {
                 exchange.setSourceAddress(InetSocketAddress.createUnresolved(remoteClient, 0));

--- a/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerWithProxyPeerAddressHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerWithProxyPeerAddressHandlerTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.server.handlers;
+
+import java.io.IOException;
+
+import io.undertow.Handlers;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(DefaultServer.class)
+public class IPAddressAccessControlHandlerWithProxyPeerAddressHandlerTestCase {
+
+    @BeforeClass
+    public static void setup() {
+        HttpHandler rootHandler = new HttpHandler() {
+            @Override
+            public void handleRequest(HttpServerExchange exchange) throws Exception {
+                exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+                exchange.getResponseSender().send(exchange.getSourceAddress().getHostString());
+            }
+        };
+        DefaultServer.setRootHandler(Handlers.proxyPeerAddress(Handlers.ipAccessControl(rootHandler, false).addAllow("127.0.0.0/8")));
+    }
+
+    @Test
+    public void testWithoutXForwardedFor() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.contains("127.0.0.1"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testWithXForwardedFor1() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            get.addHeader(Headers.X_FORWARDED_FOR_STRING, "127.0.0.2");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.contains("127.0.0.2"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testWithXForwardedFor2() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            get.addHeader(Headers.X_FORWARDED_FOR_STRING, "127.0.0.1, 192.168.0.10");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.contains("127.0.0.1"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testWithXForwardedFor3() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            get.addHeader(Headers.X_FORWARDED_FOR_STRING, "127.0.0.1, 127.0.0.2, 192.168.0.10");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.contains("127.0.0.1"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testForbiddenWithXForwardedFor1() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            get.addHeader(Headers.X_FORWARDED_FOR_STRING, "192.168.0.10");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.isEmpty());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testForbiddenWithXForwardedFor2() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL());
+            get.addHeader(Headers.X_FORWARDED_FOR_STRING, "192.168.0.10, 192.168.0.20");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            Assert.assertTrue(response.isEmpty());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+}

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -204,6 +204,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
     private static final boolean dump = Boolean.getBoolean("test.dump");
     private static final boolean single = Boolean.getBoolean("test.single");
     private static final boolean openssl = Boolean.getBoolean("test.openssl");
+    private static final boolean ipv6 = Boolean.getBoolean("test.ipv6");
     private static final int runs = Integer.getInteger("test.runs", 1);
 
     private static final DelegatingHandler rootHandler = new DelegatingHandler();
@@ -672,6 +673,21 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 return;
             }
         }
+        if (ipv6) {
+            if (method.getAnnotation(IPv6Ignore.class) != null ||
+                    method.getMethod().getDeclaringClass().isAnnotationPresent(IPv6Ignore.class) ||
+                    getTestClass().getJavaClass().isAnnotationPresent(IPv6Ignore.class)) {
+                notifier.fireTestIgnored(describeChild(method));
+                return;
+            }
+        } else {
+            if (method.getAnnotation(IPv6Only.class) != null ||
+                    method.getMethod().getDeclaringClass().isAnnotationPresent(IPv6Only.class) ||
+                    getTestClass().getJavaClass().isAnnotationPresent(IPv6Only.class)) {
+                notifier.fireTestIgnored(describeChild(method));
+                return;
+            }
+        }
         try {
             if (runs > 1) {
                 Statement statement = methodBlock(method);
@@ -710,6 +726,9 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
             }
             if (h2cUpgrade) {
                 sb.append("[http2-clear-upgrade]");
+            }
+            if (ipv6) {
+                sb.append("[ipv6]");
             }
             return sb.toString();
         }
@@ -965,6 +984,10 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
 
     public static boolean isH2upgrade() {
         return h2cUpgrade;
+    }
+
+    public static boolean isIpv6() {
+        return ipv6;
     }
 
     /**

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -443,7 +443,15 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                     proxyOpenListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true));
                     proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                     proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
-                    proxyOpenListener.setRootHandler(new ProxyHandler(loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER).addHost(new URI("ajp", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null)), 120000, HANDLE_404));
+                    loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .addHost(new URI("ajp", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null));
+                    ProxyHandler proxyHandler = ProxyHandler.builder()
+                        .setProxyClient(loadBalancingProxyClient)
+                        .setMaxRequestTime(120000)
+                        .setNext(HANDLE_404)
+                        .setReuseXForwarded(true)
+                        .build();
+                    proxyOpenListener.setRootHandler(proxyHandler);
                     proxyServer.resumeAccepts();
                 }
             } else if (h2 && isAlpnEnabled()) {
@@ -457,8 +465,14 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyOpenListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true));
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
-                ProxyHandler proxyHandler = new ProxyHandler(loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
-                        .addHost(new URI("h2", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, new UndertowXnioSsl(xnio, OptionMap.EMPTY, SSL_BUFFER_POOL, clientContext), OptionMap.create(UndertowOptions.ENABLE_HTTP2, true)), 120000, HANDLE_404);
+                loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                    .addHost(new URI("h2", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, new UndertowXnioSsl(xnio, OptionMap.EMPTY, SSL_BUFFER_POOL, clientContext), OptionMap.create(UndertowOptions.ENABLE_HTTP2, true));
+                ProxyHandler proxyHandler = ProxyHandler.builder()
+                    .setProxyClient(loadBalancingProxyClient)
+                    .setMaxRequestTime(120000)
+                    .setNext(HANDLE_404)
+                    .setReuseXForwarded(true)
+                    .build();
                 setupProxyHandlerForSSL(proxyHandler);
                 proxyOpenListener.setRootHandler(proxyHandler);
                 proxyServer.resumeAccepts();
@@ -472,8 +486,14 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyOpenListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true));
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
-                ProxyHandler proxyHandler = new ProxyHandler(loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
-                        .addHost(new URI(h2cUpgrade ? "http" : "h2c-prior", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, null, OptionMap.create(UndertowOptions.ENABLE_HTTP2, true)), 30000, HANDLE_404);
+                loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .addHost(new URI(h2cUpgrade ? "http" : "h2c-prior", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, null, OptionMap.create(UndertowOptions.ENABLE_HTTP2, true));
+                ProxyHandler proxyHandler = ProxyHandler.builder()
+                    .setProxyClient(loadBalancingProxyClient)
+                    .setMaxRequestTime(30000)
+                    .setNext(HANDLE_404)
+                    .setReuseXForwarded(true)
+                    .build();
                 setupProxyHandlerForSSL(proxyHandler);
                 proxyOpenListener.setRootHandler(proxyHandler);
                 proxyServer.resumeAccepts();
@@ -489,8 +509,14 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyOpenListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true));
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
-                ProxyHandler proxyHandler = new ProxyHandler(loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER).addHost(new URI("https", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), clientSsl), 30000,
-                        HANDLE_404);
+                loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                    .addHost(new URI("https", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), clientSsl);
+                ProxyHandler proxyHandler = ProxyHandler.builder()
+                    .setProxyClient(loadBalancingProxyClient)
+                    .setMaxRequestTime(30000)
+                    .setNext(HANDLE_404)
+                    .setReuseXForwarded(true)
+                    .build();
                 setupProxyHandlerForSSL(proxyHandler);
                 proxyOpenListener.setRootHandler(proxyHandler);
                 proxyServer.resumeAccepts();
@@ -510,8 +536,14 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                     proxyOpenListener = new HttpOpenListener(pool, OptionMap.create(UndertowOptions.BUFFER_PIPELINED_DATA, true));
                     proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                     proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
-                    ProxyHandler proxyHandler = new ProxyHandler(loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER).addHost(new URI("http", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null)), 30000,
-                            HANDLE_404);
+                    loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .addHost(new URI("http", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null));
+                    ProxyHandler proxyHandler = ProxyHandler.builder()
+                        .setProxyClient(loadBalancingProxyClient)
+                        .setMaxRequestTime(30000)
+                        .setNext(HANDLE_404)
+                        .setReuseXForwarded(true)
+                        .build();
                     setupProxyHandlerForSSL(proxyHandler);
                     proxyOpenListener.setRootHandler(proxyHandler);
                     proxyServer.resumeAccepts();

--- a/core/src/test/java/io/undertow/testutils/IPv6Ignore.java
+++ b/core/src/test/java/io/undertow/testutils/IPv6Ignore.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.testutils;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Inherited
+public @interface IPv6Ignore {
+
+    String value() default "";
+
+}

--- a/core/src/test/java/io/undertow/testutils/IPv6Only.java
+++ b/core/src/test/java/io/undertow/testutils/IPv6Only.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.testutils;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Inherited
+public @interface IPv6Only {
+
+    String value() default "";
+
+}


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-1964
Master PR: #1245 