### PR TITLE
[UNDERTOW-2285] Query parameters get lost in the included JSP page

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/util/DispatchUtils.java
+++ b/servlet/src/main/java/io/undertow/servlet/util/DispatchUtils.java
@@ -253,7 +253,7 @@ public final class DispatchUtils {
         }
         // both forward and include merge parameters by spec
         if (!fake.getQueryString().isEmpty()) {
-            requestImpl.setQueryParameters(mergeQueryParameters(fake.getQueryParameters(), exchange.getQueryParameters()));
+            requestImpl.setQueryParameters(mergeQueryParameters(fake.getQueryParameters(), requestImpl.getQueryParameters()));
         }
         return newRequestPath;
     }

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherIncludeTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/DispatcherIncludeTestCase.java
@@ -48,6 +48,8 @@ import org.junit.runner.RunWith;
 import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.wildfly.common.Assert.assertTrue;
@@ -295,4 +297,28 @@ public class DispatcherIncludeTestCase {
             client.getConnectionManager().shutdown();
         }
     }
+
+    @Test
+    public void testDisptacherServletIncludeNest() throws IOException, InterruptedException {
+        TestHttpClient client = new TestHttpClient();
+        try {
+            HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/servletContext/dis%25patch.dispatch?n1=v1&n2=v%252");
+            String include = URLEncoder.encode("/path%25include.includeinfo?n4=v4", StandardCharsets.UTF_8.name());
+            get.setHeader("include", "/servletContext/dis%25patch.dispatch?n3=v3&include=" + include);
+            HttpResponse result = client.execute(get);
+            assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
+            String response = HttpClientUtils.readResponse(result);
+            MatcherAssert.assertThat(response, CoreMatchers.containsString(IncludeServlet.MESSAGE + "pathInfo:null queryString:n1=v1&n2=v%252 servletPath:/dis%patch.dispatch requestUri:/servletContext/dis%25patch.dispatch\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.request_uri:/servletContext/path%25include.includeinfo\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.context_path:/servletContext\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.servlet_path:/path%include.includeinfo\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.path_info:null\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.query_string:n4=v4\r\n"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("javax.servlet.include.mapping:"));
+            MatcherAssert.assertThat(response, CoreMatchers.containsString("request params:include=/path%25include.includeinfo?n4=v4n1=v1n2=v%2n3=v3n4=v4\r\n"));
+        } finally {
+            client.getConnectionManager().shutdown();
+        }
+    }
+
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/IncludePathTestServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/IncludePathTestServlet.java
@@ -19,6 +19,9 @@ package io.undertow.servlet.test.dispatcher;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -45,6 +48,12 @@ public class IncludePathTestServlet extends HttpServlet {
             out.println("javax.servlet.include.query_string:" + req.getAttribute("javax.servlet.include.query_string"));
             out.println("javax.servlet.include.mapping:" + req.getAttribute("javax.servlet.include.mapping"));
 
+            StringBuilder sb = new StringBuilder();
+            for (Map.Entry<String, String[]> entry: req.getParameterMap().entrySet()) {
+                Optional<String> r = Arrays.stream(entry.getValue()).reduce((i, j) -> i + "," + j);
+                sb.append(entry.getKey()).append("=").append(r.orElse(""));
+            }
+            out.println("request params:" + sb);
         }
     }
 }

--- a/servlet/src/test/java/io/undertow/servlet/test/dispatcher/IncludeServlet.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/dispatcher/IncludeServlet.java
@@ -40,7 +40,11 @@ public class IncludeServlet extends HttpServlet {
         if (req.getHeader("name") != null) {
             dispatcher = req.getServletContext().getNamedDispatcher(req.getHeader("include"));
         } else {
-            dispatcher = req.getRequestDispatcher(req.getHeader("include"));
+            String include = req.getParameter("include");
+            if (include == null) {
+                include = req.getHeader("include");
+            }
+            dispatcher = req.getRequestDispatcher(include);
         }
         dispatcher.include(req, resp);
     }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2285

This is the back port of https://github.com/undertow-io/undertow/pull/1496 to `2.2.x` branch