### PR TITLE
UNDERTOW-2276: Fix NPE in HeaderMap.contains

### DIFF
--- a/core/src/main/java/io/undertow/util/HeaderMap.java
+++ b/core/src/main/java/io/undertow/util/HeaderMap.java
@@ -800,7 +800,7 @@ public final class HeaderMap implements Iterable<HeaderValues> {
 
     public boolean contains(HttpString headerName) {
         final HeaderValues headerValues = getEntry(headerName);
-        if (headerValues == null) {
+        if (headerValues == null || headerValues.size == 0) {
             return false;
         }
         final Object v = headerValues.value;
@@ -818,7 +818,7 @@ public final class HeaderMap implements Iterable<HeaderValues> {
 
     public boolean contains(String headerName) {
         final HeaderValues headerValues = getEntry(headerName);
-        if (headerValues == null) {
+        if (headerValues == null || headerValues.size == 0) {
             return false;
         }
         final Object v = headerValues.value;

--- a/core/src/test/java/io/undertow/util/HeaderMapTestCase.java
+++ b/core/src/test/java/io/undertow/util/HeaderMapTestCase.java
@@ -108,4 +108,15 @@ public final class HeaderMapTestCase {
         assertEquals("a", headerMap.getFirst("Link"));
         assertEquals("b", headerMap.getFirst("Rest"));
     }
+
+    // Test for UNDERTOW-2276
+    @Test
+    public void testContainsAfterClear() {
+        HeaderMap headerMap = new HeaderMap();
+        HttpString header = Headers.HOST;
+        headerMap.put(header, "a");
+        headerMap.get(header).clear();
+        assertFalse(headerMap.contains(header));
+        assertFalse(headerMap.contains(header.toString()));
+    }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2276

I've added a test which reproduces the defect prior to the provided `HeaderMap` change. It's a bit subtle because `HeaderMap.remove(header)` doesn't reproduce the problem as it removes the HeaderValues entirely, but removal via the HeaderValues collection does not clear the map entry.