### PR TITLE
[UNDERTOW-2171..UNDERTOW-2175][UNDERTOW-2177..UNDERTOW-2183] Dependencies upgrade

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/JDBCLogDatabaseTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/JDBCLogDatabaseTestCase.java
@@ -85,8 +85,8 @@ public class JDBCLogDatabaseTestCase {
                     " virtualHost VARCHAR(64)," +
                     " method VARCHAR(8)," +
                     " query VARCHAR(255) NOT NULL," +
-                    " status SMALLINT UNSIGNED NOT NULL," +
-                    " bytes INT UNSIGNED NOT NULL," +
+                    " status SMALLINT NOT NULL," +
+                    " bytes INT NOT NULL," +
                     " referer VARCHAR(128)," +
                     " userAgent VARCHAR(128)," +
                     " PRIMARY KEY (id)" +
@@ -150,7 +150,9 @@ public class JDBCLogDatabaseTestCase {
                 statement = conn.createStatement();
                 ResultSet resultDatabase = statement.executeQuery("SELECT * FROM PUBLIC.ACCESS;");
                 resultDatabase.next();
-                Assert.assertEquals(DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), resultDatabase.getString(logHandler.getRemoteHostField()));
+                // for some reason H2 database version 2 is filling in extra blanks in the remote host field. So, even though
+                // Undertow sets "127.0.0.1", h2 database is witing "127.0.0.1      " (length 15), so, just trim it
+                Assert.assertEquals(DefaultServer.getDefaultServerAddress().getAddress().getHostAddress(), resultDatabase.getString(logHandler.getRemoteHostField()).trim());
                 Assert.assertEquals("5", resultDatabase.getString(logHandler.getBytesField()));
                 Assert.assertEquals("200", resultDatabase.getString(logHandler.getStatusField()));
                 client.getConnectionManager().shutdown();

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.junit>4.13.2</version.junit>
-        <version.netty>4.1.50.Final</version.netty>
+        <version.netty>4.1.82.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>
         <version.org.jboss.classfilewriter>1.2.4.Final</version.org.jboss.classfilewriter>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <version.xnio>3.8.8.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
         <version.org.jboss.threads>3.5.0.Final</version.org.jboss.threads>
-        <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
+        <version.org.wildfly.common>1.6.0.Final</version.org.wildfly.common>
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
 
         <!-- jacoco -->

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             For example: <version.org.jboss.as.console>
          -->
         <version.com.h2database>2.1.214</version.com.h2database>
-        <version.easymock>4.2</version.easymock>
+        <version.easymock>4.3</version.easymock>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <version.netty>4.1.82.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>
-        <version.org.jboss.classfilewriter>1.2.4.Final</version.org.jboss.classfilewriter>
+        <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.2.1.Final</version.org.jboss.logging.processor>
         <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.2.1.Final</version.org.jboss.logging.processor>
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
-        <version.xnio>3.8.7.Final</version.xnio>
+        <version.xnio>3.8.8.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
         <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
-        <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
+        <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.2.1.Final</version.org.jboss.logging.processor>
         <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>
         <version.xnio>3.8.7.Final</version.xnio>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
          -->
         <version.com.h2database>2.1.214</version.com.h2database>
         <version.easymock>4.3</version.easymock>
-        <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
+        <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.org.wildfly.extras.batavia>1.0.13.Final</version.org.wildfly.extras.batavia>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
-        <version.junit>4.13</version.junit>
+        <version.junit>4.13.2</version.junit>
         <version.netty>4.1.50.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
         <version.org.jboss.logging.processor>2.2.1.Final</version.org.jboss.logging.processor>
-        <version.org.jboss.logmanager>2.1.14.Final</version.org.jboss.logmanager>
+        <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
         <version.xnio>3.8.7.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
         <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
             versions, add the artifactId or other qualifier to the property name.
             For example: <version.org.jboss.as.console>
          -->
-        <version.com.h2database>1.4.200</version.com.h2database>
+        <version.com.h2database>2.1.214</version.com.h2database>
         <version.easymock>4.2</version.easymock>
         <version.jakarta.annotation.jakarta-annotation-api>2.0.0</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.0.0</version.jakarta.servlet.jakarta-servlet-api>
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
-        <version.org.wildfly.extras.batavia>1.0.13.Final</version.org.wildfly.extras.batavia>
         <version.junit>4.13</version.junit>
         <version.netty>4.1.50.Final</version.netty>
         <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
@@ -290,30 +289,6 @@
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>${version.bundle.plugin}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.wildfly.extras.batavia</groupId>
-                    <artifactId>transformer-tools-mvn</artifactId>
-                    <version>${version.org.wildfly.extras.batavia}</version>
-                    <executions>
-                        <execution>
-                            <id>transform-sources</id>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>transform-sources</goal>
-                            </goals>
-                            <configuration>
-                                <source-project>${jakarta.transformer.input.dir}</source-project>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.wildfly.extras.batavia</groupId>
-                            <artifactId>transformer-impl-eclipse</artifactId>
-                            <version>${version.org.wildfly.extras.batavia}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -555,18 +530,6 @@
                 <artifactId>jmh-generator-annprocess</artifactId>
                 <version>${version.jmh}</version>
                 <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.extras.batavia</groupId>
-                <artifactId>transformer-api</artifactId>
-                <version>${version.org.wildfly.extras.batavia}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.extras.batavia</groupId>
-                <artifactId>transformer-impl-eclipse</artifactId>
-                <version>${version.org.wildfly.extras.batavia}</version>
             </dependency>
 
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.org.jboss.logmanager>2.1.19.Final</version.org.jboss.logmanager>
         <version.xnio>3.8.8.Final</version.xnio>
         <!-- TODO remove this dependency once xnio upgrades to latest jboss threads -->
-        <version.org.jboss.threads>3.1.0.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>3.5.0.Final</version.org.jboss.threads>
         <version.org.wildfly.common>1.5.4.Final</version.org.wildfly.common>
         <version.org.wildfly.client-config>1.0.1.Final</version.org.wildfly.client-config>
 


### PR DESCRIPTION
Jiras:
https://issues.redhat.com/browse/UNDERTOW-2171 upgrade h2 database to 2.1.214
https://issues.redhat.com/browse/UNDERTOW-2172 upgrade easy mock to 4.3
https://issues.redhat.com/browse/UNDERTOW-2173 upgrade jakarta annotation api to 2.1.1
https://issues.redhat.com/browse/UNDERTOW-2174 remove batavia dependencies
https://issues.redhat.com/browse/UNDERTOW-2175 upgrade junit to 4.13.2
https://issues.redhat.com/browse/UNDERTOW-2177 upgrade netty to 4.1.82.Final
https://issues.redhat.com/browse/UNDERTOW-2178 upgrade jboss class file writer to 1.2.5.Final
https://issues.redhat.com/browse/UNDERTOW-2179 upgrade jboss logging to 3.4.3.Final
https://issues.redhat.com/browse/UNDERTOW-2180 upgrade jboss log manager to 2.1.19.Final
https://issues.redhat.com/browse/UNDERTOW-2181 upgrade XNIO to 3.8.8.Final
https://issues.redhat.com/browse/UNDERTOW-2182 upgrade jboss threads to 3.50.Final
https://issues.redhat.com/browse/UNDERTOW-2183 upgrade wildfly common to 1.6.0.Final