### PR TITLE
[UNDERTOW-2122] Javax imports in servlet tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -239,6 +239,7 @@
                 <configuration>
                     <enableAssertions>true</enableAssertions>
                     <runOrder>reversealphabetical</runOrder>
+                    <failIfNoTests>true</failIfNoTests>
                     <systemPropertyVariables>
                         <test.ajp>${ajp}</test.ajp>
                         <test.proxy>${proxy}</test.proxy>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -197,6 +197,7 @@
                 <configuration>
                     <enableAssertions>true</enableAssertions>
                     <runOrder>reversealphabetical</runOrder>
+                    <failIfNoTests>true</failIfNoTests>
                     <systemPropertyVariables>
                         <test.ajp>${ajp}</test.ajp>
                         <test.proxy>${proxy}</test.proxy>

--- a/servlet/src/test/java/io/undertow/servlet/test/redirect/RelativeRedirectServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/redirect/RelativeRedirectServlet.java
@@ -19,10 +19,10 @@ package io.undertow.servlet.test.redirect;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  *

--- a/servlet/src/test/java/io/undertow/servlet/test/redirect/RelativeRedirectServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/redirect/RelativeRedirectServletTestCase.java
@@ -19,7 +19,7 @@ package io.undertow.servlet.test.redirect;
 
 import static io.undertow.servlet.Servlets.servlet;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/websockets-jsr/pom.xml
+++ b/websockets-jsr/pom.xml
@@ -171,6 +171,7 @@
                     <runOrder>reversealphabetical</runOrder>
                     <skip>${skipWebSocketTests}</skip>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <failIfNoTests>true</failIfNoTests>
                     <systemPropertyVariables>
                         <proxy>${proxy}</proxy>
                         <default.server.address>localhost</default.server.address>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2122

There are javax imports (instead of jakarta)  that are creating issues in master. I have fixed that and also added `failIfNoTests` to `true` in the main poms because the error was undetected because of that. If you prefer to not add the last part just let me know.

@ropalka @fl4via Please review this when you have time. This is stopping my other PRs. :smile: 

Thanks!