### PR TITLE
[UNDERTOW-1818] AbstractServletInputStreamTestCase.runTestParallel fails with bytes out of order

### DIFF
--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -144,8 +144,12 @@ public class Connectors {
             System.arraycopy(buffers, 0, newArray, 0, buffers.length);
         } else {
             newArray = new PooledByteBuffer[existing.length + buffers.length];
-            System.arraycopy(existing, 0, newArray, 0, existing.length);
-            System.arraycopy(buffers, 0, newArray, existing.length, buffers.length);
+            // If there are previous buffers we are re-buffering data so although
+            // counterintuitive first put the new data and then the existing buffers.
+            // Example: there are buffered data with buffers A,B and A is retrieved
+            // but returned, it should be A,B again and not B,A
+            System.arraycopy(buffers, 0, newArray, 0, buffers.length);
+            System.arraycopy(existing, 0, newArray, buffers.length, existing.length);
         }
         exchange.putAttachment(HttpServerExchange.BUFFERED_REQUEST_DATA, newArray); //todo: force some kind of wakeup?
         exchange.addExchangeCompleteListener(BufferedRequestDataCleanupListener.INSTANCE);

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -448,10 +448,11 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                     proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                     proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
                     loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .setMaxQueueSize(20)
                         .addHost(new URI("ajp", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null));
                     ProxyHandler proxyHandler = ProxyHandler.builder()
                         .setProxyClient(loadBalancingProxyClient)
-                        .setMaxRequestTime(120000)
+                        .setMaxRequestTime(60000)
                         .setNext(HANDLE_404)
                         .setReuseXForwarded(true)
                         .build();
