### PR TITLE
[UNDERTOW-2243] At ServletOutputStreamImpl.updateWritten, flush the c…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletOutputStreamImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletOutputStreamImpl.java
@@ -373,7 +373,7 @@ public class ServletOutputStreamImpl extends ServletOutputStream implements Buff
         this.written += len;
         long contentLength = servletRequestContext.getOriginalResponse().getContentLength();
         if (contentLength != -1 && this.written >= contentLength) {
-            close();
+            flushInternal();
         }
     }
 


### PR DESCRIPTION
…hannel instead of closing it if full content length has been written

Jira: https://issues.redhat.com/browse/UNDERTOW-2243