### PR TITLE
[UNDERTOW-2249] Add more info to the IOException thrown by ClientConnection

### DIFF
--- a/core/src/main/java/io/undertow/client/UndertowClientMessages.java
+++ b/core/src/main/java/io/undertow/client/UndertowClientMessages.java
@@ -57,6 +57,7 @@ public interface UndertowClientMessages {
     @Message(id = 1032, value = "Unknown transfer encoding %s")
     IOException unknownTransferEncoding(String transferEncodingString);
 
+    @Deprecated (forRemoval = true)
     @Message(id = 1033, value = "Invalid connection state")
     IOException invalidConnectionState();
 
@@ -74,4 +75,11 @@ public interface UndertowClientMessages {
 
     @Message(id = 1038, value = "Received invalid AJP chunk %s with response already complete")
     IOException receivedInvalidChunk(byte prefix);
+
+    @Message(id = 1039, value = "Invalid connection state: upgrade")
+    IOException invalidUpgradeConnectionState();
+
+    @Message(id = 1040, value = "Invalid connection state: close")
+    IOException invalidCloseConnectionState();
+
 }

--- a/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
@@ -233,8 +233,12 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
 
     @Override
     public void sendRequest(final ClientRequest request, final ClientCallback<ClientExchange> clientCallback) {
-        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED | CLOSE_REQ | CLOSED)) {
-            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidConnectionState());
+        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidUpgradeConnectionState());
+            return;
+        }
+        if (anyAreSet(state, CLOSE_REQ | CLOSED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidCloseConnectionState());
             return;
         }
         final AjpClientExchange AjpClientExchange = new AjpClientExchange(clientCallback, request, this);

--- a/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
@@ -348,8 +348,12 @@ class HttpClientConnection extends AbstractAttachable implements Closeable, Clie
             http2Delegate.sendRequest(request, clientCallback);
             return;
         }
-        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED | CLOSE_REQ | CLOSED)) {
-            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidConnectionState());
+        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidUpgradeConnectionState());
+            return;
+        }
+        if (anyAreSet(state, CLOSE_REQ | CLOSED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.invalidCloseConnectionState());
             return;
         }
         final HttpClientExchange httpClientExchange = new HttpClientExchange(clientCallback, request, this);

--- a/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
+++ b/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
@@ -360,8 +360,7 @@ public class HttpClientTestCase {
             latch.await(10, TimeUnit.SECONDS);
 
             Assert.assertEquals(0, responses.size());
-            // see UNDERTOW-2249: assert exception instanceof ClosedChannelException
-            Assert.assertNotNull(exception);
+            Assert.assertTrue(exception instanceof ClosedChannelException || exception.getMessage().equals("Invalid connection state: close"));
         } finally {
             connection.getIoThread().execute(() -> IoUtils.safeClose(connection));
             DefaultServer.stopSSLServer();


### PR DESCRIPTION
, differentiating the upgrade states from closed ones. At HttpClientTestCase.testSslServerIdentity, enforce that the exception is either a ClosedChannelException or it is an IOException with the message for invalid closed state message.

Jira: https://issues.redhat.com/browse/UNDERTOW-2249
Alternative to PR #1455 
Which option should be chosen is being discussed at Zulip: https://wildfly.zulipchat.com/#narrow/stream/174183-undertow/topic/Should.20ClientConnection.20request.20get.20IOException.20when.20closed.3F