### PR TITLE
[UNDERTOW-2254] Included the HttpServerExchange in the HostSelector.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingProxyClient.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingProxyClient.java
@@ -360,7 +360,7 @@ public class LoadBalancingProxyClient implements ProxyClient {
             }
         }
 
-        int host = hostSelector.selectHost(hosts);
+        int host = hostSelector.selectHost(hosts, exchange);
 
         final int startHost = host; //if the all hosts have problems we come back to this one
         Host full = null;
@@ -473,7 +473,7 @@ public class LoadBalancingProxyClient implements ProxyClient {
 
     public interface HostSelector {
 
-        int selectHost(Host[] availableHosts);
+        int selectHost(Host[] availableHosts, HttpServerExchange exchange);
     }
 
     static class RoundRobinHostSelector implements HostSelector {
@@ -481,7 +481,7 @@ public class LoadBalancingProxyClient implements ProxyClient {
         private final AtomicInteger currentHost = new AtomicInteger(0);
 
         @Override
-        public int selectHost(Host[] availableHosts) {
+        public int selectHost(Host[] availableHosts, HttpServerExchange exchange) {
             return currentHost.incrementAndGet() % availableHosts.length;
         }
     }

--- a/core/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingProxyClient.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/LoadBalancingProxyClient.java
@@ -473,7 +473,11 @@ public class LoadBalancingProxyClient implements ProxyClient {
 
     public interface HostSelector {
 
+        @Deprecated(forRemoval = true)
+        int selectHost(Host[] availableHosts);
+
         int selectHost(Host[] availableHosts, HttpServerExchange exchange);
+
     }
 
     static class RoundRobinHostSelector implements HostSelector {
@@ -481,8 +485,15 @@ public class LoadBalancingProxyClient implements ProxyClient {
         private final AtomicInteger currentHost = new AtomicInteger(0);
 
         @Override
-        public int selectHost(Host[] availableHosts, HttpServerExchange exchange) {
+        @Deprecated(forRemoval = true)
+        public int selectHost(Host[] availableHosts) {
             return currentHost.incrementAndGet() % availableHosts.length;
         }
+
+        @Override
+        public int selectHost(Host[] availableHosts, HttpServerExchange exchange) {
+            return selectHost(availableHosts);
+        }
+
     }
 }

--- a/core/src/test/java/io/undertow/server/handlers/proxy/LoadBalancingProxyWithCustomHostSelectorTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/proxy/LoadBalancingProxyWithCustomHostSelectorTestCase.java
@@ -2,6 +2,7 @@ package io.undertow.server.handlers.proxy;
 
 import io.undertow.Undertow;
 import io.undertow.client.UndertowClient;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.server.session.InMemorySessionManager;
 import io.undertow.server.session.SessionAttachmentHandler;
 import io.undertow.server.session.SessionCookieConfig;
@@ -54,7 +55,7 @@ public class LoadBalancingProxyWithCustomHostSelectorTestCase {
 
         LoadBalancingProxyClient.HostSelector hostSelector = new LoadBalancingProxyClient.HostSelector() {
             @Override
-            public int selectHost(LoadBalancingProxyClient.Host[] availableHosts) {
+            public int selectHost(LoadBalancingProxyClient.Host[] availableHosts, HttpServerExchange exchange) {
                 return 0;
             }
         };


### PR DESCRIPTION
This allows for advanced routing based on eg. header values or attributes.
Jira: https://issues.redhat.com/browse/UNDERTOW-2254