### PR TITLE
[UNDERTOW-2189] IOException thrown when trying to close already closed stream

### DIFF
--- a/core/src/main/java/io/undertow/channels/DetachableStreamSourceChannel.java
+++ b/core/src/main/java/io/undertow/channels/DetachableStreamSourceChannel.java
@@ -196,9 +196,6 @@ public abstract class DetachableStreamSourceChannel implements StreamSourceChann
     }
 
     public <T> T getOption(final Option<T> option) throws IOException {
-        if (isFinished()) {
-            throw UndertowMessages.MESSAGES.streamIsClosed();
-        }
         return delegate.getOption(option);
     }
 

--- a/core/src/main/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/main/java/io/undertow/server/HttpServerExchange.java
@@ -2021,9 +2021,15 @@ public final class HttpServerExchange extends AbstractAttachable {
         @Override
         public void close() throws IOException {
             try {
-                getInputStream().close();
+                // close the input stream if open or force closing if the request is incomplete
+                if (inputStream != null || !exchange.isRequestComplete()) {
+                    getInputStream().close();
+                }
             } finally {
-                getOutputStream().close();
+                // same for the output stream
+                if (outputStream != null || !exchange.isResponseComplete()) {
+                    getOutputStream().close();
+                }
             }
         }
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2189

Two main changes:

* The `DetachableStreamSourceChannel` does not throw and exception in `getOption` if finished. It delegates to the wrapped `StreamSourceChannel`. This way the exception is avoided when using a fake channel, created [here](https://github.com/rmartinc/undertow/blob/2d5f2a3eecb8b91b038d3b04a4d228dc44ea24a6/core/src/main/java/io/undertow/server/HttpServerExchange.java#L1284).
* The `DefaultBlockingHttpExchange` now only closes input/output streams if used (`!= null`) or not completed, avoiding calling close twice in normal flow when they were not used and fully read/written.

All CIs worked for me. I have even tested jakartaee 8 TCK to see if something failed.