### PR TITLE
UNDERTOW-2017 debugging 

### DIFF
--- a/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
+++ b/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
@@ -280,11 +280,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                             do {
                                 res = writeNext(buffer);
                                 if (res == 0) {
-                                    this.string = string;
-                                    this.headerName = headerName;
-                                    this.charIndex = charIndex;
-                                    this.valueIterator = valueIterator;
-                                    this.nameIterator = nameIterator;
                                     log.trace("Continuation");
                                     return STATE_HDR_EOL_CR;
                                 }
@@ -297,11 +292,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                             do {
                                 res = writeNext(buffer);
                                 if (res == 0) {
-                                    this.string = string;
-                                    this.headerName = headerName;
-                                    this.charIndex = charIndex;
-                                    this.valueIterator = valueIterator;
-                                    this.nameIterator = nameIterator;
                                     log.trace("Continuation");
                                     return STATE_HDR_EOL_LF;
                                 }
@@ -320,11 +310,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     res = writeNext(buffer);
                                     if (res == 0) {
-                                        this.string = string;
-                                        this.headerName = headerName;
-                                        this.charIndex = charIndex;
-                                        this.valueIterator = valueIterator;
-                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_HDR_FINAL_CR;
                                     }
@@ -337,11 +322,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     res = writeNext(buffer);
                                     if (res == 0) {
-                                        this.string = string;
-                                        this.headerName = headerName;
-                                        this.charIndex = charIndex;
-                                        this.valueIterator = valueIterator;
-                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_HDR_FINAL_LF;
                                     }
@@ -367,11 +347,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     long r = next.write(b, 0, b.length);
                                     if (r == 0 && buffer.hasRemaining()) {
-                                        this.string = string;
-                                        this.headerName = headerName;
-                                        this.charIndex = charIndex;
-                                        this.valueIterator = valueIterator;
-                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_BUF_FLUSH;
                                     }
@@ -393,11 +368,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_EOL_CR;
                             }
@@ -412,11 +382,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_EOL_LF;
                             }
@@ -441,11 +406,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_FINAL_CR;
                             }
@@ -461,11 +421,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_FINAL_LF;
                             }
@@ -482,11 +437,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_BUF_FLUSH;
                             }
@@ -496,11 +446,6 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             long r = next.write(b, 0, b.length);
                             if (r == 0 && buffer.hasRemaining()) {
-                                this.string = string;
-                                this.headerName = headerName;
-                                this.charIndex = charIndex;
-                                this.valueIterator = valueIterator;
-                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_BUF_FLUSH;
                             }

