### PR TITLE
UNDERTOW-2162: Only canonicalize the servlet path when getting request dispatcher

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -343,12 +343,18 @@ public class ServletContextImpl implements ServletContext {
         if (!path.startsWith("/")) {
             throw UndertowServletMessages.MESSAGES.pathMustStartWithSlashForRequestDispatcher(path);
         }
-        final String realPath = CanonicalPathUtils.canonicalize(path, true);
-        if (realPath == null) {
+        int qsPos = path.indexOf("?");
+        final String newServletPath = qsPos != -1 ?  path.substring(0, qsPos) : path;
+        final String queryString = qsPos != -1 ? path.substring(qsPos) : "";
+
+        // Only canonicalize the servlet path
+        final String realServletPath = CanonicalPathUtils.canonicalize(newServletPath, true);
+        if (realServletPath == null) {
             // path is outside the servlet context, return null per spec
             return null;
         }
-        return new RequestDispatcherImpl(realPath, this);
+
+        return new RequestDispatcherImpl(realServletPath + queryString, this);
     }
 
     @Override

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherForwardTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherForwardTestCase.java
@@ -255,4 +255,21 @@ public class DispatcherForwardTestCase {
             client.getConnectionManager().shutdown();
         }
     }
+
+    @Test
+    public void testIncludesUrlInPathParameters() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/dispatch");
+            get.setHeader("forward", "/path?url=http://test.com");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            // Path parameters should not be canonicalized
+            Assert.assertEquals("pathInfo:null queryString:url=http://test.com servletPath:/path requestUri:/servletContext/path", response);
+
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
 }


### PR DESCRIPTION
**Issue:** https://issues.redhat.com/browse/UNDERTOW-2162

**Description:** : We found this issue after upgrade to Wildfly 26.1.2, and the following code no longer work as expected
```
RequestDispatcher rd = request.getRequestDispatcher("/aaa?url=http://bb.com");
rd.forward(request, response);
``` 
The forwarded request has path `/aaa?url=http:/bb.com` which caused by canonicalize the whole path with query params in `ServletContextImpl`. 

**Fix**: Only canonicalize the servlet path in `ServletContextImpl`

**Test**:
* Unit test added in `DispatcherForwardTestCase`
* Tested locally with the updated undertow-servlet 2.2.19 jar in wildfly 26.1.2 modules, works great.
