### PR TITLE
[UNDERTOW-2331] At RapidResetDDoSUnitTestCase, accept  a smaller numb…

### DIFF
--- a/core/src/test/java/io/undertow/protocols/http2/RapidResetDDoSUnitTestCase.java
+++ b/core/src/test/java/io/undertow/protocols/http2/RapidResetDDoSUnitTestCase.java
@@ -243,7 +243,7 @@ public class RapidResetDDoSUnitTestCase {
 
             // server sent go away before processing and responding client frames, sometimes this happens, depends on the order of threads
             // being executed
-            if (responses.isEmpty()) {
+            if (responses.size() < totalNumberOfRequests) {
                 Assert.assertTrue(errorExpected);
                 Assert.assertNotNull(exception);
                 Assert.assertTrue(exception instanceof ClosedChannelException);


### PR DESCRIPTION
…er of responses than expected as the result of race condition where client notices the connection is closed by server before processing responses and it marks reads as broken

Relates to UNDERTOW-2328
Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/UNDERTOW-2331