### PR TITLE
[UNDERTOW-1938] Resolve MaxRequestSizeTestCase flakiness on Windows

### DIFF
--- a/core/src/test/java/io/undertow/server/MaxRequestSizeTestCase.java
+++ b/core/src/test/java/io/undertow/server/MaxRequestSizeTestCase.java
@@ -18,29 +18,27 @@
 
 package io.undertow.server;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
+import io.undertow.UndertowOptions;
+import io.undertow.server.handlers.BlockingHandler;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpClientUtils;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.testutils.ProxyIgnore;
+import io.undertow.testutils.TestHttpClient;
+import io.undertow.util.Headers;
 import io.undertow.util.StatusCodes;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.OptionMap;
 
-import io.undertow.UndertowOptions;
-import io.undertow.server.handlers.BlockingHandler;
-import io.undertow.testutils.DefaultServer;
-import io.undertow.testutils.HttpOneOnly;
-import io.undertow.testutils.HttpClientUtils;
-import io.undertow.testutils.ProxyIgnore;
-import io.undertow.testutils.TestHttpClient;
-import io.undertow.util.Headers;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * @author Stuart Douglas
@@ -71,8 +69,6 @@ public class MaxRequestSizeTestCase {
 
     @Test
     public void testMaxRequestHeaderSize() throws IOException {
-        // FIXME UNDERTOW-1938 (returns 500 response instead of 200, sporadic)
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
         OptionMap existing = DefaultServer.getUndertowOptions();
         final TestHttpClient client = new TestHttpClient();
         try {

--- a/core/src/test/java/io/undertow/testutils/DefaultServer.java
+++ b/core/src/test/java/io/undertow/testutils/DefaultServer.java
@@ -951,6 +951,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
             if (loadBalancingProxyClient != null) {
                 loadBalancingProxyClient.closeCurrentConnections();
             }
+            waitWorkerRunnableCycle(worker);
         }
     }
 
@@ -969,6 +970,7 @@ public class DefaultServer extends BlockJUnit4ClassRunner {
         if (proxyOpenListener != null) {
             proxyOpenListener.setUndertowOptions(builder.getMap());
             proxyOpenListener.closeConnections();
+            waitWorkerRunnableCycle(worker);
         }
     }
 


### PR DESCRIPTION
...by waiting for a worker cycle to complete after closing the open listener's connections, making sure no connection is going to be reused in the next request.

Jira: https://issues.redhat.com/browse/UNDERTOW-1938

