### PR TITLE
[UNDERTOW-2389] Use WeakHashMap in DefaultByteBufferPool to avoid leak for released threads

### DIFF
--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -26,9 +26,10 @@ import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -334,7 +335,7 @@ public class DefaultByteBufferPool implements ByteBufferPool {
     // class can be called by a different thread than the one that initialized the data.
     private static class ThreadLocalCache {
 
-        Map<Thread, ThreadLocalData> localsByThread = new HashMap<>();
+        Map<Thread, ThreadLocalData> localsByThread = Collections.synchronizedMap(new WeakHashMap<>());
 
         ThreadLocalData get() {
             return localsByThread.get(Thread.currentThread());


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2389