### PR TITLE
[UNDERTOW-2425] At ServletOutputStreamImpl synchronized workflow (lis…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
@@ -103,7 +103,9 @@ public class ServletPrintWriter {
                 underflow = null;
             }
             if (charsetEncoder != null) {
+                int remaining = 0;
                 do {
+                    // before we get the underlying buffer, we need to flush outputStream
                     ByteBuffer out = outputStream.underlyingBuffer();
                     if (out == null) {
                         //servlet output stream has already been closed
@@ -113,11 +115,13 @@ public class ServletPrintWriter {
                     CoderResult result = charsetEncoder.encode(buffer, out, true);
                     if (result.isOverflow()) {
                         outputStream.flushInternal();
-                        if (out.remaining() == 0) {
+                        if (out.remaining() == remaining) {
+                            // no progress in flush
                             outputStream.close();
                             error = true;
                             return;
-                        }
+                        } else
+                            remaining = out.remaining();
                     } else {
                         done = true;
                     }
@@ -177,7 +181,7 @@ public class ServletPrintWriter {
                 outputStream.updateWritten(writtenLength);
                 if (result.isOverflow() || !buffer.hasRemaining()) {
                     outputStream.flushInternal();
-                    if (!buffer.hasRemaining()) {
+                    if (buffer.remaining() == remaining) {
                         error = true;
                         return;
                     }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -925,8 +925,13 @@
     </Match>
     <Match>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-        <Class name="io.undertow.client.http.HttpClientConnection$ClientReadListener"/>
-        <Method name="handleEvent"/>
+        <Or>
+            <And>
+                <Class name="io.undertow.client.http.HttpClientConnection$ClientReadListener"/>
+                <Method name="handleEvent"/>
+            </And>
+            <Class name="io.undertow.servlet.spec.ServletOutputStreamImpl"/>
+        </Or>
     </Match>
     <!-- ignore benchmarks -->
     <Match>


### PR DESCRIPTION
…tener = null), prevent the buffer.flip() from not being cleared after an error during attempts to write. Also, at ServletPrintWriter, verify if no progress is being made when attempting to encode returns overflow after flushing, and mark error even if there are remaining bytes in the buffer.

Issue: https://issues.redhat.com/browse/UNDERTOW-2425