### PR TITLE
[UNDERTOW-2185] Upgrade Apache DS to 2.0.0.AM26

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -111,9 +111,15 @@
         
         <dependency>
             <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-all</artifactId>
+            <artifactId>apacheds-test-framework</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-interceptor-kerberos</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/core/src/test/java/io/undertow/server/handlers/BlockingReadTimeoutHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/BlockingReadTimeoutHandlerTestCase.java
@@ -21,10 +21,10 @@ package io.undertow.server.handlers;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
 import io.undertow.testutils.HttpOneOnly;
 import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.Headers;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.junit.Assert;
@@ -71,7 +71,7 @@ public class BlockingReadTimeoutHandlerTestCase {
             @Override
             public void handleRequest(final HttpServerExchange exchange) throws Exception {
                 try {
-                    IOUtils.copyLarge(exchange.getInputStream(), STUB_OUTPUT_STREAM);
+                    HttpClientUtils.transfer(exchange.getInputStream(), STUB_OUTPUT_STREAM);
                     exchange.getOutputStream().write("COMPLETED".getBytes(StandardCharsets.UTF_8));
                 } catch (IOException e) {
                     exception = e;

--- a/core/src/test/java/io/undertow/server/handlers/URLDecodingHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/URLDecodingHandlerTestCase.java
@@ -23,15 +23,16 @@ import io.undertow.UndertowOptions;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.RoutingHandler;
+import io.undertow.testutils.HttpClientUtils;
 import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.PathTemplateMatch;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Carter Kozak
@@ -162,6 +163,6 @@ public class URLDecodingHandlerTestCase {
 
     private static String getResponseString(CloseableHttpResponse response) throws IOException {
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());
-        return IOUtils.toString(response.getEntity().getContent(), "UTF-8");
+        return HttpClientUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
     }
 }

--- a/core/src/test/java/io/undertow/server/handlers/form/MultipartFormDataParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/form/MultipartFormDataParserTestCase.java
@@ -24,15 +24,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.Charsets;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -184,7 +181,7 @@ public class MultipartFormDataParserTestCase {
             entity.addPart("formValue", new StringBody("myValue", "text/plain", StandardCharsets.UTF_8));
 
             File uploadfile = new File(MultipartFormDataParserTestCase.class.getResource("uploadfile.txt").getFile());
-            FormBodyPart filePart = new FormBodyPart("file", new FileBody(uploadfile, "τεστ", "application/octet-stream", Charsets.UTF_8.toString()));
+            FormBodyPart filePart = new FormBodyPart("file", new FileBody(uploadfile, "τεστ", "application/octet-stream", StandardCharsets.UTF_8.toString()));
             filePart.addField("Content-Disposition", "form-data; name=\"file\"; filename*=\"utf-8''%CF%84%CE%B5%CF%83%CF%84.txt\"");
             entity.addPart(filePart);
 
@@ -230,9 +227,7 @@ public class MultipartFormDataParserTestCase {
 
             private String stream2String(FormData.FormValue file) throws IOException {
                 try (InputStream is = file.getFileItem().getInputStream()) {
-                    StringWriter sw = new StringWriter();
-                    IOUtils.copy(is, sw, "UTF-8");
-                    return sw.toString();
+                    return HttpClientUtils.toString(is, StandardCharsets.UTF_8);
                 }
             }
 

--- a/core/src/test/java/io/undertow/server/security/KerberosKDCUtil.java
+++ b/core/src/test/java/io/undertow/server/security/KerberosKDCUtil.java
@@ -142,7 +142,7 @@ class KerberosKDCUtil {
     private static void createPartition(final DirectoryServiceFactory dsf, final SchemaManager schemaManager, final String id,
             final String suffix) throws Exception {
         PartitionFactory pf = dsf.getPartitionFactory();
-        Partition p = pf.createPartition(schemaManager, id, suffix, 1000, workingDir.toFile());
+        Partition p = pf.createPartition(schemaManager, dsf.getDirectoryService().getDnFactory(), id, suffix, 1000, workingDir.toFile());
         pf.addIndex(p, "krb5PrincipalName", 10);
         p.initialize();
         directoryService.addPartition(p);

--- a/core/src/test/java/io/undertow/server/security/SpnegoAuthenticationTestCase.java
+++ b/core/src/test/java/io/undertow/server/security/SpnegoAuthenticationTestCase.java
@@ -28,7 +28,6 @@ import io.undertow.testutils.HttpClientUtils;
 import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.FlexBase64;
 import io.undertow.util.StatusCodes;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -44,6 +43,7 @@ import org.junit.runner.RunWith;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -128,7 +128,7 @@ public class SpnegoAuthenticationTestCase extends AuthenticationTestBase {
                             // FlexBase64.decode() returns byte buffer, which can contain backend array of greater size.
                             // when on such ByteBuffer is called array(), it returns the underlying byte array including the 0 bytes
                             // at the end, which makes the token invalid. => using Base64 mime decoder, which returnes directly properly sized byte[].
-                            token = Base64.getMimeDecoder().decode(ArrayUtils.subarray(headerBytes, NEGOTIATE.toString().length() + 1, headerBytes.length));
+                            token = Base64.getMimeDecoder().decode(Arrays.copyOfRange(headerBytes, NEGOTIATE.toString().length() + 1, headerBytes.length));
                         }
 
                         if (result.getStatusLine().getStatusCode() == StatusCodes.OK) {

--- a/core/src/test/java/io/undertow/testutils/HttpClientUtils.java
+++ b/core/src/test/java/io/undertow/testutils/HttpClientUtils.java
@@ -24,6 +24,7 @@ import org.apache.http.HttpResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
@@ -82,5 +83,21 @@ public class HttpClientUtils {
             b.write(data, 0, read);
         }
         return b.toByteArray();
+    }
+
+    public static String toString(InputStream is, Charset charset) throws IOException {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            transfer(is, out);
+            return new String(out.toByteArray(), charset);
+        }
+    }
+
+    public static void transfer(InputStream is, OutputStream os) throws IOException {
+        byte[] buffer = new byte[8192];
+        int length = is.read(buffer);
+        while (length != -1) {
+            os.write(buffer, 0, length);
+            length = is.read(buffer);
+        }
     }
 }

--- a/core/src/test/java/io/undertow/websockets/extensions/AutobahnExtensionCustomReceiverServer.java
+++ b/core/src/test/java/io/undertow/websockets/extensions/AutobahnExtensionCustomReceiverServer.java
@@ -31,7 +31,6 @@ import io.undertow.websockets.core.StreamSourceFrameChannel;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.WebSocketFrameType;
 import io.undertow.websockets.spi.WebSocketHttpExchange;
-import org.apache.log4j.BasicConfigurator;
 import org.xnio.ChannelExceptionHandler;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
@@ -166,14 +165,6 @@ public class AutobahnExtensionCustomReceiverServer {
     }
 
     public static void main(String[] args) {
-        /*
-            Use BasicConfigurator.configure() for fully console debug
-         */
-        if (args.length == 1) {
-            if (args[0].equals("--debug")) {
-                BasicConfigurator.configure();
-            }
-        }
         new AutobahnExtensionCustomReceiverServer(7777).run();
     }
 

--- a/core/src/test/java/io/undertow/websockets/extensions/AutobahnExtensionsServer.java
+++ b/core/src/test/java/io/undertow/websockets/extensions/AutobahnExtensionsServer.java
@@ -29,7 +29,6 @@ import io.undertow.websockets.WebSocketProtocolHandshakeHandler;
 import io.undertow.websockets.core.WebSocketChannel;
 import io.undertow.websockets.core.WebSocketLogger;
 import io.undertow.websockets.spi.WebSocketHttpExchange;
-import org.apache.log4j.BasicConfigurator;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.OptionMap;
@@ -107,14 +106,6 @@ public class AutobahnExtensionsServer {
     }
 
     public static void main(String[] args) {
-        /*
-            Use BasicConfigurator.configure() for fully debug
-         */
-        if (args.length == 1) {
-            if (args[0].equals("--debug")) {
-                BasicConfigurator.configure();
-            }
-        }
         new AutobahnExtensionsServer(7777).run();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
         <version.junit>4.13.2</version.junit>
         <version.netty>4.1.82.Final</version.netty>
-        <version.org.apache.directory.server>2.0.0-M15</version.org.apache.directory.server>
+        <version.org.apache.directory.server>2.0.0.AM26</version.org.apache.directory.server>
         <version.org.apache.httpcomponents>4.5.12</version.org.apache.httpcomponents>
         <version.org.jboss.classfilewriter>1.2.5.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.logging>3.4.3.Final</version.org.jboss.logging>
@@ -426,7 +426,14 @@
 
             <dependency>
                 <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-all</artifactId>
+                <artifactId>apacheds-test-framework</artifactId>
+                <version>${version.org.apache.directory.server}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-interceptor-kerberos</artifactId>
                 <version>${version.org.apache.directory.server}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2185

Changes:

* Upgrade apacheds to 2.0.0.AM26, now the test artifact should be used in combination with the kerberos interceptor for the spnego tests.
* Tests previously used things from apacheds dependencies, all of them have been removed and substituted by two methods in the `HttpClientUtils` utility test class.
* The dependency for log4j has been removed from autobahn cos I think it's not used for anything in the tests.

Just remind the comment in the Jira. The version 2.0.0.AM26 has an issue with IBM jdk-8 and it doesn't work with it. So take care and do not backport to 2.2.x if the TS should work with that runtime. Last version that works with IBM jdk-8 is AM25.