### PR TITLE
[UNDERTOW-2113] Read Timeout Test Case Fail on Windows with JDK17 due to different exception message

### DIFF
--- a/core/src/test/java/io/undertow/server/ReadTimeoutTestCase.java
+++ b/core/src/test/java/io/undertow/server/ReadTimeoutTestCase.java
@@ -136,7 +136,7 @@ public class ReadTimeoutTestCase {
                 client.execute(post);
             } catch (SocketException e) {
                 Assert.assertTrue(e.getMessage(), e.getMessage().contains("Broken pipe")
-                        || e.getMessage().contains("connection abort"));
+                        || e.getMessage().contains("connection abort") || e.getMessage().contains("connection was aborted"));
                 socketFailure = true;
             }
             Assert.assertTrue("Test sent request without any exception", socketFailure);


### PR DESCRIPTION
Read Timeout Test Case Fail on Windows with JDK17 due to different exception message

https://issues.redhat.com/browse/UNDERTOW-2113