### PR TITLE
[UNDERTOW-2130] Classes witch annotation RunWith are triggered as TestCase

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/streams/EarlyCloseClientServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/EarlyCloseClientServlet.java
@@ -18,9 +18,6 @@
 
 package io.undertow.servlet.test.streams;
 
-import io.undertow.testutils.DefaultServer;
-import org.junit.runner.RunWith;
-
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServlet;
@@ -33,7 +30,6 @@ import java.util.concurrent.CountDownLatch;
 /**
  * @author Stuart Douglas
  */
-@RunWith(DefaultServer.class)
 public class EarlyCloseClientServlet extends HttpServlet {
 
     private static volatile boolean exceptionThrown;

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/EarlyCloseServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/EarlyCloseServlet.java
@@ -29,12 +29,10 @@ import io.undertow.server.ServerConnection;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.servlet.spec.HttpServletRequestImpl;
 import io.undertow.testutils.DefaultServer;
-import org.junit.runner.RunWith;
 
 /**
  * @author Stuart Douglas
  */
-@RunWith(DefaultServer.class)
 public class EarlyCloseServlet extends HttpServlet {
 
     private volatile ServerConnection connection;

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/ForceDrainServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/ForceDrainServlet.java
@@ -23,14 +23,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.runner.RunWith;
-
-import io.undertow.testutils.DefaultServer;
 
 /**
  * @author Stuart Douglas
  */
-@RunWith(DefaultServer.class)
 public class ForceDrainServlet extends HttpServlet {
 
     @Override


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2130

Just removing the @RunWith annotation that is present in three test Servlets. They are bothering QA in the CI. I cherry-picked what @kstekovi did in his branch.