### PR TITLE
[UNDERTOW-2251] At Http2DataStreamSinkChannel, dot not send END_STREA…

### DIFF
--- a/core/src/main/java/io/undertow/protocols/http2/Http2DataStreamSinkChannel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2DataStreamSinkChannel.java
@@ -127,7 +127,7 @@ public class Http2DataStreamSinkChannel extends Http2StreamSinkChannel implement
             firstBuffer.put(0, (byte) ((headerFrameLength >> 16) & 0xFF));
             firstBuffer.put(1, (byte) ((headerFrameLength >> 8) & 0xFF));
             firstBuffer.put(2, (byte) (headerFrameLength & 0xFF));
-            firstBuffer.put(4, (byte) ((isFinalFrameQueued() && !getBuffer().hasRemaining() && frameType == Http2Channel.FRAME_TYPE_HEADERS && trailers == null ? Http2Channel.HEADERS_FLAG_END_STREAM : 0) | (result == HpackEncoder.State.COMPLETE ? Http2Channel.HEADERS_FLAG_END_HEADERS : 0 ) | (paddingBytes > 0 ? Http2Channel.HEADERS_FLAG_PADDED : 0))); //flags
+            firstBuffer.put(4, (byte) ((isFinalFrameQueued() && !getBuffer().hasRemaining() && frameType == Http2Channel.FRAME_TYPE_HEADERS && !isContinueStatus() && trailers == null ? Http2Channel.HEADERS_FLAG_END_STREAM : 0) | (result == HpackEncoder.State.COMPLETE ? Http2Channel.HEADERS_FLAG_END_HEADERS : 0 ) | (paddingBytes > 0 ? Http2Channel.HEADERS_FLAG_PADDED : 0))); //flags
             ByteBuffer currentBuffer = firstBuffer;
 
             if(currentBuffer.remaining() < paddingBytes) {
@@ -263,6 +263,10 @@ public class Http2DataStreamSinkChannel extends Http2StreamSinkChannel implement
             }
         }
 
+    }
+
+    private boolean isContinueStatus() {
+        return "100".equals(this.getHeaders().getFirst(Http2Channel.STATUS));
     }
 
     private HpackEncoder.State encodeContinuationFrame(HeaderMap headers, PooledByteBuffer current) {


### PR DESCRIPTION
…M in the response if response status is 100

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/UNDERTOW-2251
Follows up the Jira: https://issues.redhat.com/browse/UNDERTOW-2031

For more information on the absence of a test in this commit, see https://issues.redhat.com/browse/UNDERTOW-2031?focusedCommentId=21078926&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21078926

For manually reproducing the bug and verifying the fix, check https://github.com/fl4via/undertow/tree/UNDERTOW-2031-reproducer