### PR TITLE
[UNDERTOW-2374] Move the check for allowUnescapedCharactersInUrl to o…

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -322,9 +322,9 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         }
 
         // verify content of request pseudo-headers. Each header should only have a single value.
-        if (headers.contains(PATH)) {
+        if (headers.contains(PATH) && !allowUnescapedCharactersInUrl) {
             for (byte b: headers.get(PATH).getFirst().getBytes(ISO_8859_1)) {
-                if (!allowUnescapedCharactersInUrl && !HttpRequestParser.isTargetCharacterAllowed((char)b)){
+                if (!HttpRequestParser.isTargetCharacterAllowed((char)b)){
                     return false;
                 }
             }


### PR DESCRIPTION
…utside path verification loop the loop in Http2ReceiveListener.checkRequestHeaders

Jira: https://issues.redhat.com/browse/UNDERTOW-2374