### PR TITLE
[UNDERTOW-2054] Buffer leak errors involving SslConduit on CI

### DIFF
--- a/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/SslConduit.java
@@ -881,8 +881,8 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
                 requiresListenerInvocation = true;
             }
             if (dataToUnwrap != null) {
-                //if there is no data in the buffer we just free it
-                if (!dataToUnwrap.getBuffer().hasRemaining()) {
+                //if there is no data in the buffer or closed while unwrapping we just free it
+                if (!dataToUnwrap.getBuffer().hasRemaining() || anyAreSet(state, FLAG_CLOSED)) {
                     dataToUnwrap.close();
                     dataToUnwrap = null;
                     state &= ~FLAG_DATA_TO_UNWRAP;
@@ -992,9 +992,9 @@ public class SslConduit implements StreamSourceConduit, StreamSinkConduit {
             }
             throw e;
         } finally {
-            //this can be cleared if the channel is fully closed
+            //this can be cleared if the channel is fully closed or no data remaining
             if(wrappedData != null) {
-                if (!wrappedData.getBuffer().hasRemaining()) {
+                if (!wrappedData.getBuffer().hasRemaining() || anyAreSet(state, FLAG_CLOSED)) {
                     wrappedData.close();
                     wrappedData = null;
                 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2054

There are errors with leaks in CI runs involving `SslConduit` (mainly `doUnwrap` method). For example this [run](https://github.com/undertow-io/undertow/actions/runs/3321170261/jobs/5488507673) or this [run](https://github.com/undertow-io/undertow/actions/runs/3235864053/jobs/5300966510). As commented in  the JIRA I think that the reason is that there is a race between the `close` and the `doUnwrap` (called by a handle read in the channel). The `doUnwrap` checks at the beginning that it is not closed but it can be closed during the execution. And if a new `dataToUnwrap` was buffered after the close it is never freed. So just adding a new condition that cleans the buffers in the finally if the conduit is closed. If you prefer to throw a closed exception or similar just let me know (but I decided to just clean it).

Let's see the CI.