--- a/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
+++ b/core/src/main/java/io/undertow/client/http/HttpRequestConduit.java
@@ -280,7 +280,9 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                             do {
                                 res = writeNext(buffer);
                                 if (res == 0) {
+                                    this.string = string;
                                     this.headerName = headerName;
+                                    this.charIndex = charIndex;
                                     this.valueIterator = valueIterator;
                                     this.nameIterator = nameIterator;
                                     log.trace("Continuation");
@@ -295,7 +297,9 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                             do {
                                 res = writeNext(buffer);
                                 if (res == 0) {
+                                    this.string = string;
                                     this.headerName = headerName;
+                                    this.charIndex = charIndex;
                                     this.valueIterator = valueIterator;
                                     this.nameIterator = nameIterator;
                                     log.trace("Continuation");
@@ -316,6 +320,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     res = writeNext(buffer);
                                     if (res == 0) {
+                                        this.string = string;
+                                        this.headerName = headerName;
+                                        this.charIndex = charIndex;
+                                        this.valueIterator = valueIterator;
+                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_HDR_FINAL_CR;
                                     }
@@ -328,6 +337,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     res = writeNext(buffer);
                                     if (res == 0) {
+                                        this.string = string;
+                                        this.headerName = headerName;
+                                        this.charIndex = charIndex;
+                                        this.valueIterator = valueIterator;
+                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_HDR_FINAL_LF;
                                     }
@@ -353,6 +367,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                                 do {
                                     long r = next.write(b, 0, b.length);
                                     if (r == 0 && buffer.hasRemaining()) {
+                                        this.string = string;
+                                        this.headerName = headerName;
+                                        this.charIndex = charIndex;
+                                        this.valueIterator = valueIterator;
+                                        this.nameIterator = nameIterator;
                                         log.trace("Continuation");
                                         return STATE_BUF_FLUSH;
                                     }
@@ -374,7 +393,9 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
+                                this.string = string;
                                 this.headerName = headerName;
+                                this.charIndex = charIndex;
                                 this.valueIterator = valueIterator;
                                 this.nameIterator = nameIterator;
                                 log.trace("Continuation");
@@ -391,7 +412,9 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
+                                this.string = string;
                                 this.headerName = headerName;
+                                this.charIndex = charIndex;
                                 this.valueIterator = valueIterator;
                                 this.nameIterator = nameIterator;
                                 log.trace("Continuation");
@@ -418,6 +441,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
+                                this.string = string;
+                                this.headerName = headerName;
+                                this.charIndex = charIndex;
+                                this.valueIterator = valueIterator;
+                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_FINAL_CR;
                             }
@@ -433,6 +461,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
+                                this.string = string;
+                                this.headerName = headerName;
+                                this.charIndex = charIndex;
+                                this.valueIterator = valueIterator;
+                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_HDR_FINAL_LF;
                             }
@@ -449,6 +482,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             res = writeNext(buffer);
                             if (res == 0) {
+                                this.string = string;
+                                this.headerName = headerName;
+                                this.charIndex = charIndex;
+                                this.valueIterator = valueIterator;
+                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_BUF_FLUSH;
                             }
@@ -458,6 +496,11 @@ final class HttpRequestConduit extends AbstractStreamSinkConduit<StreamSinkCondu
                         do {
                             long r = next.write(b, 0, b.length);
                             if (r == 0 && buffer.hasRemaining()) {
+                                this.string = string;
+                                this.headerName = headerName;
+                                this.charIndex = charIndex;
+                                this.valueIterator = valueIterator;
+                                this.nameIterator = nameIterator;
                                 log.trace("Continuation");
                                 return STATE_BUF_FLUSH;
                             }

--- a/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
@@ -257,10 +257,7 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
                 return res = next.read(dst);
             }
         } catch (IOException | RuntimeException | Error e) {
-            HttpServerExchange exchangeSnapshot = exchange;
-            if (exchangeSnapshot != null) {
-                IoUtils.safeClose(exchangeSnapshot.getConnection());
-            }
+            IoUtils.safeClose(exchange.getConnection());
             readError = e;
             throw e;
         }  finally {

--- a/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/FixedLengthStreamSourceConduit.java
@@ -257,7 +257,10 @@ public final class FixedLengthStreamSourceConduit extends AbstractStreamSourceCo
                 return res = next.read(dst);
             }
         } catch (IOException | RuntimeException | Error e) {
-            IoUtils.safeClose(exchange.getConnection());
+            HttpServerExchange exchangeSnapshot = exchange;
+            if (exchangeSnapshot != null) {
+                IoUtils.safeClose(exchangeSnapshot.getConnection());
+            }
             readError = e;
             throw e;
         }  finally {

--- a/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
+++ b/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
@@ -190,13 +190,14 @@ public class HttpClientTestCase {
         final UndertowClient client = createClient();
 
         final List<ClientResponse> responses = new CopyOnWriteArrayList<>();
-        final CountDownLatch latch = new CountDownLatch(10);
+        final int iterations = 100;
+        final CountDownLatch latch = new CountDownLatch(iterations);
         final ClientConnection connection = client.connect(ADDRESS, worker, getBufferPool(), OptionMap.EMPTY).get();
         try {
             connection.getIoThread().execute(new Runnable() {
                 @Override
                 public void run() {
-                    for (int i = 0; i < 10; i++) {
+                    for (int i = 0; i < iterations; i++) {
                         final ClientRequest request = new ClientRequest().setMethod(Methods.GET).setPath(MESSAGE);
                         request.getRequestHeaders().put(Headers.HOST, DefaultServer.getHostAddress());
                         for (int j = 0; j < 100; j++) {
@@ -211,7 +212,7 @@ public class HttpClientTestCase {
 
             latch.await(10, TimeUnit.SECONDS);
 
-            Assert.assertEquals(10, responses.size());
+            Assert.assertEquals(iterations, responses.size());
             for (final ClientResponse response : responses) {
                 Assert.assertEquals(message, response.getAttachment(RESPONSE_BODY));
             }


### PR DESCRIPTION
It appears that transitions between states fail to store
relevant data -- this is difficult to reproduce locally because
tests use loopback or otherwise fast networks. By introducing
small buffers and writes that often make no progress, we can
reproduce issues from slower networks.