### PR TITLE
[UNDERTOW-2022] At MultipartParser.MultipartUploadHandler.close, clea…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -372,7 +372,6 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
             }
         }
 
-
         public List<Path> getCreatedFiles() {
             return createdFiles;
         }
@@ -395,6 +394,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                             }
                         }
                     }
+                    files.clear();
                 }
             });
 


### PR DESCRIPTION
…r the references to temp file handles

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/UNDERTOW-2202