@@ -470,10 +471,11 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
                 loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                    .setMaxQueueSize(20)
                     .addHost(new URI("h2", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, new UndertowXnioSsl(xnio, OptionMap.EMPTY, SSL_BUFFER_POOL, clientContext), OptionMap.create(UndertowOptions.ENABLE_HTTP2, true));
                 ProxyHandler proxyHandler = ProxyHandler.builder()
                     .setProxyClient(loadBalancingProxyClient)
-                    .setMaxRequestTime(120000)
+                    .setMaxRequestTime(60000)
                     .setNext(HANDLE_404)
                     .setReuseXForwarded(true)
                     .build();
@@ -491,10 +493,11 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
                 loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .setMaxQueueSize(20)
                         .addHost(new URI(h2cUpgrade ? "http" : "h2c-prior", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), null, null, OptionMap.create(UndertowOptions.ENABLE_HTTP2, true));
                 ProxyHandler proxyHandler = ProxyHandler.builder()
                     .setProxyClient(loadBalancingProxyClient)
-                    .setMaxRequestTime(30000)
+                    .setMaxRequestTime(60000)
                     .setNext(HANDLE_404)
                     .setReuseXForwarded(true)
                     .build();
@@ -514,10 +517,11 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                 proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                 proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
                 loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                    .setMaxQueueSize(20)
                     .addHost(new URI("https", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null), clientSsl);
                 ProxyHandler proxyHandler = ProxyHandler.builder()
                     .setProxyClient(loadBalancingProxyClient)
-                    .setMaxRequestTime(30000)
+                    .setMaxRequestTime(60000)
                     .setNext(HANDLE_404)
                     .setReuseXForwarded(true)
                     .build();
@@ -541,10 +545,11 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
                     proxyAcceptListener = ChannelListeners.openListenerAdapter(wrapOpenListener(proxyOpenListener));
                     proxyServer = worker.createStreamConnectionServer(new InetSocketAddress(Inet4Address.getByName(getHostAddress(DEFAULT)), getHostPort(DEFAULT)), proxyAcceptListener, serverOptions);
                     loadBalancingProxyClient = new LoadBalancingProxyClient(GSSAPIAuthenticationMechanism.EXCLUSIVITY_CHECKER)
+                        .setMaxQueueSize(20)
                         .addHost(new URI("http", null, getHostAddress(DEFAULT), getHostPort(DEFAULT) + PROXY_OFFSET, "/", null, null));
                     ProxyHandler proxyHandler = ProxyHandler.builder()
                         .setProxyClient(loadBalancingProxyClient)
-                        .setMaxRequestTime(30000)
+                        .setMaxRequestTime(60000)
                         .setNext(HANDLE_404)
                         .setReuseXForwarded(true)
                         .build();
@@ -891,7 +896,8 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
         if (proxyOpenListener != null) {
             proxyOpenListener.closeConnections();
             shuttingDown = true;
-        } else if (openListener != null) {
+        }
+        if (openListener != null) {
             openListener.closeConnections();
             shuttingDown = true;
         }

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/AbstractServletInputStreamTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/AbstractServletInputStreamTestCase.java
@@ -59,6 +59,7 @@ public abstract class AbstractServletInputStreamTestCase {
     public static final String BLOCKING_SERVLET = "blockingInput";
     public static final String ASYNC_SERVLET = "asyncInput";
     public static final String ASYNC_EAGER_SERVLET = "asyncEagerInput";
+    private static final int CONCURRENCY = Math.min(20, 4 * Runtime.getRuntime().availableProcessors());
 
     @Test
     public void testBlockingServletInputStream() {
@@ -117,7 +118,7 @@ public abstract class AbstractServletInputStreamTestCase {
             builder.append(HELLO_WORLD);
         }
         String message = builder.toString();
-        runTestParallel(20, message, ASYNC_SERVLET, false, false);
+        runTestParallel(CONCURRENCY, message, ASYNC_SERVLET, false, false);
     }
 
     @Test
@@ -127,7 +128,7 @@ public abstract class AbstractServletInputStreamTestCase {
             builder.append(HELLO_WORLD);
         }
         String message = builder.toString();
-        runTestParallel(20, message, ASYNC_SERVLET, false, true);
+        runTestParallel(CONCURRENCY, message, ASYNC_SERVLET, false, true);
     }
 
     @Test

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/AsyncInputStreamServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/AsyncInputStreamServlet.java
@@ -42,6 +42,7 @@ public class AsyncInputStreamServlet extends HttpServlet {
         final int preamble = Math.max(0, req.getIntHeader("preamble"));
         final boolean offIoThread = req.getHeader("offIoThread") != null;
         final AsyncContext context = req.startAsync();
+        context.setTimeout(60000);
 
         final ServletOutputStream outputStream = resp.getOutputStream();
         ServletInputStream inputStream = req.getInputStream();

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/AsyncOutputStreamServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/AsyncOutputStreamServlet.java
@@ -45,6 +45,7 @@ public class AsyncOutputStreamServlet extends HttpServlet {
         final AtomicInteger count = new AtomicInteger();
 
         final AsyncContext context = req.startAsync();
+        context.setTimeout(60000);
         final ServletOutputStream outputStream = resp.getOutputStream();
         if(preable) {
             for(int i = 0; i < reps; ++i) {

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamRequestBufferingTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamRequestBufferingTestCase.java
@@ -26,9 +26,7 @@ import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.ServletInfo;
 import io.undertow.servlet.test.util.DeploymentUtils;
 import io.undertow.testutils.DefaultServer;
-import org.junit.Assume;
 import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -51,17 +49,5 @@ public class ServletInputStreamRequestBufferingTestCase extends AbstractServletI
                 new ServletInfo(ASYNC_SERVLET, AsyncInputStreamServlet.class)
                         .addMapping("/" + ASYNC_SERVLET)
                         .setAsyncSupported(true));
-    }
-
-    @Test
-    public void testAsyncServletInputStreamInParallel() throws Exception {
-        Assume.assumeFalse(DefaultServer.isH2upgrade()); // FIXME UNDERTOW-1818 bytes out of order
-        super.testAsyncServletInputStreamInParallel();
-    }
-
-    @Test
-    public void testAsyncServletInputStreamInParallelOffIoThread() throws Exception {
-        Assume.assumeFalse(DefaultServer.isH2upgrade()); // FIXME UNDERTOW-1818 bytes out of order
-        super.testAsyncServletInputStreamInParallelOffIoThread();
     }
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/streams/ServletInputStreamTestCase.java
@@ -67,7 +67,7 @@ public class ServletInputStreamTestCase extends AbstractServletInputStreamTestCa
     public void testAsyncServletInputStreamInParallelOffIoThread() {
     }
 
-    @Override @Test @Ignore ("UNDERTOW-1927 503 result received sporadically UNDERTOW-1818 bytes out of order") // FIXME
+    @Override @Test @Ignore ("UNDERTOW-1927 503 result received sporadically") // FIXME
     public void testAsyncServletInputStreamInParallel() {
     }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-1818

There are different changes in the PR although the former is the main one (the rest fixes minor issues in the same `AbstractServletInputStreamTestCase` test):

1. The direct solution for the issue is in the `Connectors` class. As the method is called `ungetRequestBytes` the order is directly changed. If we identify that something needs to insert real new data at the current point in the exchange (not data that was read before and is push back to be read again) another method can be created with the previous order. I think that all the callers are using the re-read / push-back idea.
2. Adding a max queue size because sometimes proxy tests fail (error 500) when concurrency tests start in input stream classes. The proxy conf now allows the requests to be queued up to 20 (max concurrency).
3. Setting a timeout of 60s for all the proxy configurations and inside the async stream tests. Previously it was 30 and 120 (although servlets had default 30s), so aligning everything to 60s. It was enough for me.
4. Reducing the concurrency of the input stream tests to 4 * CPUs up to previous 20 (maximum). Envs with only a few CPUs are limited to cope with the requests in 60s.

In my envs (windows-2016 and linux-fedora) the `ServletInputStreamRequestBufferingTestCase` was executed with `-P proxy` option 50 times without issues.  Let's see how the tests go.