### PR TITLE
[UNDERTOW-2258] Fix the new method HeaderMap.putAll

### DIFF
--- a/core/src/main/java/io/undertow/util/HeaderMap.java
+++ b/core/src/main/java/io/undertow/util/HeaderMap.java
@@ -762,10 +762,10 @@ public final class HeaderMap implements Iterable<HeaderValues> {
 
     public HeaderMap putAll(HeaderMap headerMap) {
         checkNotNullParam("headerMap", headerMap);
-        if (headerMap.headerNames != null) {
-            for (HttpString headerName: headerMap.headerNames) {
-                putAll(headerName, headerMap.getEntry(headerName));
-            }
+        final Iterator<HeaderValues> iterator = headerMap.iterator();
+        while (iterator.hasNext()) {
+            final HeaderValues headerValues = iterator.next();
+            putAll(headerValues.getHeaderName(), headerValues);
         }
         return this;
     }


### PR DESCRIPTION
The previous fix is not fully correct. This completes the UNDERTOW-2258 fix.

Jira: https://issues.redhat.com/browse/UNDERTOW-2258