### PR TITLE
Remove uses of classes in javax.security.cert

### DIFF
--- a/core/src/main/java/io/undertow/protocols/ssl/SNISSLEngine.java
+++ b/core/src/main/java/io/undertow/protocols/ssl/SNISSLEngine.java
@@ -33,7 +33,6 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSessionContext;
-import javax.security.cert.X509Certificate;
 
 import io.undertow.UndertowMessages;
 
@@ -255,10 +254,6 @@ class SNISSLEngine extends SSLEngine {
 
             public Certificate[] getLocalCertificates() {
                 return null;
-            }
-
-            public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
-                throw new UnsupportedOperationException();
             }
 
             public Principal getPeerPrincipal() throws SSLPeerUnverifiedException {

--- a/core/src/main/java/io/undertow/server/BasicSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/BasicSSLSessionInfo.java
@@ -24,8 +24,6 @@ import org.xnio.SslClientAuthMode;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.CertificateException;
-import javax.security.cert.X509Certificate;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +39,6 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
     private final byte[] sessionId;
     private final String cypherSuite;
     private final java.security.cert.Certificate[] peerCertificate;
-    private final X509Certificate[] certificate;
     private final Integer keySize;
 
     /**
@@ -51,9 +48,8 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
      * @param certificate A string representation of the client certificate
      * @param keySize The key-size used by the cypher
      * @throws java.security.cert.CertificateException If the client cert could not be decoded
-     * @throws CertificateException If the client cert could not be decoded
      */
-    public BasicSSLSessionInfo(byte[] sessionId, String cypherSuite, String certificate, Integer keySize) throws java.security.cert.CertificateException, CertificateException {
+    public BasicSSLSessionInfo(byte[] sessionId, String cypherSuite, String certificate, Integer keySize) throws java.security.cert.CertificateException {
         this.sessionId = sessionId;
         this.cypherSuite = cypherSuite;
         this.keySize = keySize;
@@ -63,26 +59,13 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
             ByteArrayInputStream stream = new ByteArrayInputStream(certificateBytes);
             Collection<? extends java.security.cert.Certificate> certCol = cf.generateCertificates(stream);
             this.peerCertificate = new java.security.cert.Certificate[certCol.size()];
-            X509Certificate[] legacyCertificate = new X509Certificate[certCol.size()];
             int i=0;
             for(java.security.cert.Certificate cert : certCol) {
                 this.peerCertificate[i] = cert;
-                if (legacyCertificate != null) {
-                    try {
-                        legacyCertificate[i] = X509Certificate.getInstance(cert.getEncoded());
-                    } catch (CertificateException ce) {
-                        // [UNDERTOW-1969] We don't care about deprecated JDK methods failure caused by the fact newer JDKs
-                        // doesn't support them anymore. "this.certificate" is used only by deprecated method
-                        // {@link SSLSessionInfo.getPeerCertificateChain()} which call should be avoided by API users.
-                        legacyCertificate = null;
-                    }
-                }
                 i++;
             }
-            this.certificate = legacyCertificate;
         } else {
             this.peerCertificate = null;
-            this.certificate = null;
         }
     }
 
@@ -92,9 +75,8 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
      * @param cypherSuite The cypher suite name
      * @param certificate A string representation of the client certificate
      * @throws java.security.cert.CertificateException If the client cert could not be decoded
-     * @throws CertificateException If the client cert could not be decoded
      */
-    public BasicSSLSessionInfo(byte[] sessionId, String cypherSuite, String certificate) throws java.security.cert.CertificateException, CertificateException {
+    public BasicSSLSessionInfo(byte[] sessionId, String cypherSuite, String certificate) throws java.security.cert.CertificateException {
         this(sessionId, cypherSuite, certificate, null);
     }
 
@@ -104,9 +86,8 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
      * @param cypherSuite The cypher suite name
      * @param certificate A string representation of the client certificate
      * @throws java.security.cert.CertificateException If the client cert could not be decoded
-     * @throws CertificateException If the client cert could not be decoded
      */
-    public BasicSSLSessionInfo(String sessionId, String cypherSuite, String certificate) throws java.security.cert.CertificateException, CertificateException {
+    public BasicSSLSessionInfo(String sessionId, String cypherSuite, String certificate) throws java.security.cert.CertificateException {
         this(sessionId == null ? null : fromHex(sessionId), cypherSuite, certificate, null);
     }
 
@@ -117,9 +98,8 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
      * @param certificate A string representation of the client certificate
      * @param keySize The key-size used by the cypher
      * @throws java.security.cert.CertificateException If the client cert could not be decoded
-     * @throws CertificateException If the client cert could not be decoded
      */
-    public BasicSSLSessionInfo(String sessionId, String cypherSuite, String certificate, Integer keySize) throws java.security.cert.CertificateException, CertificateException {
+    public BasicSSLSessionInfo(String sessionId, String cypherSuite, String certificate, Integer keySize) throws java.security.cert.CertificateException {
         this(sessionId == null ? null : fromHex(sessionId), cypherSuite, certificate, keySize);
     }
 
@@ -153,15 +133,6 @@ public class BasicSSLSessionInfo implements SSLSessionInfo {
             throw UndertowMessages.MESSAGES.peerUnverified();
         }
         return peerCertificate;
-    }
-
-    @Deprecated
-    @Override
-    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException {
-        if (certificate == null) {
-            throw UndertowMessages.MESSAGES.peerUnverified();
-        }
-        return certificate;
     }
 
     @Override

--- a/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/ConnectionSSLSessionInfo.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 
 import org.xnio.ChannelListener;
 import org.xnio.IoUtils;
@@ -93,32 +92,6 @@ public class ConnectionSSLSessionInfo implements SSLSessionInfo {
             } catch (IOException e1) {
                 //ignore, will not actually happen
             }
-            unverified = PEER_UNVERIFIED_EXCEPTION;
-            throw unverified;
-        }
-    }
-
-    @Override
-    @Deprecated(since="2.2.3", forRemoval=false)
-    public X509Certificate[] getPeerCertificateChain() throws SSLPeerUnverifiedException, RenegotiationRequiredException {
-        if (unverified != null) {
-            throw unverified;
-        }
-        if (renegotiationRequiredException != null) {
-            throw renegotiationRequiredException;
-        }
-        try {
-            return channel.getSslSession().getPeerCertificateChain();
-        } catch (SSLPeerUnverifiedException e) {
-          try {
-              SslClientAuthMode sslClientAuthMode = channel.getOption(Options.SSL_CLIENT_AUTH_MODE);
-              if (sslClientAuthMode == SslClientAuthMode.NOT_REQUESTED) {
-                  renegotiationRequiredException = RENEGOTIATION_REQUIRED_EXCEPTION;
-                  throw renegotiationRequiredException;
-              }
-          } catch (IOException ioe) {
-              // ignore, will not actually happen
-          }
             unverified = PEER_UNVERIFIED_EXCEPTION;
             throw unverified;
         }

--- a/core/src/main/java/io/undertow/server/SSLSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/SSLSessionInfo.java
@@ -101,15 +101,6 @@ public interface SSLSessionInfo {
     java.security.cert.Certificate[] getPeerCertificates() throws javax.net.ssl.SSLPeerUnverifiedException, RenegotiationRequiredException;
 
     /**
-     * This method is no longer supported on java 15 and should be avoided.
-     * @deprecated in favor of {@link #getPeerCertificates()} because {@link SSLSession#getPeerCertificateChain()}
-     *             throws java 15.
-     * @see SSLSession#getPeerCertificateChain()
-     */
-    @Deprecated(since="2.2.3", forRemoval=false)
-    javax.security.cert.X509Certificate[] getPeerCertificateChain() throws javax.net.ssl.SSLPeerUnverifiedException, RenegotiationRequiredException;
-
-    /**
      * Renegotiate in a blocking manner. This will set the client aut
      *
      * TODO: we also need a non-blocking version

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParseState.java
@@ -128,8 +128,6 @@ class AjpRequestParseState {
             return new BasicSSLSessionInfo(sessionId, cypher, cert, keySize);
         } catch (CertificateException e) {
             return null;
-        } catch (javax.security.cert.CertificateException e) {
-            return null;
         }
     }
 

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2SslSessionInfo.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.security.cert.Certificate;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
-import javax.security.cert.X509Certificate;
 import org.xnio.Options;
 import org.xnio.SslClientAuthMode;
 
@@ -65,24 +64,6 @@ class Http2SslSessionInfo implements SSLSessionInfo {
                 }
             } catch (IOException e1) {
                 //ignore, will not actually happen
-            }
-            throw e;
-        }
-    }
-
-    @Override
-    public X509Certificate[] getPeerCertificateChain()
-        throws SSLPeerUnverifiedException, RenegotiationRequiredException {
-        try {
-            return channel.getSslSession().getPeerCertificateChain();
-        } catch (SSLPeerUnverifiedException e) {
-            try {
-                SslClientAuthMode sslClientAuthMode = channel.getOption(Options.SSL_CLIENT_AUTH_MODE);
-                if (sslClientAuthMode == SslClientAuthMode.NOT_REQUESTED) {
-                    throw new RenegotiationRequiredException();
-                }
-            } catch (IOException e1) {
-              // ignore, will not actually happen
             }
             throw e;
         }

--- a/core/src/main/java/io/undertow/util/Certificates.java
+++ b/core/src/main/java/io/undertow/util/Certificates.java
@@ -28,12 +28,6 @@ public class Certificates {
 
     public static final String END_CERT = "-----END CERTIFICATE-----";
 
-    @Deprecated (since = "2.3.0", forRemoval=true)
-    public static String toPem(final javax.security.cert.X509Certificate certificate)
-            throws javax.security.cert.CertificateEncodingException {
-        return toPem(certificate.getEncoded());
-    }
-
     /**
      * Converts a certificate to PEM format.
      * @param certificate the Certificate to recode


### PR DESCRIPTION
Efforts are underway in the OpenJDK project to remove the long deprecated-for-removal classes in the package javax.security.cert. These classes were introduced for backwards compatibility concerns with the unbundled JSSE release for JDK 1.2/1.3, but their use have been discouraged since they were introduced.

It would be good to update Undertow to not depend on / use these archaic APIs.

See https://bugs.openjdk.org/browse/JDK-8227024 and the corresponding CSR https://bugs.openjdk.org/browse/JDK-8227395

Changes:

- Remove `SSLSessionInfo.getPeerCertificateChain` and its overrides in `BasicSSLSessionInfo`, `ConnectionSSLSessionInfo` and `Http2SslSessionInfo`
- Remove a catch of `javax.security.cert.CertificateException` in `AjpRequestParseState.createSslSessionInfo`
- Remove the util method `Certificates.toPem` which takes `javax.security.cert.X509Certificate` as parameter and seems unused
- SNISSLEngine.InitalState overrides `SSLEngine.getHandshakeSession` and returns a custom, mostly no-op `SSLSession`.  Since `getHandshakeSession` does not seem to be called, I opted to simply remove this override and the custom SSLSession implementation. This way we also don't need to implement `SSLSession.getPeerCertificateChain` which returns `javax.security.cert.X509Certificate[]`. Please advice if this is correct.
