### PR TITLE
UNDERTOW-2038: InputStream.read implementations avoid unnecessary ByteBuffer.wrap

### DIFF
--- a/core/src/main/java/io/undertow/io/UndertowInputStream.java
+++ b/core/src/main/java/io/undertow/io/UndertowInputStream.java
@@ -20,7 +20,6 @@ package io.undertow.io;
 
 import io.undertow.UndertowMessages;
 import io.undertow.server.HttpServerExchange;
-import org.xnio.Buffers;
 import io.undertow.connector.ByteBufferPool;
 import io.undertow.connector.PooledByteBuffer;
 import org.xnio.channels.Channels;
@@ -94,7 +93,8 @@ public class UndertowInputStream extends InputStream {
             return 0;
         }
         ByteBuffer buffer = pooled.getBuffer();
-        int copied = Buffers.copy(ByteBuffer.wrap(b, off, len), buffer);
+        int copied = Math.min(buffer.remaining(), len);
+        buffer.get(b, off, copied);
         if (!buffer.hasRemaining()) {
             pooled.close();
             pooled = null;

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import javax.servlet.ReadListener;
 import javax.servlet.ServletInputStream;
 
-import org.xnio.Buffers;
 import org.xnio.ChannelListener;
 import org.xnio.IoUtils;
 import org.xnio.channels.Channels;
@@ -183,7 +182,8 @@ public class ServletInputStreamImpl extends ServletInputStream {
             return 0;
         }
         ByteBuffer buffer = pooled.getBuffer();
-        int copied = Buffers.copy(ByteBuffer.wrap(b, off, len), buffer);
+        int copied = Math.min(buffer.remaining(), len);
+        buffer.get(b, off, copied);
         if (!buffer.hasRemaining()) {
             pooled.close();
             pooled = null;

--- a/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletInputStream.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/UpgradeServletInputStream.java
@@ -19,7 +19,6 @@
 package io.undertow.servlet.spec;
 
 import io.undertow.servlet.UndertowServletMessages;
-import org.xnio.Buffers;
 import org.xnio.ChannelListener;
 import org.xnio.IoUtils;
 import io.undertow.connector.ByteBufferPool;
@@ -132,7 +131,8 @@ public class UpgradeServletInputStream extends ServletInputStream {
             return 0;
         }
         ByteBuffer buffer = pooled.getBuffer();
-        int copied = Buffers.copy(ByteBuffer.wrap(b, off, len), buffer);
+        int copied = Math.min(buffer.remaining(), len);
+        buffer.get(b, off, copied);
         if (!buffer.hasRemaining()) {
             pooled.close();
             pooled = null;


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2038