### PR TITLE
[UNDERTOW-2339] CVE-2024-1459 Path segment "/..;" should not be treated as "/.."

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/ParseState.java
@@ -142,6 +142,7 @@ class ParseState {
         this.leftOver = 0;
         this.urlDecodeRequired = false;
         this.stringBuilder.setLength(0);
+        this.canonicalPath.setLength(0);
         this.nextHeader = null;
         this.nextQueryParam = null;
         this.mapCount = 0;


### PR DESCRIPTION
Proxies such as httpd proxy do not resolve the path segment "/..;/" to be a double dot segment, so they would pass such request path unchanged to target server. Undertow on the other hand resolves "/..;/" as double dot, which can cause essentially a path traversal problem, where client can request resources that should not be available to him per proxy configuration.

Jira: https://issues.redhat.com/browse/UNDERTOW-2339