### PR TITLE
[UNDERTOW-2340] Remove Content-Length header when request is deflated.

### DIFF
--- a/core/src/main/java/io/undertow/io/AsyncReceiverImpl.java
+++ b/core/src/main/java/io/undertow/io/AsyncReceiverImpl.java
@@ -24,6 +24,7 @@ import io.undertow.connector.PooledByteBuffer;
 import io.undertow.server.Connectors;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
 import io.undertow.util.Headers;
 import io.undertow.util.StatusCodes;
 import org.xnio.ChannelListener;
@@ -108,6 +109,9 @@ public class AsyncReceiverImpl implements Receiver {
             return;
         }
         String contentLengthString = exchange.getRequestHeaders().getFirst(Headers.CONTENT_LENGTH);
+        if(contentLengthString == null) {
+            contentLengthString = exchange.getRequestHeaders().getFirst(Headers.X_CONTENT_LENGTH);
+        }
         long contentLength;
         final ByteArrayOutputStream sb;
         if (contentLengthString != null) {
@@ -137,7 +141,12 @@ public class AsyncReceiverImpl implements Receiver {
                     res = channel.read(buffer);
                     if (res == -1) {
                         done = true;
-                        callback.handle(exchange, sb.toString(charset.name()));
+                        final String message = sb.toString(charset.name());
+                        final HeaderMap requestHeaders = exchange.getRequestHeaders();
+                        if(requestHeaders.contains(Headers.X_CONTENT_LENGTH) && !requestHeaders.contains(Headers.CONTENT_LENGTH)) {
+                            requestHeaders.put(Headers.CONTENT_LENGTH, message.length());
+                        }
+                        callback.handle(exchange, message);
                         return;
                     } else if (res == 0) {
                         channel.getReadSetter().set(new ChannelListener<StreamSourceChannel>() {
@@ -159,7 +168,12 @@ public class AsyncReceiverImpl implements Receiver {
                                                 Connectors.executeRootHandler(new HttpHandler() {
                                                     @Override
                                                     public void handleRequest(HttpServerExchange exchange) throws Exception {
-                                                        callback.handle(exchange, sb.toString(charset.name()));
+                                                        final String message = sb.toString(charset.name());
+                                                        final HeaderMap requestHeaders = exchange.getRequestHeaders();
+                                                        if(requestHeaders.contains(Headers.X_CONTENT_LENGTH) && !requestHeaders.contains(Headers.CONTENT_LENGTH)) {
+                                                            requestHeaders.put(Headers.CONTENT_LENGTH, message.length());
+                                                        }
+                                                        callback.handle(exchange, message);
                                                     }
                                                 }, exchange);
                                                 return;
@@ -238,6 +252,9 @@ public class AsyncReceiverImpl implements Receiver {
             return;
         }
         String contentLengthString = exchange.getRequestHeaders().getFirst(Headers.CONTENT_LENGTH);
+        if(contentLengthString == null) {
+            contentLengthString = exchange.getRequestHeaders().getFirst(Headers.X_CONTENT_LENGTH);
+        }
         long contentLength;
         if (contentLengthString != null) {
             contentLength = Long.parseLong(contentLengthString);
@@ -396,7 +413,12 @@ public class AsyncReceiverImpl implements Receiver {
                     res = channel.read(buffer);
                     if (res == -1) {
                         done = true;
-                        callback.handle(exchange, sb.toByteArray());
+                        final byte[] message = sb.toByteArray();
+                        final HeaderMap requestHeaders = exchange.getRequestHeaders();
+                        if(requestHeaders.contains(Headers.X_CONTENT_LENGTH) && !requestHeaders.contains(Headers.CONTENT_LENGTH)) {
+                            requestHeaders.put(Headers.CONTENT_LENGTH, message.length);
+                        }
+                        callback.handle(exchange, message);
                         return;
                     } else if (res == 0) {
                         channel.getReadSetter().set(new ChannelListener<StreamSourceChannel>() {
@@ -418,7 +440,12 @@ public class AsyncReceiverImpl implements Receiver {
                                                 Connectors.executeRootHandler(new HttpHandler() {
                                                     @Override
                                                     public void handleRequest(HttpServerExchange exchange) throws Exception {
-                                                        callback.handle(exchange, sb.toByteArray());
+                                                        final byte[] message = sb.toByteArray();
+                                                        final HeaderMap requestHeaders = exchange.getRequestHeaders();
+                                                        if(requestHeaders.contains(Headers.X_CONTENT_LENGTH) && !requestHeaders.contains(Headers.CONTENT_LENGTH)) {
+                                                            requestHeaders.put(Headers.CONTENT_LENGTH, message.length);
+                                                        }
+                                                        callback.handle(exchange, message);
                                                     }
                                                 }, exchange);
                                                 return;
@@ -495,6 +522,9 @@ public class AsyncReceiverImpl implements Receiver {
             return;
         }
         String contentLengthString = exchange.getRequestHeaders().getFirst(Headers.CONTENT_LENGTH);
+        if(contentLengthString == null) {
+            contentLengthString = exchange.getRequestHeaders().getFirst(Headers.X_CONTENT_LENGTH);
+        }
         long contentLength;
         if (contentLengthString != null) {
             contentLength = Long.parseLong(contentLengthString);

--- a/core/src/main/java/io/undertow/server/handlers/encoding/RequestEncodingHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/encoding/RequestEncodingHandler.java
@@ -61,6 +61,11 @@ public class RequestEncodingHandler implements HttpHandler {
             // Nested handlers or even servlet filters may implement logic to decode encoded request data.
             // Since the data is no longer encoded, we remove the encoding header.
             exchange.getRequestHeaders().remove(Headers.CONTENT_ENCODING);
+            final String encodedContentLength = exchange.getRequestHeaders().getFirst(Headers.CONTENT_LENGTH);
+            if(encodedContentLength != null) {
+                exchange.getRequestHeaders().remove(Headers.CONTENT_LENGTH);
+                exchange.getRequestHeaders().put(Headers.X_CONTENT_LENGTH, encodedContentLength);
+            }
         }
         next.handleRequest(exchange);
     }

--- a/core/src/main/java/io/undertow/util/Headers.java
+++ b/core/src/main/java/io/undertow/util/Headers.java
@@ -114,6 +114,7 @@ public final class Headers {
     public static final String VIA_STRING = "Via";
     public static final String WARNING_STRING = "Warning";
     public static final String WWW_AUTHENTICATE_STRING = "WWW-Authenticate";
+    public static final String X_CONTENT_LENGTH_STRING = "X-Content-Length";
     public static final String X_CONTENT_TYPE_OPTIONS_STRING = "X-Content-Type-Options";
     public static final String X_DISABLE_PUSH_STRING = "X-Disable-Push";
     public static final String X_FORWARDED_FOR_STRING = "X-Forwarded-For";
@@ -123,7 +124,6 @@ public final class Headers {
     public static final String X_FORWARDED_SERVER_STRING = "X-Forwarded-Server";
     public static final String X_FRAME_OPTIONS_STRING = "X-Frame-Options";
     public static final String X_XSS_PROTECTION_STRING = "X-Xss-Protection";
-
     // Header names
 
     public static final HttpString ACCEPT = new HttpString(ACCEPT_STRING, 1);
@@ -200,15 +200,16 @@ public final class Headers {
     public static final HttpString VIA = new HttpString(VIA_STRING, 72);
     public static final HttpString WARNING = new HttpString(WARNING_STRING, 73);
     public static final HttpString WWW_AUTHENTICATE = new HttpString(WWW_AUTHENTICATE_STRING, 74);
-    public static final HttpString X_CONTENT_TYPE_OPTIONS = new HttpString(X_CONTENT_TYPE_OPTIONS_STRING, 75);
-    public static final HttpString X_DISABLE_PUSH = new HttpString(X_DISABLE_PUSH_STRING, 76);
-    public static final HttpString X_FORWARDED_FOR = new HttpString(X_FORWARDED_FOR_STRING, 77);
-    public static final HttpString X_FORWARDED_HOST = new HttpString(X_FORWARDED_HOST_STRING, 78);
-    public static final HttpString X_FORWARDED_PORT = new HttpString(X_FORWARDED_PORT_STRING, 79);
-    public static final HttpString X_FORWARDED_PROTO = new HttpString(X_FORWARDED_PROTO_STRING, 80);
-    public static final HttpString X_FORWARDED_SERVER = new HttpString(X_FORWARDED_SERVER_STRING, 81);
-    public static final HttpString X_FRAME_OPTIONS = new HttpString(X_FRAME_OPTIONS_STRING, 82);
-    public static final HttpString X_XSS_PROTECTION = new HttpString(X_XSS_PROTECTION_STRING, 83);
+    public static final HttpString X_CONTENT_LENGTH = new HttpString(X_CONTENT_LENGTH_STRING, 75);
+    public static final HttpString X_CONTENT_TYPE_OPTIONS = new HttpString(X_CONTENT_TYPE_OPTIONS_STRING, 76);
+    public static final HttpString X_DISABLE_PUSH = new HttpString(X_DISABLE_PUSH_STRING, 77);
+    public static final HttpString X_FORWARDED_FOR = new HttpString(X_FORWARDED_FOR_STRING, 78);
+    public static final HttpString X_FORWARDED_HOST = new HttpString(X_FORWARDED_HOST_STRING, 79);
+    public static final HttpString X_FORWARDED_PORT = new HttpString(X_FORWARDED_PORT_STRING, 80);
+    public static final HttpString X_FORWARDED_PROTO = new HttpString(X_FORWARDED_PROTO_STRING, 81);
+    public static final HttpString X_FORWARDED_SERVER = new HttpString(X_FORWARDED_SERVER_STRING, 82);
+    public static final HttpString X_FRAME_OPTIONS = new HttpString(X_FRAME_OPTIONS_STRING, 83);
+    public static final HttpString X_XSS_PROTECTION = new HttpString(X_XSS_PROTECTION_STRING, 84);
     // Content codings
 
     public static final HttpString COMPRESS = new HttpString("compress");

--- a/core/src/test/java/io/undertow/server/handlers/encoding/RequestContentEncodingTestCase4.java
+++ b/core/src/test/java/io/undertow/server/handlers/encoding/RequestContentEncodingTestCase4.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
+ * Copyright 2024 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,9 @@
 package io.undertow.server.handlers.encoding;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -28,10 +30,12 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import io.undertow.conduits.GzipStreamSourceConduit;
 import io.undertow.conduits.InflatingStreamSourceConduit;
 import io.undertow.io.IoCallback;
@@ -50,12 +54,14 @@ import io.undertow.util.StatusCodes;
  * @author Stuart Douglas
  */
 @RunWith(DefaultServer.class)
-public class RequestContentEncodingTestCase {
+public class RequestContentEncodingTestCase4 {
 
     private static volatile String message;
+    private static ExecutorService executor;
 
     @BeforeClass
     public static void setup() {
+        executor = Executors.newFixedThreadPool(2);
         final ContentEncodingRepository contentEncodingRepository = new ContentEncodingRepository()
                 .addEncodingHandler("deflate", new DeflateEncodingProvider(), 50)
                 .addEncodingHandler("gzip", new GzipEncodingProvider(), 60);
@@ -71,13 +77,20 @@ public class RequestContentEncodingTestCase {
         final HttpHandler decode = new RequestEncodingHandler(new HttpHandler() {
             @Override
             public void handleRequest(HttpServerExchange exchange) throws Exception {
-                exchange.getRequestReceiver().receiveFullBytes(new Receiver.FullBytesCallback() {
+                exchange.startBlocking();
+                Future<?> result =  executor.submit(new Runnable() {
                     @Override
-                    public void handle(HttpServerExchange exchange, byte[] message) {
-                        Assert.assertTrue(exchange.getRequestContentLength()>0);
-                        exchange.getResponseSender().send(ByteBuffer.wrap(message));
+                    public void run() {
+                        exchange.getRequestReceiver().receiveFullString(new Receiver.FullStringCallback() {
+                            @Override
+                            public void handle(HttpServerExchange exchange, String message) {
+                                Assert.assertTrue(exchange.getRequestContentLength()>0);
+                                exchange.getResponseSender().send(message);
+                            }
+                        });
                     }
                 });
+                result.get();
             }
         }).addEncoding("deflate", InflatingStreamSourceConduit.WRAPPER)
                 .addEncoding("gzip", GzipStreamSourceConduit.WRAPPER);
@@ -87,6 +100,11 @@ public class RequestContentEncodingTestCase {
         pathHandler.addPrefixPath("/decode", decode);
 
         DefaultServer.setRootHandler(pathHandler);
+    }
+
+    @AfterClass
+    public static void boom() {
+        executor.shutdownNow();
     }
 
     /**
@@ -115,25 +133,6 @@ public class RequestContentEncodingTestCase {
         runTest(sb.toString(), "gzip");
     }
 
-    private static final String MESSAGE = "COMPRESSED I'AM";
-    private static final byte[] COMPRESSED_MESSAGE = { 0x78, (byte) (0x9C & 0xFF), 0x73, (byte) (0xF6 & 0xFF),
-            (byte) (0xF7 & 0xFF), 0x0D, 0x08, 0x72, 0x0D, 0x0E, 0x76, 0x75, 0x51, (byte) (0xF0 & 0xFF), 0x54, 0x77,
-            (byte) (0xF4 & 0xFF), 0x05, 0x00, 0x22, 0x35, 0x04, 0x14 };
-
-    @Test
-    public void testDeflateWithNoWrapping() throws IOException {
-        HttpPost post = new HttpPost(DefaultServer.getDefaultServerURL() + "/decode");
-        post.setEntity(new ByteArrayEntity(COMPRESSED_MESSAGE));
-        post.addHeader(Headers.CONTENT_ENCODING_STRING, "deflate");
-
-        try (CloseableHttpClient client = HttpClientBuilder.create().disableContentCompression().build()) {
-            HttpResponse result = client.execute(post);
-            Assert.assertEquals(StatusCodes.OK, result.getStatusLine().getStatusCode());
-            String sb = HttpClientUtils.readResponse(result);
-            Assert.assertEquals(MESSAGE.length(), sb.length());
-            Assert.assertEquals(MESSAGE, sb);
-        }
-    }
 
     public void runTest(final String theMessage, String encoding) throws IOException {
         try (CloseableHttpClient client = HttpClientBuilder.create().disableContentCompression().build()){


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2340

This needs review. Possibly change to Partial receive methods?