### PR TITLE
[UNDERTOW-2289] limit SavedRequest's buffer allocation to the request length

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/util/SavedRequest.java
+++ b/servlet/src/main/java/io/undertow/servlet/util/SavedRequest.java
@@ -88,6 +88,10 @@ public class SavedRequest implements Serializable {
                     UndertowLogger.REQUEST_LOGGER.debugf("Request to %s was to large to save", exchange.getRequestURI());
                     return;//failed to save the request, we just return
                 }
+                // we don't need to size the buffer larger than a known request length
+                if (requestContentLength > 0) {
+                    maxSize = (int) requestContentLength;
+                }
                 //TODO: we should really be used pooled buffers
                 //TODO: we should probably limit the number of saved requests at any given time
                 byte[] buffer = new byte[maxSize];
@@ -97,7 +101,10 @@ public class SavedRequest implements Serializable {
                 try {
                     while ((res = in.read(buffer, read, buffer.length - read)) > 0) {
                         read += res;
-                        if (read == maxSize) {
+                        if (requestContentLength == maxSize && read == maxSize) {
+                           break;
+                        }
+                        if (read >= maxSize) {
                             UndertowLogger.REQUEST_LOGGER.debugf("Request to %s was to large to save", exchange.getRequestURI());
                             return;//failed to save the request, we just return
                         }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2289