### PR TITLE
[UNDERTOW-2200] - Path and query parameters are not decoded properly …

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -117,10 +117,24 @@ public class UndertowOptions {
      * this is disabled by default.
      * <p>
      * Defaults to false
-     *
+     * <p>
      * See <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-0450">CVE-2007-0450</a>
+     * @deprecated - this option was interpreted improperly.
+     * @See {@link #DECODE_SLASH}
      */
     public static final Option<Boolean> ALLOW_ENCODED_SLASH = Option.simple(UndertowOptions.class, "ALLOW_ENCODED_SLASH", Boolean.class);
+
+    /**
+     * If a request comes in with encoded / characters (i.e. %2F), will these be decoded.
+     * <p>
+     * This can cause security problems if a front end proxy does not perform the same decoding, and as a result
+     * this is disabled by default.
+     * <p>
+     * If this option is set explicitly, the {@link #ALLOW_ENCODED_SLASH} is ignored. Should default to <b>true</b>
+     * <p>
+     * See <a href="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2007-0450">CVE-2007-0450</a>
+     */
+    public static final Option<Boolean> DECODE_SLASH = Option.simple(UndertowOptions.class, "DECODE_SLASH", Boolean.class);
 
     /**
      * If this is true then the parser will decode the URL and query parameters using the selected character encoding (UTF-8 by default). If this is false they will

--- a/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/URLDecodingHandler.java
@@ -76,10 +76,10 @@ public class URLDecodingHandler implements HttpHandler {
     }
 
     private static void decodePath(HttpServerExchange exchange, String charset, StringBuilder sb) {
-        final boolean decodeSlash = exchange.getConnection().getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
-        exchange.setRequestPath(URLUtils.decode(exchange.getRequestPath(), charset, decodeSlash, false, sb));
-        exchange.setRelativePath(URLUtils.decode(exchange.getRelativePath(), charset, decodeSlash, false, sb));
-        exchange.setResolvedPath(URLUtils.decode(exchange.getResolvedPath(), charset, decodeSlash, false, sb));
+        boolean slashDecodingFlag = URLUtils.getSlashDecodingFlag(exchange.getConnection().getUndertowOptions());
+        exchange.setRequestPath(URLUtils.decode(exchange.getRequestPath(), charset, slashDecodingFlag, false, sb));
+        exchange.setRelativePath(URLUtils.decode(exchange.getRelativePath(), charset, slashDecodingFlag, false, sb));
+        exchange.setResolvedPath(URLUtils.decode(exchange.getResolvedPath(), charset, slashDecodingFlag, false, sb));
     }
 
     private static void decodeQueryString(HttpServerExchange exchange, String charset, StringBuilder sb) {

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
@@ -32,6 +32,8 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.OpenListener;
 import io.undertow.server.ServerConnection;
 import io.undertow.server.XnioByteBufferPool;
+import io.undertow.util.URLUtils;
+
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 import org.xnio.Options;
@@ -98,7 +100,7 @@ public class AjpOpenListener implements OpenListener {
         PooledByteBuffer buf = pool.allocate();
         this.bufferSize = buf.getBuffer().remaining();
         buf.close();
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), undertowOptions.get(UndertowOptions.ALLOW_ENCODED_SLASH, false), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, false), undertowOptions.get(UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN, DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, false), undertowOptions.get(UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN, DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
         connectorStatistics = new ConnectorStatisticsImpl();
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
     }
@@ -178,7 +180,7 @@ public class AjpOpenListener implements OpenListener {
         }
         this.undertowOptions = undertowOptions;
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), undertowOptions.get(UndertowOptions.ALLOW_ENCODED_SLASH, false), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, false));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, true), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, false));
     }
 
     @Override

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -74,7 +74,7 @@ public class AjpRequestParser {
 
     private final String encoding;
     private final boolean doDecode;
-    private final boolean allowEncodedSlash;
+    private final boolean slashDecodingFlag;
     private final int maxParameters;
     private final int maxHeaders;
     private StringBuilder decodeBuffer;
@@ -184,16 +184,16 @@ public class AjpRequestParser {
         ATTR_SET = new HashSet<>(Arrays.asList(ATTRIBUTES));
     }
 
-    public AjpRequestParser(String encoding, boolean doDecode, int maxParameters, int maxHeaders, boolean allowEncodedSlash, boolean allowUnescapedCharactersInUrl) {
-        this(encoding, doDecode, maxParameters, maxHeaders, allowEncodedSlash, allowUnescapedCharactersInUrl, null);
+    public AjpRequestParser(String encoding, boolean doDecode, int maxParameters, int maxHeaders, boolean slashDecodingFlag, boolean allowUnescapedCharactersInUrl) {
+        this(encoding, doDecode, maxParameters, maxHeaders, slashDecodingFlag, allowUnescapedCharactersInUrl, null);
     }
 
-    public AjpRequestParser(String encoding, boolean doDecode, int maxParameters, int maxHeaders, boolean allowEncodedSlash, boolean allowUnescapedCharactersInUrl, String allowedRequestAttributesPattern) {
+    public AjpRequestParser(String encoding, boolean doDecode, int maxParameters, int maxHeaders, boolean slashDecodingFlag, boolean allowUnescapedCharactersInUrl, String allowedRequestAttributesPattern) {
         this.encoding = encoding;
         this.doDecode = doDecode;
         this.maxParameters = maxParameters;
         this.maxHeaders = maxHeaders;
-        this.allowEncodedSlash = allowEncodedSlash;
+        this.slashDecodingFlag = slashDecodingFlag;
         this.allowUnescapedCharactersInUrl = allowUnescapedCharactersInUrl;
         if (allowedRequestAttributesPattern != null && !allowedRequestAttributesPattern.isEmpty()) {
             this.allowedRequestAttributesPattern = Pattern.compile(allowedRequestAttributesPattern);
@@ -512,7 +512,7 @@ public class AjpRequestParser {
                 if(decodeBuffer == null) {
                     decodeBuffer = new StringBuilder();
                 }
-                return URLUtils.decode(url, this.encoding, allowEncodedSlash, false, decodeBuffer);
+                return URLUtils.decode(url, this.encoding, slashDecodingFlag, false, decodeBuffer);
             } catch (Exception e) {
                 throw UndertowMessages.MESSAGES.failedToDecodeURL(url, encoding, e);
             }

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -164,7 +164,7 @@ public abstract class HttpRequestParser {
 
     private final int maxParameters;
     private final int maxHeaders;
-    private final boolean allowEncodedSlash;
+    private final boolean slashDecodingFlag;
     private final boolean decode;
     private final String charset;
     private final int maxCachedHeaderSize;
@@ -212,7 +212,7 @@ public abstract class HttpRequestParser {
     public HttpRequestParser(OptionMap options) {
         maxParameters = options.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS);
         maxHeaders = options.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS);
-        allowEncodedSlash = options.get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
+        slashDecodingFlag = URLUtils.getSlashDecodingFlag(options);
         decode = options.get(UndertowOptions.DECODE_URL, true);
         charset = options.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
         maxCachedHeaderSize = options.get(UndertowOptions.MAX_CACHED_HEADER_SIZE, UndertowOptions.DEFAULT_MAX_CACHED_HEADER_SIZE);
@@ -474,7 +474,7 @@ public abstract class HttpRequestParser {
             exchange.setRelativePath("/");
             exchange.setRequestURI(path, true);
         } else if (parseState < HOST_DONE && state.canonicalPath.length() == 0) {
-            String decodedPath = decode(path, urlDecodeRequired, state, allowEncodedSlash, false);
+            String decodedPath = decode(path, urlDecodeRequired, state, slashDecodingFlag, false);
             exchange.setRequestPath(decodedPath);
             exchange.setRelativePath(decodedPath);
             exchange.setRequestURI(path, false);
@@ -497,7 +497,7 @@ public abstract class HttpRequestParser {
 
     private void handleFullUrl(ParseState state, HttpServerExchange exchange, int canonicalPathStart, boolean urlDecodeRequired, String path, int parseState) {
         state.canonicalPath.append(path.substring(canonicalPathStart));
-        String thePath = decode(state.canonicalPath.toString(), urlDecodeRequired, state, allowEncodedSlash, false);
+        String thePath = decode(state.canonicalPath.toString(), urlDecodeRequired, state, slashDecodingFlag, false);
         exchange.setRequestPath(thePath);
         exchange.setRelativePath(thePath);
         exchange.setRequestURI(path, parseState == HOST_DONE);
@@ -587,9 +587,9 @@ public abstract class HttpRequestParser {
         state.mapCount = mapCount;
     }
 
-    private String decode(final String value, boolean urlDecodeRequired, ParseState state, final boolean allowEncodedSlash, final boolean formEncoded) {
+    private String decode(final String value, boolean urlDecodeRequired, ParseState state, final boolean slashDecodingFlag, final boolean formEncoded) {
         if (urlDecodeRequired) {
-            return URLUtils.decode(value, charset, allowEncodedSlash, formEncoded, state.decodeBuffer);
+            return URLUtils.decode(value, charset, slashDecodingFlag, formEncoded, state.decodeBuffer);
         } else {
             return value;
         }

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -72,6 +72,7 @@ import io.undertow.util.AttachmentList;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
 import io.undertow.util.StatusCodes;
+import io.undertow.util.URLUtils;
 
 import static io.undertow.protocols.http2.Http2Channel.AUTHORITY;
 import static io.undertow.protocols.http2.Http2Channel.METHOD;
@@ -440,7 +441,7 @@ public class Http2ServerConnection extends ServerConnection {
             exchange.setProtocol(Protocols.HTTP_1_1);
             exchange.setRequestScheme(this.exchange.getRequestScheme());
             try {
-                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), getUndertowOptions().get(UndertowOptions.ALLOW_ENCODED_SLASH, false), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
+                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), URLUtils.getSlashDecodingFlag(getUndertowOptions()), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
             } catch (ParameterLimitException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.debug("Too many parameters in HTTP/2 request", e);
                 exchange.setStatusCode(StatusCodes.BAD_REQUEST);

--- a/core/src/main/java/io/undertow/util/URLUtils.java
+++ b/core/src/main/java/io/undertow/util/URLUtils.java
@@ -21,7 +21,10 @@ package io.undertow.util;
 import java.io.UnsupportedEncodingException;
 import java.util.regex.Pattern;
 
+import org.xnio.OptionMap;
+
 import io.undertow.UndertowMessages;
+import io.undertow.UndertowOptions;
 import io.undertow.server.HttpServerExchange;
 
 /**
@@ -348,5 +351,21 @@ public class URLUtils {
             return SCHEME_PATTERN.matcher(location).matches();
         }
         return false;
+    }
+
+    public static boolean getSlashDecodingFlag(final OptionMap options) {
+        final boolean allowEncodedSlash = options.get(UndertowOptions.ALLOW_ENCODED_SLASH, false);
+        final Boolean decodeSlash = options.get(UndertowOptions.DECODE_SLASH);
+        return getSlashDecodingFlag(allowEncodedSlash, decodeSlash);
+    }
+
+    public static boolean getSlashDecodingFlag(final boolean allowEncodedSlash, final Boolean decodeSlash) {
+        final boolean slashDecodingFlag;
+        if (decodeSlash != null) {
+            slashDecodingFlag = decodeSlash;
+        } else {
+            slashDecodingFlag = allowEncodedSlash;
+        }
+        return slashDecodingFlag;
     }
 }

--- a/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
+++ b/core/src/test/java/io/undertow/server/protocol/http/SimpleParserTestCase.java
@@ -72,6 +72,31 @@ public class SimpleParserTestCase {
     }
 
     @Test
+    public void testEncodedSlashDisallowed_DECODE_FLAG() throws BadRequestException {
+        byte[] in = "GET /somepath%2FotherPath HTTP/1.1\r\n\r\n".getBytes();
+
+        final ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.DECODE_SLASH, false)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("/somepath%2FotherPath", result.getRequestURI());
+        Assert.assertEquals("/somepath%2FotherPath", result.getRequestPath());
+    }
+
+    @Test
+    public void testEncodedSlashAllowed_DECODE_FLAG() throws BadRequestException {
+        byte[] in = "GET /somepath%2fotherPath HTTP/1.1\r\n\r\n".getBytes();
+
+        final ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        //this also tests override of UndertowOptions.ALLOW_ENCODED_SLASH
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.ALLOW_ENCODED_SLASH, false, UndertowOptions.DECODE_SLASH, true)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertSame(Methods.GET, result.getRequestMethod());
+        Assert.assertEquals("/somepath/otherPath", result.getRequestPath());
+        Assert.assertEquals("/somepath%2fotherPath", result.getRequestURI());
+    }
+
+    @Test
     public void testColonSlashInURL() throws BadRequestException {
         byte[] in = "GET /a/http://myurl.com/b/c HTTP/1.1\r\n\r\n".getBytes();
 
@@ -564,6 +589,24 @@ public class SimpleParserTestCase {
         Assert.assertEquals("http://www.somehost.net/somepath", result.getRequestURI());
         Assert.assertEquals("a=b&b=c&d&e&f=", result.getQueryString());
         Assert.assertEquals("b", result.getQueryParameters().get("a").getFirst());
+        Assert.assertEquals("c", result.getQueryParameters().get("b").getFirst());
+        Assert.assertEquals("", result.getQueryParameters().get("d").getFirst());
+        Assert.assertEquals("", result.getQueryParameters().get("e").getFirst());
+        Assert.assertEquals("", result.getQueryParameters().get("f").getFirst());
+
+    }
+
+    @Test
+    public void testQueryParams_DECODE_FLAG() throws BadRequestException {
+        byte[] in = "GET http://www.somehost.net/somepath?a=b%3e%2F&b=c&d&e&f= HTTP/1.1\nHost: \t www.somehost.net\nOtherHeader:\tsome\n \t value\n\r\n".getBytes();
+
+        final ParseState context = new ParseState(10);
+        HttpServerExchange result = new HttpServerExchange(null);
+        HttpRequestParser.instance(OptionMap.create(UndertowOptions.DECODE_SLASH, false)).handle(ByteBuffer.wrap(in), context, result);
+        Assert.assertEquals("/somepath", result.getRelativePath());
+        Assert.assertEquals("http://www.somehost.net/somepath", result.getRequestURI());
+        Assert.assertEquals("a=b%3e%2F&b=c&d&e&f=", result.getQueryString());
+        Assert.assertEquals("b>/", result.getQueryParameters().get("a").getFirst());
         Assert.assertEquals("c", result.getQueryParameters().get("b").getFirst());
         Assert.assertEquals("", result.getQueryParameters().get("d").getFirst());
         Assert.assertEquals("", result.getQueryParameters().get("e").getFirst());

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -954,6 +954,24 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
         }
     }
 
+    public static OptionMap getProxyOptions() {
+        if (proxyOpenListener != null) {
+            return proxyOpenListener.getUndertowOptions();
+        } else {
+            return null;
+        }
+    }
+
+    public static void setProxyOptions(final OptionMap options) {
+        OptionMap.Builder builder = OptionMap.builder().addAll(options);
+        builder = builder.set(UndertowOptions.BUFFER_PIPELINED_DATA, true);
+
+        if (proxyOpenListener != null) {
+            proxyOpenListener.setUndertowOptions(builder.getMap());
+            proxyOpenListener.closeConnections();
+        }
+    }
+
     public static void setServerOptions(final OptionMap options) {
         serverOptionMapBuilder = OptionMap.builder().addAll(options);
     }


### PR DESCRIPTION
…due to flag switch
Issue: https://issues.redhat.com/browse/UNDERTOW-2200
Deprecates: https://github.com/undertow-io/undertow/pull/1414