### PR TITLE
[UNDERTOW-2345] Use SSLContext from ClientEndpointConfig when provided

### DIFF
--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/DefaultWebSocketClientSslProvider.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/DefaultWebSocketClientSslProvider.java
@@ -63,6 +63,9 @@ public class DefaultWebSocketClientSslProvider implements WebsocketClientSslProv
         }
         //look for some SSL config
         SSLContext sslContext = (SSLContext) cec.getUserProperties().get(SSL_CONTEXT);
+        if (sslContext == null) {
+            sslContext = cec.getSSLContext();
+        }
 
         if (sslContext != null) {
             return new UndertowXnioSsl(worker.getXnio(), OptionMap.EMPTY, sslContext);


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2345

With websocket 2.1 in Jakara EE10,
"ClientEndpointConfig.Builder sslContext​(SSLContext sslContext)"
method has been added that allows us to hold SSLContext within ClientEndpointConfig.

The current DefaultWebSocketClientSslProvider (in Undertow WebSockets JSR356 implementations) ignores it.
