### PR TITLE
[UNDERTOW-2334] CVE-2024-6162 AJP Parser: Do not share the decodeBuff…

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpRequestParser.java
@@ -77,7 +77,6 @@ public class AjpRequestParser {
     private final boolean slashDecodingFlag;
     private final int maxParameters;
     private final int maxHeaders;
-    private StringBuilder decodeBuffer;
     private final boolean allowUnescapedCharactersInUrl;
     private final Pattern allowedRequestAttributesPattern;
 
@@ -509,9 +508,7 @@ public class AjpRequestParser {
     private String decode(String url, final boolean containsUrlCharacters) throws UnsupportedEncodingException {
         if (doDecode && containsUrlCharacters) {
             try {
-                if(decodeBuffer == null) {
-                    decodeBuffer = new StringBuilder();
-                }
+                final StringBuilder decodeBuffer = new StringBuilder();
                 return URLUtils.decode(url, this.encoding, slashDecodingFlag, false, decodeBuffer);
             } catch (Exception e) {
                 throw UndertowMessages.MESSAGES.failedToDecodeURL(url, encoding, e);


### PR DESCRIPTION
…er StringBuilder instance between requests

Jira: https://issues.redhat.com/browse/UNDERTOW-2334