### PR TITLE
[UNDERTOW-2070] At ServletOutputStreamImpl, allow redirects with cont…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletOutputStreamImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletOutputStreamImpl.java
@@ -603,13 +603,13 @@ public class ServletOutputStreamImpl extends ServletOutputStream implements Buff
             if (anyAreSet(state, FLAG_CLOSED)) return;
             setFlags(FLAG_CLOSED);
             clearFlags(FLAG_READY);
-            if (allAreClear(state, FLAG_WRITE_STARTED) && channel == null && servletRequestContext.getOriginalResponse().getHeader(Headers.CONTENT_LENGTH_STRING) == null) {
+            if (allAreClear(state, FLAG_WRITE_STARTED) && channel == null) {
                 if (servletRequestContext.getOriginalResponse().getHeader(Headers.TRANSFER_ENCODING_STRING) == null
                         && servletRequestContext.getExchange().getAttachment(HttpAttachments.RESPONSE_TRAILER_SUPPLIER) == null
                         && servletRequestContext.getExchange().getAttachment(HttpAttachments.RESPONSE_TRAILERS) == null) {
                     if (buffer == null) {
                         servletRequestContext.getExchange().getResponseHeaders().put(Headers.CONTENT_LENGTH, "0");
-                    } else {
+                    } else if (servletRequestContext.getOriginalResponse().getHeader(Headers.CONTENT_LENGTH_STRING) == null) {
                         servletRequestContext.getExchange().getResponseHeaders().put(Headers.CONTENT_LENGTH, Integer.toString(buffer.position()));
                     }
                 }

--- a/servlet/src/test/java/io/undertow/servlet/test/redirect/RedirectWithContentLengthServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/redirect/RedirectWithContentLengthServlet.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.servlet.test.redirect;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Servlet that redirects the request after setting content length (see UNDERTOW-2070).
+ *
+ * @author Flavia Rainone
+ */
+public class RedirectWithContentLengthServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (request.getRequestURI().contains("subpath")) {
+            response.getWriter().write(request.getRequestURI());
+        } else {
+            response.setContentLength(10);
+            response.sendRedirect(response.encodeRedirectURL("./subpath"));
+        }
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/redirect/RedirectWithContentLengthTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/redirect/RedirectWithContentLengthTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.servlet.test.redirect;
+
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.undertow.servlet.Servlets.servlet;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test redirection after setting content length (see UNDERTOW-2070)
+ * @author Flavia Rainone
+ */
+@RunWith(DefaultServer.class)
+public class RedirectWithContentLengthTestCase {
+    @BeforeClass
+    public static void setup() throws javax.servlet.ServletException {
+        final PathHandler pathHandler = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassLoader(RedirectWithContentLengthTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setClassIntrospecter(io.undertow.servlet.test.util.TestClassIntrospector.INSTANCE)
+                .setDeploymentName("servletContext.war")
+                .addServlets(
+                        servlet("redirect", RedirectWithContentLengthServlet.class)
+                                .addMapping("/redirect/*"));
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        pathHandler.addPrefixPath(builder.getContextPath(), manager.start());
+        DefaultServer.setRootHandler(pathHandler);
+    }
+
+    @Test
+    public void testServletRedirect() throws Exception {
+        final String requestURL = DefaultServer.getDefaultServerURL() + "/servletContext/redirect/";
+        final String expectedBody = "/servletContext/redirect/subpath";
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(requestURL);
+            HttpResponse result = client.execute(get);
+            assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            final String response = HttpClientUtils.readResponse(result);
+            assertEquals(expectedBody, response);
+            Header[] header = result.getHeaders(Headers.CONTENT_LENGTH_STRING);
+            assertEquals(1, header.length);
+            assertEquals(expectedBody.length(), Integer.valueOf(header[0].getValue()).intValue());
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}


### PR DESCRIPTION
…ent length set by setting a zero content length on close even if CONTENT_LENGTH header is set. Also, still keep the "CONTENT_LENGTH is not set" restriction to prevent overwriting the value if buffer is not null.

As demonstrated by ResponseWriterTestCase.testContentLengthBasedFlush, the latter part of keeping the restriction is important to have flush taking into account a content length that is set for normal requests without redirects, where data is printed to the ServletOutputStreamImpl. This will cause the flush to limit the length of printed bytes to be equal to the content length set by the servlet.

As for the UNDERTOW-2070 bug itself, as demonstrated by RedirectWithContentLengthTestCase, a response is expected even if content length is set by the servlet before redirecting. By having ServletOutputStreamImpl.close setting the zero length in this scenario, we prevent the server from mistaking the redirect with an unfinished response, which is the cause of the empty reply.

Jira: https://issues.redhat.com/browse/UNDERTOW-2070