### PR TITLE
[UNDERTOW-2405] CVE-2024-27316 Fix vulnerability by limiting the numb…

### DIFF
--- a/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2Channel.java
@@ -240,7 +240,7 @@ public class Http2Channel extends AbstractFramedChannel<Http2Channel, AbstractHt
         encoderHeaderTableSize = settings.get(UndertowOptions.HTTP2_SETTINGS_HEADER_TABLE_SIZE, Hpack.DEFAULT_TABLE_SIZE);
         receiveMaxFrameSize = settings.get(UndertowOptions.HTTP2_SETTINGS_MAX_FRAME_SIZE, DEFAULT_MAX_FRAME_SIZE);
         maxPadding = settings.get(UndertowOptions.HTTP2_PADDING_SIZE, 0);
-        maxHeaderListSize = settings.get(UndertowOptions.HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, settings.get(UndertowOptions.MAX_HEADER_SIZE, -1));
+        maxHeaderListSize = settings.get(UndertowOptions.HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE, settings.get(UndertowOptions.MAX_HEADER_SIZE, UndertowOptions.DEFAULT_MAX_HEADER_SIZE));
         if(maxPadding > 0) {
             paddingRandom = new SecureRandom();
         } else {

--- a/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2FrameHeaderParser.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import static io.undertow.protocols.http2.Http2Channel.DATA_FLAG_END_STREAM;
+import static io.undertow.protocols.http2.Http2Channel.ERROR_ENHANCE_YOUR_CALM;
 import static io.undertow.protocols.http2.Http2Channel.FRAME_TYPE_CONTINUATION;
 import static io.undertow.protocols.http2.Http2Channel.FRAME_TYPE_DATA;
 import static io.undertow.protocols.http2.Http2Channel.FRAME_TYPE_GOAWAY;
@@ -108,7 +109,9 @@ class Http2FrameHeaderParser implements FrameHeaderData {
                         throw UndertowMessages.MESSAGES.http2ContinuationFrameNotExpected();
                     }
                     parser = continuationParser;
-                    continuationParser.moreData(length);
+                    if (!continuationParser.moreData(length)) {
+                        http2Channel.sendGoAway(ERROR_ENHANCE_YOUR_CALM);
+                    }
                     break;
                 }
                 case FRAME_TYPE_PUSH_PROMISE: {

--- a/core/src/main/java/io/undertow/protocols/http2/Http2PushBackParser.java
+++ b/core/src/main/java/io/undertow/protocols/http2/Http2PushBackParser.java
@@ -18,10 +18,10 @@
 
 package io.undertow.protocols.http2;
 
+import io.undertow.UndertowMessages;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import io.undertow.UndertowMessages;
 
 /**
  * Parser that supports push back when not all data can be read.
@@ -123,9 +123,10 @@ public abstract class Http2PushBackParser {
         finished = true;
     }
 
-    protected void moreData(int data) {
+    protected boolean moreData(int data) {
         finished = false;
         this.remainingData += data;
+        return true;
     }
 
     public int getFrameLength() {

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpOpenListener.java
@@ -18,19 +18,6 @@
 
 package io.undertow.server.protocol.http;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
-import org.xnio.ChannelListener;
-import org.xnio.IoUtils;
-import org.xnio.OptionMap;
-import org.xnio.Options;
-import org.xnio.Pool;
-import org.xnio.StreamConnection;
-
 import io.undertow.UndertowLogger;
 import io.undertow.UndertowMessages;
 import io.undertow.UndertowOptions;
@@ -47,6 +34,18 @@ import io.undertow.server.DelegateOpenListener;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.ServerConnection;
 import io.undertow.server.XnioByteBufferPool;
+import org.xnio.ChannelListener;
+import org.xnio.IoUtils;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Pool;
+import org.xnio.StreamConnection;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Open listener for HTTP server.  XNIO should be set up to chain the accept handler to post-accept open
@@ -56,6 +55,8 @@ import io.undertow.server.XnioByteBufferPool;
  */
 public final class HttpOpenListener implements ChannelListener<StreamConnection>, DelegateOpenListener {
 
+    private static final int DEFAULT_MAX_CONNECTIONS_PER_LISTENER = 100;
+    private static final int MAX_CONNECTIONS_PER_LISTENER = Integer.getInteger("io.undertow.max-connections-per-listener", DEFAULT_MAX_CONNECTIONS_PER_LISTENER);
     private final Set<HttpServerConnection> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private final ByteBufferPool bufferPool;
@@ -102,6 +103,12 @@ public final class HttpOpenListener implements ChannelListener<StreamConnection>
 
     @Override
     public void handleEvent(final StreamConnection channel, PooledByteBuffer buffer) {
+        if (connections.size() >= MAX_CONNECTIONS_PER_LISTENER) {
+            UndertowLogger.REQUEST_IO_LOGGER.debugf("Reached maximum number of connections %d per listener; closing open connection request from %s",
+                    MAX_CONNECTIONS_PER_LISTENER, channel.getPeerAddress());
+            IoUtils.safeClose(channel);
+            return;
+        }
         if (UndertowLogger.REQUEST_LOGGER.isTraceEnabled()) {
             UndertowLogger.REQUEST_LOGGER.tracef("Opened connection with %s", channel.getPeerAddress());
         }


### PR DESCRIPTION
…er of connections and the length of header frames in the server.

The number of connections is now limited by the system property io.undertow.max-connections-per-listener, whose default value is 100. Also, the length of the header was already being partially controlled by MAX_HEADER_SIZE. Now that value has the default max header size enforced by Http2Channel.

Jira: https://issues.redhat.com/browse/UNDERTOW-2405