### PR TITLE
[Concept] BlockHound integration across undertow tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -151,6 +151,11 @@
             <version>${version.org.wildfly.openssl}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.tools</groupId>
+            <artifactId>blockhound</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
+++ b/core/src/main/java/io/undertow/server/protocol/framed/AbstractFramedChannel.java
@@ -33,8 +33,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -106,7 +106,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
      * new frames to be sent. These will be added to either the pending or held frames list
      * depending on the {@link #framePriority} implementation in use.
      */
-    private final Deque<S> newFrames = new LinkedBlockingDeque<>();
+    private final Deque<S> newFrames = new ConcurrentLinkedDeque<>();
 
     private volatile long frameDataRemaining;
     private volatile R receiver;
@@ -135,7 +135,7 @@ public abstract class AbstractFramedChannel<C extends AbstractFramedChannel<C, R
     private volatile int outstandingBuffers;
     private static final AtomicIntegerFieldUpdater<AbstractFramedChannel> outstandingBuffersUpdater = AtomicIntegerFieldUpdater.newUpdater(AbstractFramedChannel.class, "outstandingBuffers");
 
-    private final LinkedBlockingDeque<Runnable> taskRunQueue = new LinkedBlockingDeque<>();
+    private final Deque<Runnable> taskRunQueue = new ConcurrentLinkedDeque<>();
     private final Runnable taskRunQueueRunnable = new Runnable() {
         @Override
         public void run() {

--- a/core/src/main/java/io/undertow/util/Internal.java
+++ b/core/src/main/java/io/undertow/util/Internal.java
@@ -1,0 +1,31 @@
+package io.undertow.util;
+
+import org.xnio.XnioIoThread;
+import reactor.blockhound.BlockHound;
+import reactor.blockhound.integration.BlockHoundIntegration;
+
+final class Internal {
+
+    public static final class UndertowBlockHoundIntegration implements BlockHoundIntegration {
+        @Override
+        public void applyTo(BlockHound.Builder builder) {
+            builder
+                    // Result of a yield when the lock is held. This isn't necessary in jboss-threads 3.1.1.Final
+                    // .allowBlockingCallsInside("org.jboss.threads.EnhancedQueueExecutorBase1", "lockTail")
+
+                    // Session creation uses a SecureRandom created using 'new SecureRandom()'. This may be a bug.
+                    // If this module is shipped for undertow consumers, it would be better to enumerate the known
+                    // undertow call-sites rather than allowing this method explicitly.
+                    .allowBlockingCallsInside("sun.security.provider.NativePRNG", "engineNextBytes")
+
+                    // Working as intended
+                    .allowBlockingCallsInside("org.xnio.nio.WorkerThread$SynchTask", "run")
+                    // Wrap and Unwrap read random data from NativePRNG$NonBlocking which shouldn't block
+                    // https://bugs.openjdk.java.net/browse/JDK-8251304
+                    .allowBlockingCallsInside("sun.security.ssl.SSLEngineImpl", "wrap")
+                    .allowBlockingCallsInside("sun.security.ssl.SSLEngineImpl", "unwrap")
+                    .nonBlockingThreadPredicate(next -> next.or(thread -> thread instanceof XnioIoThread));
+        }
+    }
+
+}

--- a/core/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
+++ b/core/src/main/resources/META-INF/services/reactor.blockhound.integration.BlockHoundIntegration
@@ -1,0 +1,1 @@
+io.undertow.util.Internal$UndertowBlockHoundIntegration

--- a/core/src/test/java/io/undertow/server/handlers/GracefulShutdownTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/GracefulShutdownTestCase.java
@@ -52,7 +52,7 @@ public class GracefulShutdownTestCase {
     @BeforeClass
     public static void setup() {
 
-        shutdown = Handlers.gracefulShutdown(new HttpHandler() {
+        shutdown = Handlers.gracefulShutdown(new BlockingHandler(new HttpHandler() {
             @Override
             public void handleRequest(HttpServerExchange exchange) throws Exception {
                 final CountDownLatch countDownLatch = latch2.get();
@@ -64,7 +64,7 @@ public class GracefulShutdownTestCase {
                     countDownLatch.await();
                 }
             }
-        });
+        }));
         DefaultServer.setRootHandler(shutdown);
     }
 

--- a/core/src/test/java/io/undertow/server/handlers/MetricsHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/MetricsHandlerTestCase.java
@@ -44,7 +44,7 @@ public class MetricsHandlerTestCase {
 
         MetricsHandler metricsHandler;
         CompletionLatchHandler latchHandler;
-        DefaultServer.setRootHandler(latchHandler = new CompletionLatchHandler(metricsHandler = new MetricsHandler(new HttpHandler() {
+        DefaultServer.setRootHandler(latchHandler = new CompletionLatchHandler(metricsHandler = new MetricsHandler(new BlockingHandler(new HttpHandler() {
             @Override
             public void handleRequest(HttpServerExchange exchange) throws Exception {
                 Thread.sleep(100);
@@ -53,7 +53,7 @@ public class MetricsHandlerTestCase {
                 }
                 exchange.getResponseSender().send("Hello");
             }
-        })));
+        }))));
         HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/path");
         TestHttpClient client = new TestHttpClient();
         try {

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -97,6 +97,7 @@ import org.xnio.Xnio;
 import org.xnio.XnioWorker;
 import org.xnio.channels.AcceptingChannel;
 import org.xnio.ssl.XnioSsl;
+import reactor.blockhound.BlockHound;
 
 import static io.undertow.server.handlers.ResponseCodeHandler.HANDLE_404;
 import static io.undertow.testutils.StopServerWithExternalWorkerUtils.stopWorker;
@@ -168,6 +169,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
             failure = t;
         }
         OPENSSL_FAILURE = failure;
+        BlockHound.install();
     }
 
     static final String DEFAULT = "default";

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <version.jakarta.servlet.jakarta-servlet-api>5.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.0.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.org.wildfly.extras.batavia>1.0.11.Final</version.org.wildfly.extras.batavia>
+        <version.io.projectreactor.tools.blockhound>1.0.6.RELEASE</version.io.projectreactor.tools.blockhound>
         <version.junit>4.13</version.junit>
         <version.netty>4.1.50.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
@@ -79,7 +80,7 @@
         <version.org.jboss.spec.javax.websockets>2.0.0.Final</version.org.jboss.spec.javax.websockets>
         <version.xnio>3.8.4.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
-        <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>3.1.1.Final</version.org.jboss.threads>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
 
@@ -595,6 +596,11 @@
                 <version>${version.org.wildfly.extras.batavia}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.projectreactor.tools</groupId>
+                <artifactId>blockhound</artifactId>
+                <version>${version.io.projectreactor.tools.blockhound}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/stress/WebsocketStressTestCase.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/stress/WebsocketStressTestCase.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -49,6 +48,7 @@ import io.undertow.testutils.DefaultServer;
 import io.undertow.testutils.HttpOneOnly;
 import io.undertow.websockets.jsr.ServerWebSocketContainer;
 import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import org.jboss.threads.EnhancedQueueExecutor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -75,7 +75,10 @@ public class WebsocketStressTestCase {
     @BeforeClass
     public static void setup() throws Exception {
         defaultContainer = ContainerProvider.getWebSocketContainer();
-        executor = Executors.newFixedThreadPool(NUM_THREADS);
+        executor = new EnhancedQueueExecutor.Builder()
+                .setCorePoolSize(NUM_THREADS)
+                .setMaximumPoolSize(NUM_THREADS)
+                .build();
 
         final ServletContainer container = ServletContainer.Factory.newInstance();
 

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/suspendresume/SuspendResumeTestCase.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/suspendresume/SuspendResumeTestCase.java
@@ -77,6 +77,7 @@ public class SuspendResumeTestCase {
                         new WebSocketDeploymentInfo()
                                 .setBuffers(DefaultServer.getBufferPool())
                                 .setWorker(DefaultServer.getWorker())
+                                .setDispatchToWorkerThread(true)
                                 .addListener(c -> serverContainer = c)
                                 .addEndpoint(SuspendResumeEndpoint.class)
                 )


### PR DESCRIPTION
This defines a BlockHound integration within undertow-core, however
this could be an entirely separate module. For this to become
mergable, BlockHound would minimally have to become a `provided`
dependency so it's not added to consumers classpaths unnecessarily,
but applied in test modules.

Arguably the blockhound integration belongs in an xnio-associated
module because xnio defines the relevant XnioIoThread class.

This idea is borrowed from Netty, which added BlockHound here:
https://github.com/netty/netty/pull/9687