### PR TITLE
[UNDERTOW-2025][UNDERTOW-1981] Test that client cannot access files inside of meta-info sub folder

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletTestCase.java
@@ -260,6 +260,18 @@ public class DefaultServletTestCase {
     }
 
     @Test
+    public void testNoAccessToMetaInfResource() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/meta-inf/secret");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.NOT_FOUND, result.getStatusLine().getStatusCode());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
     public void testDirectoryListing() throws IOException {
         TestHttpClient client = new TestHttpClient();
         try {

--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/meta-inf/secret
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/meta-inf/secret
@@ -1,0 +1,1 @@
+confidential


### PR DESCRIPTION
This PR tries to add a test for issue: https://issues.redhat.com/browse/UNDERTOW-1981