### PR TITLE
[UNDERTOW-2357] remove JDK check in Http2 example

### DIFF
--- a/examples/src/main/java/io/undertow/examples/http2/Http2Server.java
+++ b/examples/src/main/java/io/undertow/examples/http2/Http2Server.java
@@ -63,14 +63,7 @@ public class Http2Server {
     private static final char[] STORE_PASSWORD = "password".toCharArray();
 
     public static void main(final String[] args) throws Exception {
-        String version = System.getProperty("java.version");
-        System.out.println("Java version " + version);
-        if(version.charAt(0) == '1' && Integer.parseInt(version.charAt(2) + "") < 8 ) {
-            System.out.println("This example requires Java 1.8 or later");
-            System.out.println("The HTTP2 spec requires certain cyphers that are not present in older JVM's");
-            System.out.println("See section 9.2.2 of the HTTP2 specification for details");
-            System.exit(1);
-        }
+
         String bindAddress = System.getProperty("bind.address", "localhost");
         SSLContext sslContext = createSSLContext(loadKeyStore("server.keystore"), loadKeyStore("server.truststore"));
         Undertow server = Undertow.builder()


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2357
Upstream PR: https://github.com/undertow-io/undertow/pull/1570