### PR TITLE
[UNDERTOW-2192] session.getServletContext returns wrong context with shared-session-config

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/core/SessionListenerBridge.java
+++ b/servlet/src/main/java/io/undertow/servlet/core/SessionListenerBridge.java
@@ -32,6 +32,7 @@ import io.undertow.servlet.api.Deployment;
 import io.undertow.servlet.api.ThreadSetupHandler;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.servlet.spec.HttpSessionImpl;
+import io.undertow.servlet.spec.ServletContextImpl;
 
 /**
  * Class that bridges between Undertow native session listeners and servlet ones.
@@ -60,7 +61,10 @@ public class SessionListenerBridge implements SessionListener {
 
     @Override
     public void sessionCreated(final Session session, final HttpServerExchange exchange) {
-        final HttpSessionImpl httpSession = SecurityActions.forSession(session, servletContext, true);
+        ServletContext sc = servletContext;
+        if (servletContext instanceof ServletContextImpl)
+            sc = exchange.removeAttachment(((ServletContextImpl) servletContext).contextAttachmentKey);
+        final HttpSessionImpl httpSession = SecurityActions.forSession(session, sc, true);
         applicationListeners.sessionCreated(httpSession);
     }
 

--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletContextImpl.java
@@ -115,6 +115,7 @@ public class ServletContextImpl implements ServletContext {
     private final ConcurrentMap<String, Object> attributes;
     private final SessionCookieConfigImpl sessionCookieConfig;
     private final AttachmentKey<HttpSessionImpl> sessionAttachmentKey = AttachmentKey.create(HttpSessionImpl.class);
+    public static final AttachmentKey<ServletContextImpl> contextAttachmentKey = AttachmentKey.create(ServletContextImpl.class);
     private volatile Set<SessionTrackingMode> sessionTrackingModes = new HashSet<>(Arrays.asList(new SessionTrackingMode[]{SessionTrackingMode.COOKIE, SessionTrackingMode.URL}));
     private volatile Set<SessionTrackingMode> defaultSessionTrackingModes = new HashSet<>(Arrays.asList(new SessionTrackingMode[]{SessionTrackingMode.COOKIE, SessionTrackingMode.URL}));
     private volatile SessionConfig sessionConfig;
@@ -982,6 +983,7 @@ public class ServletContextImpl implements ServletContext {
 
                 try {
                     if (httpSession == null) {
+                        exchange.putAttachment(contextAttachmentKey, this);
                         final Session newSession = sessionManager.createSession(exchange, c);
                         httpSession = SecurityActions.forSession(newSession, this, true);
                         exchange.putAttachment(sessionAttachmentKey, httpSession);


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2192
Pending equivalent for master: (TODO)