### PR TITLE
[UNDERTOW-2397] Properly index huffman table on encoding

### DIFF
--- a/core/src/main/java/io/undertow/protocols/http2/HPackHuffman.java
+++ b/core/src/main/java/io/undertow/protocols/http2/HPackHuffman.java
@@ -442,7 +442,8 @@ public class HPackHuffman {
             if(forceLowercase) {
                 c = Hpack.toLower(c);
             }
-            HuffmanCode code = HUFFMAN_CODES[c];
+            int index = c & 0xFF;
+            HuffmanCode code = HUFFMAN_CODES[index];
             length += code.length;
         }
         int byteLength = length / 8 + (length % 8 == 0 ? 0 : 1);
@@ -458,7 +459,8 @@ public class HPackHuffman {
             if(forceLowercase) {
                 c = Hpack.toLower(c);
             }
-            HuffmanCode code = HUFFMAN_CODES[c];
+            int index = c & 0xFF;
+            HuffmanCode code = HUFFMAN_CODES[index];
             if (code.length + bytePos <= 8) {
                 //it fits in the current byte
                 currentBufferByte |= ((code.value & 0xFF) << 8 - (code.length + bytePos));


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2397
Maintenance branch: https://github.com/undertow-io/undertow/pull/1621