### PR TITLE
[UNDERTOW-2295] Stop registration of managed default servlet in case default servlet exists

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
@@ -305,15 +305,16 @@ public class ServletPathMatches {
                 }
             }
         }
-        ServletHandler managedDefaultServlet = servlets.getServletHandler(DEFAULT_SERVLET_NAME);
-        if(managedDefaultServlet == null) {
-            //we always create a default servlet, even if it is not going to have any path mappings registered
-            managedDefaultServlet = servlets.addServlet(new ServletInfo(DEFAULT_SERVLET_NAME, DefaultServlet.class));
-        }
 
         if (defaultServlet == null) {
             //no explicit default servlet was specified, so we register our mapping
             pathMatches.add("/*");
+
+            ServletHandler managedDefaultServlet = servlets.getServletHandler(DEFAULT_SERVLET_NAME);
+            if(managedDefaultServlet == null) {
+                //we always create a default servlet, even if it is not going to have any path mappings registered
+                managedDefaultServlet = servlets.addServlet(new ServletInfo(DEFAULT_SERVLET_NAME, DefaultServlet.class));
+            }
             defaultServlet = managedDefaultServlet;
         }
 

--- a/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
+++ b/servlet/src/main/java/io/undertow/servlet/handlers/ServletPathMatches.java
@@ -311,8 +311,7 @@ public class ServletPathMatches {
             pathMatches.add("/*");
 
             ServletHandler managedDefaultServlet = servlets.getServletHandler(DEFAULT_SERVLET_NAME);
-            if(managedDefaultServlet == null) {
-                //we always create a default servlet, even if it is not going to have any path mappings registered
+            if (managedDefaultServlet == null) {
                 managedDefaultServlet = servlets.addServlet(new ServletInfo(DEFAULT_SERVLET_NAME, DefaultServlet.class));
             }
             defaultServlet = managedDefaultServlet;


### PR DESCRIPTION
Hi,

this addresses https://issues.redhat.com/projects/UNDERTOW/issues/UNDERTOW-2295, which came up while trying to mitigate https://spring.io/security/cve-2023-34035 and https://github.com/spring-projects/spring-security/issues/13568

Tests were green locally. Feel free to discuss the implications of this either here or in the ticket. This is more of a starting point to get the ball rolling. Unfortunately, I couldn't find a ticket that references the decision behind the default servlet registration, but only the commit https://github.com/undertow-io/undertow/commit/71c5a691 which is unfortunately not providing more info. 

There is https://issues.redhat.com/browse/UNDERTOW-149 which introduced a check for the managed default servlet not being registered twice, which the PR still kept.

Since this is likely a breaking change of some sort (is it?), I'm also happy to discuss configuration options.

Cheers,
Christoph