### PR TITLE
[UNDERTOW-2200] - Path and query parameters are not decoded properly due to flag switch

### DIFF
--- a/core/src/main/java/io/undertow/attribute/RelativePathAttribute.java
+++ b/core/src/main/java/io/undertow/attribute/RelativePathAttribute.java
@@ -48,25 +48,13 @@ public class RelativePathAttribute implements ExchangeAttribute {
         if (pos == -1) {
             exchange.setRelativePath(newValue);
             String requestURI = exchange.getResolvedPath() + newValue;
-            if(requestURI.contains("%")) {
-                //as the request URI is supposed to be encoded we need to replace
-                //percent characters with their encoded form, otherwise we can run into issues
-                //where the percent will be taked to be a encoded character
-                //TODO: should we fully encode this? It seems like it also has the potential to cause issues, and encoding the percent character is probably enough
-                exchange.setRequestURI(requestURI.replaceAll("%", "%25"));
-            } else {
-                exchange.setRequestURI(requestURI);
-            }
+            exchange.setRequestURI(requestURI);
             exchange.setRequestPath(requestURI);
         } else {
             final String path = newValue.substring(0, pos);
             exchange.setRelativePath(path);
             String requestURI = exchange.getResolvedPath() + path;
-            if(requestURI.contains("%")) {
-                exchange.setRequestURI(requestURI.replaceAll("%", "%25"));
-            } else {
-                exchange.setRequestURI(requestURI);
-            }
+            exchange.setRequestURI(requestURI);
             exchange.setRequestPath(requestURI);
 
             final String newQueryString = newValue.substring(pos);

--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -486,7 +486,7 @@ public class Connectors {
                 String part;
                 String encodedPart = encodedPath.substring(currentPathPartIndex, i);
                 if (requiresDecode) {
-                    part = URLUtils.decode(encodedPart, charset, allowEncodedSlash,false, decodeBuffer);
+                    part = URLUtils.decode(encodedPart, charset, !allowEncodedSlash,false, decodeBuffer);
                 } else {
                     part = encodedPart;
                 }
@@ -503,7 +503,7 @@ public class Connectors {
                 String part;
                 String encodedPart = encodedPath.substring(currentPathPartIndex, i);
                 if (requiresDecode) {
-                    part = URLUtils.decode(encodedPart, charset, allowEncodedSlash, false, decodeBuffer);
+                    part = URLUtils.decode(encodedPart, charset, !allowEncodedSlash, false, decodeBuffer);
                 } else {
                     part = encodedPart;
                 }
@@ -519,7 +519,7 @@ public class Connectors {
         String part;
         String encodedPart = encodedPath.substring(currentPathPartIndex);
         if (requiresDecode) {
-            part = URLUtils.decode(encodedPart, charset, allowEncodedSlash, false, decodeBuffer);
+            part = URLUtils.decode(encodedPart, charset, !allowEncodedSlash, false, decodeBuffer);
         } else {
             part = encodedPart;
         }

--- a/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
@@ -76,10 +76,10 @@ public class URLDecodingHandler implements HttpHandler {
     }
 
     private static void decodePath(HttpServerExchange exchange, String charset, StringBuilder sb) {
-        final boolean decodeSlash = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
-        exchange.setRequestPath(URLUtils.decode(exchange.getRequestPath(), charset, decodeSlash, false, sb));
-        exchange.setRelativePath(URLUtils.decode(exchange.getRelativePath(), charset, decodeSlash, false, sb));
-        exchange.setResolvedPath(URLUtils.decode(exchange.getResolvedPath(), charset, decodeSlash, false, sb));
+        final boolean allowEncodedSlash = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
+        exchange.setRequestPath(URLUtils.decode(exchange.getRequestPath(), charset, !allowEncodedSlash, false, sb));
+        exchange.setRelativePath(URLUtils.decode(exchange.getRelativePath(), charset, !allowEncodedSlash, false, sb));
+        exchange.setResolvedPath(URLUtils.decode(exchange.getResolvedPath(), charset, !allowEncodedSlash, false, sb));
     }
 
     private static void decodeQueryString(HttpServerExchange exchange, String charset, StringBuilder sb) {

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -512,7 +512,7 @@ public class AjpRequestParser {
                 if(decodeBuffer == null) {
                     decodeBuffer = new StringBuilder();
                 }
-                return URLUtils.decode(url, this.encoding, allowEncodedSlash, false, decodeBuffer);
+                return URLUtils.decode(url, this.encoding, !allowEncodedSlash, false, decodeBuffer);
             } catch (Exception e) {
                 throw UndertowMessages.MESSAGES.failedToDecodeURL(url, encoding, e);
             }

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -537,10 +537,10 @@ public abstract class HttpRequestParser {
                 exchange.setQueryString(queryString);
                 if (nextQueryParam == null) {
                     if (queryParamPos != stringBuilder.length()) {
-                        exchange.addQueryParam(decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, true, true), "");
+                        exchange.addQueryParam(decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, false, true), "");
                     }
                 } else {
-                    exchange.addQueryParam(nextQueryParam, decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, true, true));
+                    exchange.addQueryParam(nextQueryParam, decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, false, true));
                 }
                 state.state = ParseState.VERSION;
                 state.stringBuilder.setLength(0);
@@ -555,7 +555,7 @@ public abstract class HttpRequestParser {
                 if (decode && (next == '+' || next == '%' || next > 127)) { //+ is only a whitespace substitute in the query part of the URL
                     urlDecodeRequired = true;
                 } else if (next == '=' && nextQueryParam == null) {
-                    nextQueryParam = decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, true, true);
+                    nextQueryParam = decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, false, true);
                     urlDecodeRequired = false;
                     queryParamPos = stringBuilder.length() + 1;
                 } else if (next == '&' && nextQueryParam == null) {
@@ -563,7 +563,7 @@ public abstract class HttpRequestParser {
                         throw UndertowMessages.MESSAGES.tooManyQueryParameters(maxParameters);
                     }
                     if (queryParamPos != stringBuilder.length()) {
-                        exchange.addQueryParam(decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, true, true), "");
+                        exchange.addQueryParam(decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, false, true), "");
                     }
                     urlDecodeRequired = false;
                     queryParamPos = stringBuilder.length() + 1;
@@ -571,7 +571,7 @@ public abstract class HttpRequestParser {
                     if (++mapCount >= maxParameters) {
                         throw UndertowMessages.MESSAGES.tooManyQueryParameters(maxParameters);
                     }
-                    exchange.addQueryParam(nextQueryParam, decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, true, true));
+                    exchange.addQueryParam(nextQueryParam, decode(stringBuilder.substring(queryParamPos), urlDecodeRequired, state, false, true));
                     urlDecodeRequired = false;
                     queryParamPos = stringBuilder.length() + 1;
                     nextQueryParam = null;
@@ -589,7 +589,7 @@ public abstract class HttpRequestParser {
 
     private String decode(final String value, boolean urlDecodeRequired, ParseState state, final boolean allowEncodedSlash, final boolean formEncoded) {
         if (urlDecodeRequired) {
-            return URLUtils.decode(value, charset, allowEncodedSlash, formEncoded, state.decodeBuffer);
+            return URLUtils.decode(value, charset, !allowEncodedSlash, formEncoded, state.decodeBuffer);
         } else {
             return value;
         }
@@ -645,7 +645,7 @@ public abstract class HttpRequestParser {
                     urlDecodeRequired = true;
                 }
                 if ((next == '=' || (next == ',' && this.allowIDLessMatrixParams)) && param == null) {
-                    param = decode(stringBuilder.substring(pos), urlDecodeRequired, state, true, true);
+                    param = decode(stringBuilder.substring(pos), urlDecodeRequired, state, false, true);
                     urlDecodeRequired = false;
                     pos = stringBuilder.length() + 1;
                 } else if (next == ';') {
@@ -672,9 +672,9 @@ public abstract class HttpRequestParser {
 
     private void handleParsedParam(String paramName, String parameterValue, HttpServerExchange exchange, boolean urlDecodeRequired, ParseState state) throws BadRequestException {
         if (paramName == null) {
-            exchange.addPathParam(decode(parameterValue, urlDecodeRequired, state, true, true), "");
+            exchange.addPathParam(decode(parameterValue, urlDecodeRequired, state, false, true), "");
         } else {  // path param already parsed so parse and add the value
-            exchange.addPathParam(paramName, decode(parameterValue, urlDecodeRequired, state, true, true));
+            exchange.addPathParam(paramName, decode(parameterValue, urlDecodeRequired, state, false, true));
         }
     }
 

--- a/core/src/test/java/io/undertow/server/EncodedEncodedSlashTestCase.java
+++ b/core/src/test/java/io/undertow/server/EncodedEncodedSlashTestCase.java
@@ -46,28 +46,10 @@ public class EncodedEncodedSlashTestCase {
         });
     }
 
-    @Test
-    public void testSlashNotDecoded() throws Exception {
-
-        final TestHttpClient client = new TestHttpClient();
-        try {
-            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/%2f%5c");
-            HttpResponse result = client.execute(get);
-            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            Assert.assertEquals("/%2f%5c", HttpClientUtils.readResponse(result));
-
-        } finally {
-            client.getConnectionManager().shutdown();
-        }
-    }
-
-
     @Test @ProxyIgnore
     public void testSlashDecoded() throws Exception {
 
         final TestHttpClient client = new TestHttpClient();
-        OptionMap old = DefaultServer.getUndertowOptions();
-        DefaultServer.setUndertowOptions(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true));
         try {
             HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/%2f%5c");
             HttpResponse result = client.execute(get);
@@ -75,6 +57,31 @@ public class EncodedEncodedSlashTestCase {
             Assert.assertEquals("//\\", HttpClientUtils.readResponse(result));
 
         } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
+
+    @Test
+    public void testSlashNotDecoded() throws Exception {
+
+        final TestHttpClient client = new TestHttpClient();
+        final OptionMap old = DefaultServer.getUndertowOptions();
+        final OptionMap oldProxy = DefaultServer.getProxyOptions();
+        if(oldProxy != null) {
+            DefaultServer.setProxyOptions(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true));
+        }
+        DefaultServer.setUndertowOptions(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true));
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/%2f%5c");
+            HttpResponse result = client.execute(get);
+            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            Assert.assertEquals("/%2f%5c", HttpClientUtils.readResponse(result));
+
+        } finally {
+            if(oldProxy != null) {
+                DefaultServer.setProxyOptions(oldProxy);
+            }
             DefaultServer.setUndertowOptions(old);
             client.getConnectionManager().shutdown();
         }

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -56,7 +56,7 @@ public class SimpleParserTestCase {
         HttpRequestParser.instance(OptionMap.EMPTY).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertSame(Methods.GET, result.getRequestMethod());
         Assert.assertEquals("/somepath%2FotherPath", result.getRequestURI());
-        Assert.assertEquals("/somepath%2FotherPath", result.getRequestPath());
+        Assert.assertEquals("/somepath/otherPath", result.getRequestPath());
     }
 
     @Test
@@ -67,7 +67,7 @@ public class SimpleParserTestCase {
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertSame(Methods.GET, result.getRequestMethod());
-        Assert.assertEquals("/somepath/otherPath", result.getRequestPath());
+        Assert.assertEquals("/somepath%2fotherPath", result.getRequestPath());
         Assert.assertEquals("/somepath%2fotherPath", result.getRequestURI());
     }
 
@@ -555,15 +555,15 @@ public class SimpleParserTestCase {
 
     @Test
     public void testQueryParams() throws BadRequestException {
-        byte[] in = "GET http://www.somehost.net/somepath?a=b&b=c&d&e&f= HTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
+        byte[] in = "GET http://www.somehost.net/somepath?a=b%3e%2F&b=c&d&e&f= HTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t  value\n\r\n".getBytes();
 
         final ParseState context = new ParseState(10);
         HttpServerExchange result = new HttpServerExchange(null);
         HttpRequestParser.instance(OptionMap.EMPTY).handle(ByteBuffer.wrap(in), context, result);
         Assert.assertEquals("/somepath", result.getRelativePath());
         Assert.assertEquals("http://www.somehost.net/somepath", result.getRequestURI());
-        Assert.assertEquals("a=b&b=c&d&e&f=", result.getQueryString());
-        Assert.assertEquals("b", result.getQueryParameters().get("a").getFirst());
+        Assert.assertEquals("a=b%3e%2F&b=c&d&e&f=", result.getQueryString());
+        Assert.assertEquals("b>/", result.getQueryParameters().get("a").getFirst());
         Assert.assertEquals("c", result.getQueryParameters().get("b").getFirst());
         Assert.assertEquals("", result.getQueryParameters().get("d").getFirst());
         Assert.assertEquals("", result.getQueryParameters().get("e").getFirst());

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -954,6 +954,24 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
         }
     }
 
+    public static OptionMap getProxyOptions() {
+        if(proxyOpenListener != null) {
+            return proxyOpenListener.getUndertowOptions();
+        } else {
+            return null;
+        }
+    }
+
+    public static void setProxyOptions(final OptionMap options) {
+        OptionMap.Builder builder = OptionMap.builder().addAll(options);
+        builder = builder.set(UndertowOptions.BUFFER_PIPELINED_DATA, true);
+
+        if (proxyOpenListener != null) {
+            proxyOpenListener.setUndertowOptions(builder.getMap());
+            proxyOpenListener.closeConnections();
+        }
+    }
+
     public static void setServerOptions(final OptionMap options) {
         serverOptionMapBuilder = OptionMap.builder().addAll(options);
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2200
Deprecatred by: https://github.com/undertow-io/undertow/pull/1438