### PR TITLE
[UNDERTOW-2279] Re-enable LotsOfHeadersResponseTestCase in Windows

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/LotsOfHeadersResponseTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/LotsOfHeadersResponseTestCase.java
@@ -67,8 +67,6 @@ public class LotsOfHeadersResponseTestCase {
 
     @Test
     public void testLotsOfHeadersInResponse() throws IOException {
-        // FIXME UNDERTOW-2279
-        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
         TestHttpClient client = new TestHttpClient();
         try {
             HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/path");


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/UNDERTOW-2279