### PR TITLE
Reducing the chance of flaky test failure UNDERTOW-2231

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/proxy/AbstractLoadBalancingProxyTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/proxy/AbstractLoadBalancingProxyTestCase.java
@@ -203,7 +203,7 @@ public abstract class AbstractLoadBalancingProxyTestCase {
             resultString.append(HttpClientUtils.readResponse(result));
             resultString.append(' ');
             server1.stop();
-            Thread.sleep(600);
+            Thread.sleep(1200);
             get = new HttpGet(DefaultServer.getDefaultServerURL() + "/name");
             result = client.execute(get);
             Assert.assertEquals("Test failed with i=" + i, StatusCodes.OK, result.getStatusLine().getStatusCode());


### PR DESCRIPTION
This pull request will solve the Issue https://issues.redhat.com/browse/UNDERTOW-2231

**Failure:**
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.379 s <<< FAILURE! - in io.undertow.server.handlers.proxy.LoadBalancingProxyTestCase
[ERROR] testLoadSharedWithServerShutdown(io.undertow.server.handlers.proxy.LoadBalancingProxyTestCase)  Time elapsed: 2.377 s  <<< FAILURE!
java.lang.AssertionError: Test failed with i=0 expected:<200> but was:<503>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at io.undertow.server.handlers.proxy.AbstractLoadBalancingProxyTestCase.testLoadSharedWithServerShutdown(AbstractLoadBalancingProxyTestCase.java:209)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at io.undertow.testutils.DefaultServer.runChild(DefaultServer.java:707)
	at io.undertow.testutils.DefaultServer.runChild(DefaultServer.java:145)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at io.undertow.testutils.RunDefaultServer.evaluate(RunDefaultServer.java:74)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at io.undertow.testutils.DefaultServer.run(DefaultServer.java:377)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junitcore.JUnitCore.run(JUnitCore.java:55)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:137)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:107)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:83)
	at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:75)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:158)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:383)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:344)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:417)

[ERROR] Failures: 
[ERROR]   LoadBalancingProxyTestCase>AbstractLoadBalancingProxyTestCase.testLoadSharedWithServerShutdown:209 Test failed with i=0 expected:<200> but was:<503>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

