### PR TITLE
[UNDERTOW-2403] Fix race condition in read from buffer at ServletInpu…

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -937,6 +937,15 @@
             <Class name="io.undertow.servlet.spec.ServletOutputStreamImpl"/>
         </Or>
     </Match>
+    <Match>
+        <Bug pattern="DCN_NULLPOINTER_EXCEPTION"/>
+        <Class name="io.undertow.servlet.spec.ServletInputStreamImpl"/>
+        <Or>
+            <Method name="readIntoBuffer"/>
+            <Method name="readIntoBufferNonBlocking"/>
+            <Method name="closePoolIfNotNull"/>
+        </Or>
+    </Match>
     <!-- ignore benchmarks -->
     <Match>
         <Package name="io.undertow.benchmarks"/>


### PR DESCRIPTION
…tStreamImpl: prevent a NPE from being thrown to invoker in case input stream is closed by another thread (which can happen typically in timeouts)

Jira: https://issues.redhat.com/browse/UNDERTOW-2403