### PR TITLE
[UNDERTOW-2046] X-Forwarded-For is IP header, not hostname

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/ProxyHandler.java
@@ -479,7 +479,7 @@ public final class ProxyHandler implements HttpHandler {
             final String remoteHost;
             final SocketAddress address = exchange.getSourceAddress();
             if (address != null) {
-                remoteHost = ((InetSocketAddress) address).getHostString();
+                remoteHost = ((InetSocketAddress) address).getAddress().getHostAddress();
                 if(!((InetSocketAddress) address).isUnresolved()) {
                     request.putAttachment(ProxiedRequestAttachments.REMOTE_ADDRESS, ((InetSocketAddress) address).getAddress().getHostAddress());
                 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2046
Upstream PR: https://github.com/undertow-io/undertow/pull/1634