### PR TITLE
[UNDERTOW-2133] CVE-2022-2053 Handle RequestTooBigException

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerRequestConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpServerRequestConduit.java
@@ -31,6 +31,7 @@ import io.undertow.UndertowMessages;
 import io.undertow.conduits.ConduitListener;
 import io.undertow.server.Connectors;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.server.RequestTooBigException;
 import io.undertow.util.ImmediatePooledByteBuffer;
 import org.xnio.IoUtils;
 import org.xnio.channels.StreamSinkChannel;
@@ -202,6 +203,8 @@ public class AjpServerRequestConduit extends AbstractStreamSourceConduit<StreamS
             }
             assert STATE_FINISHED == state;
             return -1;
+        } catch (RequestTooBigException e) {
+            throw e;
         } catch (IOException | RuntimeException e) {
             IoUtils.safeClose(exchange.getConnection());
             throw e;


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2133

CVE-2022-2053

If the request is too big, throw an excpetion to allow the connection to
be cleaned up closed properly up the call stack.