### PR TITLE
[UNDERTOW-2383] do not canonicalize query string in sendRedirect location

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/HttpServletResponseImpl.java
@@ -219,7 +219,14 @@ public final class HttpServletResponseImpl implements HttpServletResponse {
                 } else {
                     current = "";
                 }
-                realPath = CanonicalPathUtils.canonicalize(servletContext.getContextPath() + current + location);
+                String precanonLocation = location;
+                String query = "";
+                int firstQuestionMark = location.indexOf("?");
+                if (firstQuestionMark >= 0) {
+                    precanonLocation = location.substring(0, firstQuestionMark);
+                    query = location.substring(firstQuestionMark);
+                }
+                realPath = CanonicalPathUtils.canonicalize(servletContext.getContextPath() + current + precanonLocation) + query;
             }
             String loc = exchange.getRequestScheme() + "://" + exchange.getHostAndPort() + realPath;
             exchange.getResponseHeaders().put(Headers.LOCATION, loc);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-27014
Upstream issue: https://issues.redhat.com/browse/UNDERTOW-2383
Upstream PR: https://github.com/undertow-io/undertow/pull/1588