### PR TITLE
[UNDERTOW-2371] initialize the DefaultServer once to speed up test HttpContinueSslServletTestCase

### DIFF
--- a/servlet/src/test/java/io/undertow/servlet/test/handlers/AbstractHttpContinueServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/handlers/AbstractHttpContinueServletTestCase.java
@@ -32,7 +32,6 @@ import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -56,10 +55,10 @@ public abstract class AbstractHttpContinueServletTestCase {
     public static void setup() {
         DeploymentUtils.setupServlet(Servlets.servlet(ContinueConsumeServlet.class).addMappings("/path"),
                 Servlets.servlet(ContinueIgnoreServlet.class).addMappings("/ignore"));
+        Assume.assumeFalse(DefaultServer.isAjp());
     }
 
-    @Before
-    public void before() throws Exception {
+    public static void before() throws Exception {
         Assume.assumeFalse(DefaultServer.isAjp());
     }
 

--- a/servlet/src/test/java/io/undertow/servlet/test/handlers/HttpContinueSslServletTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/handlers/HttpContinueSslServletTestCase.java
@@ -20,8 +20,8 @@ package io.undertow.servlet.test.handlers;
 
 import io.undertow.testutils.DefaultServer;
 import io.undertow.testutils.TestHttpClient;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -42,14 +42,14 @@ public class HttpContinueSslServletTestCase extends AbstractHttpContinueServletT
         return client;
     }
 
-    @Before
-    public void before() throws Exception {
-        super.before();
+    @BeforeClass
+    public static void before() throws Exception {
+        AbstractHttpContinueServletTestCase.before();
         DefaultServer.startSSLServer();
     }
 
-    @After
-    public void after() throws IOException {
+    @AfterClass
+    public static void after() throws IOException {
         DefaultServer.stopSSLServer();
     }
 }


### PR DESCRIPTION
There are five tests in the test class `HttpContinueSslServletTestCase`. However, they reply on the same DefaultServer to send post http request. The time cost of start or stop for the DefaultServer is high. They are not modifying the contents of the DefaultServer, thus we can just initialize the DefaultServer once before or after all test methods inside test class `HttpContinueSslServletTestCase`.

The test runtime can jump from `5.43160 s` to `1.8027 s` after applying these changes when run on our machine.