### PR TITLE
[UNDERTOW-2249] Change that HttpClientConnection.sendRequest on a clo...

### DIFF
--- a/core/src/main/java/io/undertow/client/UndertowClientMessages.java
+++ b/core/src/main/java/io/undertow/client/UndertowClientMessages.java
@@ -25,6 +25,7 @@ import org.jboss.logging.annotations.MessageBundle;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.channels.ClosedChannelException;
 
 /**
  * starting from 1000
@@ -74,4 +75,7 @@ public interface UndertowClientMessages {
 
     @Message(id = 1038, value = "Received invalid AJP chunk %s with response already complete")
     IOException receivedInvalidChunk(byte prefix);
+
+    @Message(id = 1039, value = "Closed connection state")
+    ClosedChannelException closedConnectionState();
 }

--- a/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/ajp/AjpClientConnection.java
@@ -233,8 +233,11 @@ class AjpClientConnection extends AbstractAttachable implements Closeable, Clien
 
     @Override
     public void sendRequest(final ClientRequest request, final ClientCallback<ClientExchange> clientCallback) {
-        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED | CLOSE_REQ | CLOSED)) {
+        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED)) {
             clientCallback.failed(UndertowClientMessages.MESSAGES.invalidConnectionState());
+            return;
+        } else if (anyAreSet(state, CLOSE_REQ | CLOSED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.closedConnectionState());
             return;
         }
         final AjpClientExchange AjpClientExchange = new AjpClientExchange(clientCallback, request, this);

--- a/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
+++ b/core/src/main/java/io/undertow/client/http/HttpClientConnection.java
@@ -348,8 +348,11 @@ class HttpClientConnection extends AbstractAttachable implements Closeable, Clie
             http2Delegate.sendRequest(request, clientCallback);
             return;
         }
-        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED | CLOSE_REQ | CLOSED)) {
+        if (anyAreSet(state, UPGRADE_REQUESTED | UPGRADED)) {
             clientCallback.failed(UndertowClientMessages.MESSAGES.invalidConnectionState());
+            return;
+        } else if (anyAreSet(state, CLOSE_REQ | CLOSED)) {
+            clientCallback.failed(UndertowClientMessages.MESSAGES.closedConnectionState());
             return;
         }
         final HttpClientExchange httpClientExchange = new HttpClientExchange(clientCallback, request, this);

--- a/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
+++ b/core/src/test/java/io/undertow/client/http/HttpClientTestCase.java
@@ -60,6 +60,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -360,8 +361,7 @@ public class HttpClientTestCase {
             latch.await(10, TimeUnit.SECONDS);
 
             Assert.assertEquals(0, responses.size());
-            // see UNDERTOW-2249: assert exception instanceof ClosedChannelException
-            Assert.assertNotNull(exception);
+            Assert.assertTrue(exception instanceof ClosedChannelException);
         } finally {
             connection.getIoThread().execute(() -> IoUtils.safeClose(connection));
             DefaultServer.stopSSLServer();


### PR DESCRIPTION
...sed connection results in a ClosedChannelException instead of IOException
https://issues.redhat.com/browse/UNDERTOW-2249