### PR TITLE
[UNDERTOW-2102] ServletPrintWriterDelegate throws exception using OpenJDK 19 EA

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
@@ -69,6 +69,7 @@ public final class ServletPrintWriterDelegate extends PrintWriter {
 
     public void setServletPrintWriter(final ServletPrintWriter servletPrintWriter) {
         this.servletPrintWriter = servletPrintWriter;
+        this.lock = servletPrintWriter;
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/response/writer/ExceptionWriterServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/response/writer/ExceptionWriterServlet.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.response.writer;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * <p>Simple servlet that prints a exception stack trace.</p>
+ *
+ * @author rmartinc
+ */
+public class ExceptionWriterServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain;charset=UTF-8");
+        try (PrintWriter writer = resp.getWriter()) {
+            new Exception("TestException").printStackTrace(writer);
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2102

Initializing the lock object using the ServletPrintWriter passed as argument.
PR for master.
PR for 2.2.x:  https://github.com/undertow-io/undertow/pull/1334