### PR TITLE
[UNDERTOW-2102] ServletPrintWriterDelegate throws exception using OpenJDK 19 EA

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
@@ -69,6 +69,7 @@ public final class ServletPrintWriterDelegate extends PrintWriter {
 
     public void setServletPrintWriter(final ServletPrintWriter servletPrintWriter) {
         this.servletPrintWriter = servletPrintWriter;
+        this.lock = servletPrintWriter;
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/response/writer/ExceptionWriterServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/response/writer/ExceptionWriterServlet.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.response.writer;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * <p>Simple servlet that prints a exception stack trace.</p>
+ *
+ * @author rmartinc
+ */
+public class ExceptionWriterServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain;charset=UTF-8");
+        try (PrintWriter writer = resp.getWriter()) {
+            new Exception("TestException").printStackTrace(writer);
+        }
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/response/writer/ResponseWriterTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/response/writer/ResponseWriterTestCase.java
@@ -20,9 +20,10 @@ package io.undertow.servlet.test.response.writer;
 
 import javax.servlet.ServletException;
 
-import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -37,6 +38,7 @@ import io.undertow.servlet.test.util.TestClassIntrospector;
 import io.undertow.testutils.DefaultServer;
 import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.FileUtils;
+import io.undertow.util.StatusCodes;
 
 /**
  * @author Tomaz Cerar
@@ -57,7 +59,9 @@ public class ResponseWriterTestCase {
                 .addServlet(Servlets.servlet("resp", ResponseWriterServlet.class)
                         .addMapping("/resp"))
                 .addServlet(Servlets.servlet("respLArget", LargeResponseWriterServlet.class)
-                        .addMapping("/large"));
+                        .addMapping("/large"))
+                .addServlet(Servlets.servlet("exception", ExceptionWriterServlet.class)
+                        .addMapping("/exception"));
 
         DeploymentManager manager = container.addDeployment(builder);
         manager.deploy();
@@ -92,6 +96,20 @@ public class ResponseWriterTestCase {
             String data = FileUtils.readFile(result.getEntity().getContent());
             Assert.assertEquals(LargeResponseWriterServlet.getMessage(), data);
 
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testExceptionResponse() throws Exception {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/exception");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = FileUtils.readFile(result.getEntity().getContent());
+            MatcherAssert.assertThat(response, CoreMatchers.startsWith("java.lang.Exception: TestException"));
         } finally {
             client.getConnectionManager().shutdown();
         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2102

Initializing the lock object using the ServletPrintWriter passed as argument.
PR for 2.2.x branch.
PR for master: https://github.com/undertow-io/undertow/pull/1335