### PR TITLE
[UNDERTOW-2061] prefix not formed properly in ACL

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/IPAddressAccessControlHandler.java
@@ -268,6 +268,7 @@ public class IPAddressAccessControlHandler implements HttpHandler {
             int no = Integer.parseInt(part);
             prefix |= no;
         }
+        prefix &= mask;
         ipv4acl.add(new PrefixIpV4PeerMatch(deny, peer, mask, prefix));
     }
 

--- a/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/IPAddressAccessControlHandlerUnitTestCase.java
@@ -37,6 +37,14 @@ import java.net.UnknownHostException;
 public class IPAddressAccessControlHandlerUnitTestCase {
 
     @Test
+    public void testIPv4SlashMatchDefaultDeny() throws UnknownHostException {
+        IPAddressAccessControlHandler handler = new IPAddressAccessControlHandler()
+                .setDefaultAllow(false)
+                .addAllow("85.112.112.58/29");
+        Assert.assertTrue(handler.isAllowed(InetAddress.getByName("85.112.112.58")));
+    }
+
+    @Test
     public void testIPv4ExactMatch() throws UnknownHostException {
         IPAddressAccessControlHandler handler = new IPAddressAccessControlHandler()
                 .setDefaultAllow(false)


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2061