### PR TITLE
UNDERTOW-2015 URLUtils QueryStringParser#parse() should not add a que…

### DIFF
--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -263,7 +263,7 @@ public class URLUtils {
                             if(++count > max) {
                                 throw UndertowMessages.MESSAGES.tooManyParameters(max);
                             }
-                        } else {
+                        } else if (stringStart != i) { // Ignore if attrName == null and stringStart == i because it means both key and value are empty.
                             handle(exchange, decode(charset, string.substring(stringStart, i), doDecode), "");
                             if(++count > max) {
                                 throw UndertowMessages.MESSAGES.tooManyParameters(max);

--- a/core/src/test/java/io/undertow/server/handlers/QueryParametersTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/QueryParametersTestCase.java
@@ -92,6 +92,7 @@ public class QueryParametersTestCase {
             runTest(client, "{unicode=>Iñtërnâtiônàližætiøn}", "/path?unicode=Iñtërnâtiônàližætiøn");
             runTest(client, "{a=>b,value=>bb bb}", "/path?a=b&value=bb%20bb");
             runTest(client, "{a=>b,value=>[bb,cc]}", "/path?a=b&value=bb&value=cc");
+            runTest(client, "{a=>b,value=>[bb,cc]}", "/path?&a=b&value=bb&&value=cc"); // Specifing some query parameters with empty by intentional for the test purpose. These should be ignored.
             runTest(client, "{a=>b,s =>,t =>,value=>[bb,cc]}", "/path?a=b&value=bb&value=cc&s%20&t%20");
             runTest(client, "{a=>b,s =>,t =>,value=>[bb,cc]}", "/path?a=b&value=bb&value=cc&s%20&t%20&");
             runTest(client, "{a=>b,s =>,t =>,u=>,value=>[bb,cc]}", "/path?a=b&value=bb&value=cc&s%20&t%20&u");


### PR DESCRIPTION
…ry parameter to HttpServerExchange when parameter name and value are empty

https://issues.redhat.com/browse/UNDERTOW-2015