### PR TITLE
[UNDERTOW-2097] DMI_RANDOM_USED_ONLY_ONCE error reported by spotbugs

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/SimpleNonceManager.java
+++ b/core/src/main/java/io/undertow/security/impl/SimpleNonceManager.java
@@ -107,6 +107,12 @@ public class SimpleNonceManager implements SessionNonceManager {
     private static final long overallTimeOut = 15 * 60 * 1000;
 
     /**
+     * Create a static instance of SecureRandom, so it can be actually reused by all instances of this class.
+     * This should also increase the randomness of generated numbers.
+     */
+    private static final Random rand = new SecureRandom();
+
+    /**
      * A previously used nonce will be allowed to remain in the knownNonces list for up to 5 minutes.
      *
      * The nonce will be accepted during this 5 minute window but will immediately be replaced causing any additional requests
@@ -128,7 +134,6 @@ public class SimpleNonceManager implements SessionNonceManager {
         this.hashLength = digest.getDigestLength();
 
         // Create a new secret only valid within this NonceManager instance.
-        Random rand = new SecureRandom();
         byte[] secretBytes = new byte[32];
         rand.nextBytes(secretBytes);
         secret = FlexBase64.encodeString(digest.digest(secretBytes), false);

--- a/core/src/main/java/io/undertow/websockets/client/WebSocket13ClientHandshake.java
+++ b/core/src/main/java/io/undertow/websockets/client/WebSocket13ClientHandshake.java
@@ -60,6 +60,12 @@ public class WebSocket13ClientHandshake extends WebSocketClientHandshake {
     private final WebSocketClientNegotiation negotiation;
     private final Set<ExtensionHandshake> extensions;
 
+    /**
+     * Create a static instance of SecureRandom, so it can be actually reused by all instances of this class.
+     * This should also increase the randomness of generated numbers.
+     */
+    private static final SecureRandom random = new SecureRandom();
+
     public WebSocket13ClientHandshake(final URI url, WebSocketClientNegotiation negotiation, Set<ExtensionHandshake> extensions) {
         super(url);
         this.negotiation = negotiation;
@@ -142,7 +148,6 @@ public class WebSocket13ClientHandshake extends WebSocketClientHandshake {
     }
 
     protected String createSecKey() {
-        SecureRandom random = new SecureRandom();
         byte[] data = new byte[16];
         for (int i = 0; i < 4; ++i) {
             int val = random.nextInt();

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -228,16 +228,6 @@
         <Class name="~io\.undertow\.protocols\.ajp\.AjpClientChannel\$.*"/>
     </Match>
 
-    <!-- Is done actually only once, no harm in it -->
-    <Match>
-        <Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
-        <Or>
-            <Class name="io.undertow.util.HttpString"/>
-            <Class name="io.undertow.security.impl.SimpleNonceManager" />
-            <Class name="io.undertow.websockets.client.WebSocket13ClientHandshake" />
-        </Or>
-    </Match>
-
     <Match>
         <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS"/>
         <Or>


### PR DESCRIPTION
Let's try to reuse instance of `SecureRandom` class when possible. This
change is attempt to fix error identified by SpotBugs plugin and
described in [1].

[1] https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#dmi-random-object-created-and-used-only-once-dmi-random-used-only-once

https://issues.redhat.com/browse/UNDERTOW-2097