### PR TITLE
[UNDERTOW-2431] Bump jboss-parent to 46, checkstyle and slightly upda…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>35</version>
+        <version>46</version>
     </parent>
 
     <groupId>io.undertow</groupId>
@@ -95,14 +95,13 @@
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
-        <version.io.undertow.build.checkstyle-config>1.0.1.Final</version.io.undertow.build.checkstyle-config>
+        <version.io.undertow.build.checkstyle-config>2.0.0.Final</version.io.undertow.build.checkstyle-config>
         <version.com.github.spotbugs-maven-plugin>4.7.3.4</version.com.github.spotbugs-maven-plugin>
 
         <version.com.twitter.hpack>1.0.2</version.com.twitter.hpack>
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.wildfly.openssl>2.2.1.Final</version.org.wildfly.openssl>
-        <version.checkstyle>7.1</version.checkstyle>
         <version.bundle.plugin>5.1.1</version.bundle.plugin>
 
         <version.jmh>1.21</version.jmh>

--- a/servlet/src/main/java/io/undertow/servlet/api/LifecycleInterceptor.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/LifecycleInterceptor.java
@@ -22,7 +22,7 @@ public interface LifecycleInterceptor {
 
     void destroy(FilterInfo filterInfo, Filter filter, LifecycleContext context) throws ServletException;
 
-    public interface LifecycleContext {
+    interface LifecycleContext {
         void proceed() throws ServletException;
     }
 }

--- a/servlet/src/main/java/io/undertow/servlet/api/ThreadSetupAction.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/ThreadSetupAction.java
@@ -37,7 +37,7 @@ public interface ThreadSetupAction {
      */
     Handle setup(final HttpServerExchange exchange);
 
-    public interface Handle {
+    interface Handle {
         void tearDown();
     }
 


### PR DESCRIPTION
…te src to align with new rules

Issue: https://issues.redhat.com/browse/UNDERTOW-2431


On hold, this require release of new undertow-checkstyle and decision which approach will be better.
This PR assumes no update to checkstyle: https://github.com/undertow-io/undertow-checkstyle-config/pull/3
Alternative: https://github.com/undertow-io/undertow/pull/1655