### PR TITLE
[UNDERTOW-2376] Enforce to build using JDK8 for 2.2.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -598,6 +598,9 @@
                     <name>release</name>
                 </property>
             </activation>
+            <properties>
+                <jdk.min.version>[1.8, 9)</jdk.min.version>
+            </properties>
             <modules>
                 <module>dist</module>
             </modules>


### PR DESCRIPTION
This tries to limit build using JDK 8 only for 2.2.x branch to avoid some errors like: `java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer` if it was built using JDK 11 but running using JDK8.

upstream not needed
Jira: https://issues.redhat.com/browse/UNDERTOW-2376