### PR TITLE
[UNDERTOW-2131] ContentEncodingRepository avoids iterator allocations

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
@@ -50,12 +50,14 @@ public class ContentEncodingRepository {
         }
         final List<EncodingMapping> resultingMappings = new ArrayList<>();
         final List<List<QValueParser.QValueResult>> found = QValueParser.parse(res);
+        //noinspection ForLoopReplaceableByForEach - using induction for loop for iteration to avoid allocation
         for (int i = 0; i < found.size(); i++) {
             final List<QValueParser.QValueResult> result = found.get(i);
             List<EncodingMapping> available = new ArrayList<>();
             boolean includesIdentity = false;
             boolean isQValue0 = false;
 
+            //noinspection ForLoopReplaceableByForEach - using induction for loop for iteration to avoid allocation
             for (int j = 0; j < result.size(); j++) {
                 final QValueParser.QValueResult value = result.get(j);
                 EncodingMapping encoding;

--- a/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
@@ -50,12 +50,14 @@ public class ContentEncodingRepository {
         }
         final List<EncodingMapping> resultingMappings = new ArrayList<>();
         final List<List<QValueParser.QValueResult>> found = QValueParser.parse(res);
-        for (List<QValueParser.QValueResult> result : found) {
+        for (int i = 0; i < found.size(); i++) {
+            List<QValueParser.QValueResult> result = found.get(i);
             List<EncodingMapping> available = new ArrayList<>();
             boolean includesIdentity = false;
             boolean isQValue0 = false;
 
-            for (final QValueParser.QValueResult value : result) {
+            for (int j = 0; j < result.size(); j++) {
+                QValueParser.QValueResult value = result.get(j);
                 EncodingMapping encoding;
                 if (value.getValue().equals("*")) {
                     includesIdentity = true;

--- a/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/ContentEncodingRepository.java
@@ -51,13 +51,13 @@ public class ContentEncodingRepository {
         final List<EncodingMapping> resultingMappings = new ArrayList<>();
         final List<List<QValueParser.QValueResult>> found = QValueParser.parse(res);
         for (int i = 0; i < found.size(); i++) {
-            List<QValueParser.QValueResult> result = found.get(i);
+            final List<QValueParser.QValueResult> result = found.get(i);
             List<EncodingMapping> available = new ArrayList<>();
             boolean includesIdentity = false;
             boolean isQValue0 = false;
 
             for (int j = 0; j < result.size(); j++) {
-                QValueParser.QValueResult value = result.get(j);
+                final QValueParser.QValueResult value = result.get(j);
                 EncodingMapping encoding;
                 if (value.getValue().equals("*")) {
                     includesIdentity = true;

--- a/core/src/main/java/io/undertow/util/QValueParser.java
+++ b/core/src/main/java/io/undertow/util/QValueParser.java
@@ -47,6 +47,7 @@ public class QValueParser {
     public static List<List<QValueResult>> parse(List<String> headers) {
         final List<QValueResult> found = new ArrayList<>();
         QValueResult current = null;
+        //noinspection ForLoopReplaceableByForEach - using induction for loop for iteration to avoid allocation
         for (int j = 0; j < headers.size(); j++) {
             final String header = headers.get(j);
             final int l = header.length();
@@ -108,6 +109,7 @@ public class QValueParser {
         List<List<QValueResult>> values = new ArrayList<>();
         List<QValueResult> currentSet = null;
 
+        //noinspection ForLoopReplaceableByForEach - using induction for loop for iteration to avoid allocation
         for (int i = 0; i < found.size(); i++) {
             final QValueResult val = found.get(i);
             if (!val.qvalue.equals(currentQValue)) {

--- a/core/src/main/java/io/undertow/util/QValueParser.java
+++ b/core/src/main/java/io/undertow/util/QValueParser.java
@@ -47,7 +47,8 @@ public class QValueParser {
     public static List<List<QValueResult>> parse(List<String> headers) {
         final List<QValueResult> found = new ArrayList<>();
         QValueResult current = null;
-        for (final String header : headers) {
+        for (int j = 0; j < headers.size(); j++) {
+            final String header = headers.get(j);
             final int l = header.length();
             //we do not use a string builder
             //we just keep track of where the current string starts and call substring()
@@ -107,8 +108,9 @@ public class QValueParser {
         List<List<QValueResult>> values = new ArrayList<>();
         List<QValueResult> currentSet = null;
 
-        for(QValueResult val : found) {
-            if(!val.qvalue.equals(currentQValue)) {
+        for (int i = 0; i < found.size(); i++) {
+            final QValueResult val = found.get(i);
+            if (!val.qvalue.equals(currentQValue)) {
                 currentQValue = val.qvalue;
                 currentSet = new ArrayList<>();
                 values.add(currentSet);


### PR DESCRIPTION
Fixes [UNDERTOW-2131](https://issues.redhat.com/browse/UNDERTOW-2131)

`ContentEncodingRepository.getContentEncodings(HttpServerExchange)` allocates many `ArrayList` iterators in hot paths for handling requests. It may be worthwhile to avoid using for-each loops and instead use old fashioned for loop with `List.get(int)` to avoid additional allocations during request processing.
 
```
java.util.ArrayList$Itr
at java.util.ArrayList.iterator()
at java.util.AbstractCollection.addAll(Collection)
at io.undertow.server.handlers.encoding.ContentEncodingRepository.getContentEncodings(HttpServerExchange)
at io.undertow.server.handlers.encoding.EncodingHandler.handleRequest(HttpServerExchange)
 ```