### PR TITLE
[UNDERTOW-1848] SimpleSSLTestCase fails on Windows

### DIFF
--- a/core/src/test/java/io/undertow/server/ssl/SimpleSSLTestCase.java
+++ b/core/src/test/java/io/undertow/server/ssl/SimpleSSLTestCase.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -42,7 +43,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -51,6 +51,10 @@ import org.junit.runner.RunWith;
  */
 @RunWith(DefaultServer.class)
 public class SimpleSSLTestCase {
+
+    // The concurrency is aligned to the #CPUs*8 up to a max of 32 threads
+    private static final int CONCURRENCY = Math.min(32, Runtime.getRuntime().availableProcessors() * 8);
+    private static final int REQUESTS_PER_THREAD = 300;
 
     @Test
     public void simpleSSLTestCase() throws IOException, GeneralSecurityException {
@@ -112,9 +116,7 @@ public class SimpleSSLTestCase {
 
     @Test
     public void parallel() throws Exception {
-        // FIXME UNDERTOW-1928
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows") && DefaultServer.isProxy());
-        runTest(32, new HttpHandler() {
+        runTest(CONCURRENCY, new HttpHandler() {
             @Override
             public void handleRequest(final HttpServerExchange exchange) throws Exception {
                 exchange.getResponseHeaders().put(HttpString.tryFromString("scheme"), exchange.getRequestScheme());
@@ -125,9 +127,7 @@ public class SimpleSSLTestCase {
 
     @Test
     public void parallelWithDispatch() throws Exception {
-        // FIXME UNDERTOW-1928
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-        runTest(32, new HttpHandler() {
+        runTest(CONCURRENCY, new HttpHandler() {
             @Override
             public void handleRequest(final HttpServerExchange exchange) throws Exception {
                 exchange.dispatch(() -> {
@@ -140,9 +140,7 @@ public class SimpleSSLTestCase {
 
     @Test
     public void parallelWithBlockingDispatch() throws Exception {
-        // FIXME UNDERTOW-1928
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
-        runTest(32, new HttpHandler() {
+        runTest(CONCURRENCY, new HttpHandler() {
             @Override
             public void handleRequest(final HttpServerExchange exchange) throws Exception {
                 if (exchange.isInIoThread()) {
@@ -159,13 +157,14 @@ public class SimpleSSLTestCase {
     private void runTest(int concurrency, HttpHandler handler) throws IOException, InterruptedException {
         DefaultServer.setRootHandler(handler);
         DefaultServer.startSSLServer();
+        ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
         try (CloseableHttpClient client = HttpClients.custom().disableConnectionState()
                 .setSSLContext(DefaultServer.getClientSSLContext())
-                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(5000).build())
+                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(60000).build())
                 .setMaxConnPerRoute(1000)
                 .build()) {
-            ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
             AtomicBoolean failed = new AtomicBoolean();
+            AtomicInteger processed = new AtomicInteger(0);
             Runnable task = new Runnable() {
                 @Override
                 public void run() {
@@ -177,22 +176,34 @@ public class SimpleSSLTestCase {
                         Header[] header = result.getHeaders("scheme");
                         Assert.assertEquals("https", header[0].getValue());
                         EntityUtils.consumeQuietly(result.getEntity());
+                        processed.incrementAndGet();
                     } catch (Throwable t) {
                         if (failed.compareAndSet(false, true)) {
                             t.printStackTrace();
-                            executorService.shutdownNow();
                         }
                     }
                 }
             };
-            for (int i = 0; i < concurrency * 300; i++) {
+            for (int i = 0; i < concurrency * REQUESTS_PER_THREAD; i++) {
                 executorService.submit(task);
             }
             executorService.shutdown();
-            Assert.assertTrue(executorService.awaitTermination(70, TimeUnit.SECONDS));
-            Assert.assertFalse(failed.get());
+            int executedPrevTime = 0;
+            while (!executorService.awaitTermination(10, TimeUnit.SECONDS) && !failed.get()) {
+                int executed = processed.get();
+                if (executedPrevTime == executed) {
+                    failed.set(true);
+                    Assert.fail("Executions hanged at " + executed);
+                }
+                executedPrevTime = executed;
+            }
+            Assert.assertFalse("A task failed! Check the stack-trace in the output file", failed.get());
+            Assert.assertTrue(executorService.isTerminated());
         } finally {
             DefaultServer.stopSSLServer();
+            if (!executorService.isTerminated()) {
+                executorService.shutdownNow();
+            }
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1848

Changes in the test:

* Reduce the load depending the #CPU in the box. The concurrency is set to #CPU*8 up to 32 (before it was always 32 threads). The idea is reducing the number of simultaneous requests when the box has less than 4 CPUs to not stress too much.
* The SO timeout of the socket has been increased from 5s to 60s (exception `java.net.SocketTimeoutException: Read timed out`).
* The total await time was changed from fixed 70s to a while that waits for 10s and counts processed requests. The test stops if failed or if in that period no requests were processed. This way there is no hard time limit.

I have tested the class a lot of times in my VM and no failures even with only 1CPU assigned (which takes 3-5 minutes in each test). But who knows... Let's see if this is enough for the CI...