### PR TITLE
[UNDERTOW-2190] DefaultServlet serves CSS and JS blobs even if directory listing is disabled

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/resource/ResourceHandler.java
@@ -165,7 +165,7 @@ public class ResourceHandler implements HttpHandler {
 
     private void serveResource(final HttpServerExchange exchange, final boolean sendContent) throws Exception {
 
-        if (DirectoryUtils.sendRequestedBlobs(exchange)) {
+        if (directoryListingEnabled && DirectoryUtils.sendRequestedBlobs(exchange)) {
             return;
         }
 

--- a/core/src/test/java/io/undertow/server/handlers/file/FileHandlerTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/file/FileHandlerTestCase.java
@@ -39,8 +39,11 @@ import io.undertow.util.Headers;
 import io.undertow.util.StatusCodes;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,6 +102,62 @@ public class FileHandlerTestCase {
     }
 
     @Test
+    public void testDirectoryListing() throws IOException, URISyntaxException {
+        TestHttpClient client = new TestHttpClient();
+        Path rootPath = Paths.get(getClass().getResource("page.html").toURI()).getParent();
+        try {
+            DefaultServer.setRootHandler(new CanonicalPathHandler()
+                    .setNext(new PathHandler()
+                            .addPrefixPath("/path", new ResourceHandler(new PathResourceManager(rootPath, 1))
+                                    .setDirectoryListingEnabled(true))));
+
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path/"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("text/html"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString("page.html"));
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path/?js"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("application/javascript"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString("growit()"));
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path/?css"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("text/css"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString("data:image/png;base64"));
+            }
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
+    public void testNoDirectoryListing() throws IOException, URISyntaxException {
+        TestHttpClient client = new TestHttpClient();
+        Path rootPath = Paths.get(getClass().getResource("page.html").toURI()).getParent();
+        try {
+            DefaultServer.setRootHandler(new CanonicalPathHandler()
+                    .setNext(new PathHandler()
+                            .addPrefixPath("/path", new ResourceHandler(new PathResourceManager(rootPath, 1)))));
+
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path?js"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/path?css"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+    @Test
     public void testDotSuffix() throws IOException, URISyntaxException {
         TestHttpClient client = new TestHttpClient();
         Path rootPath = Paths.get(getClass().getResource("page.html").toURI()).getParent();
@@ -116,6 +175,7 @@ public class FileHandlerTestCase {
             client.getConnectionManager().shutdown();
         }
     }
+
     @Test
     public void testFileTransfer() throws IOException, URISyntaxException {
         TestHttpClient client = new TestHttpClient();

--- a/servlet/src/main/java/io/undertow/servlet/handlers/DefaultServlet.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/DefaultServlet.java
@@ -176,16 +176,16 @@ public class DefaultServlet extends HttpServlet {
             }
             return;
         } else if (resource.isDirectory()) {
-            if ("css".equals(req.getQueryString())) {
-                resp.setContentType("text/css");
-                resp.getWriter().write(DirectoryUtils.Blobs.FILE_CSS);
-                return;
-            } else if ("js".equals(req.getQueryString())) {
-                resp.setContentType("application/javascript");
-                resp.getWriter().write(DirectoryUtils.Blobs.FILE_JS);
-                return;
-            }
             if (directoryListingEnabled) {
+                if ("css".equals(req.getQueryString())) {
+                    resp.setContentType("text/css");
+                    resp.getWriter().write(DirectoryUtils.Blobs.FILE_CSS);
+                    return;
+                } else if ("js".equals(req.getQueryString())) {
+                    resp.setContentType("application/javascript");
+                    resp.getWriter().write(DirectoryUtils.Blobs.FILE_JS);
+                    return;
+                }
                 resp.setContentType("text/html");
                 StringBuilder output = DirectoryUtils.renderDirectoryListing(req.getRequestURI(), resource);
                 resp.getWriter().write(output.toString());

--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletNoDirectoryListingTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletNoDirectoryListingTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2022 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.defaultservlet;
+
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.handlers.DefaultServlet;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.servlet.test.util.TestResourceLoader;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.StatusCodes;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author rmartinc
+ */
+@RunWith(DefaultServer.class)
+public class DefaultServletNoDirectoryListingTestCase {
+
+    @BeforeClass
+    public static void setup() throws ServletException {
+
+        final PathHandler root = new PathHandler();
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        DeploymentInfo builder = new DeploymentInfo()
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .setClassLoader(DefaultServletNoDirectoryListingTestCase.class.getClassLoader())
+                .setContextPath("/servletContext")
+                .setDeploymentName("servletContext.war")
+                .setResourceManager(new TestResourceLoader(DefaultServletNoDirectoryListingTestCase.class));
+
+        builder.addServlet(new ServletInfo("default", DefaultServlet.class)
+                .addMapping("/*"));
+
+        DeploymentManager manager = container.addDeployment(builder);
+        manager.deploy();
+        root.addPrefixPath(builder.getContextPath(), manager.start());
+
+        DefaultServer.setRootHandler(root);
+    }
+
+    @Test
+    public void testDirectoryListing() throws IOException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path?js"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path?css"))) {
+                Assert.assertEquals(StatusCodes.FORBIDDEN, result.getStatusLine().getStatusCode());
+            }
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/defaultservlet/DefaultServletTestCase.java
@@ -40,10 +40,12 @@ import io.undertow.testutils.TestHttpClient;
 import io.undertow.util.DateUtils;
 import io.undertow.util.Headers;
 import io.undertow.util.StatusCodes;
-import org.apache.http.Header;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -275,19 +277,28 @@ public class DefaultServletTestCase {
     public void testDirectoryListing() throws IOException {
         TestHttpClient client = new TestHttpClient();
         try {
-            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path");
-            HttpResponse result = client.execute(get);
-            Header contentType = result.getFirstHeader(Headers.CONTENT_TYPE_STRING);
-            Assert.assertNotNull(contentType);
-            Assert.assertTrue(contentType.getValue().contains("text/html"));
-            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            HttpClientUtils.readResponse(result);
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("text/html"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString(".gitkeep"));
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path?js"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("application/javascript"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString("growit()"));
+            }
+            try (CloseableHttpResponse result = client.execute(new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/path?css"))) {
+                Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+                Assert.assertNotNull(result.getFirstHeader(Headers.CONTENT_TYPE_STRING));
+                MatcherAssert.assertThat(result.getFirstHeader(Headers.CONTENT_TYPE_STRING).getValue(), CoreMatchers.startsWith("text/css"));
+                MatcherAssert.assertThat(HttpClientUtils.readResponse(result), CoreMatchers.containsString("data:image/png;base64"));
+            }
         } finally {
             client.getConnectionManager().shutdown();
         }
     }
-
-
 
     @Test
     public void testIfMoodifiedSince() throws IOException {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2190

Only send css and js for directory listing if it's enabled. Doing the same for the `ResourceHandler` and the `DefaultServlet`. Tests added for both cases.

@fl4via @ropalka An easy fix to not display the related resources for directory listing if not enabled.