### PR TITLE
[UNDERTOW-2483] - marked deprecated field forRemoval

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -292,7 +292,7 @@ public class UndertowOptions {
      *
      * @see #MAX_HEADER_SIZE
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static final Option<Integer> HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE = Option.simple(UndertowOptions.class, "HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE", Integer.class);
 
     /**


### PR DESCRIPTION
Adds `forRemoval` field for `HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE`.  [Issue Link](https://issues.redhat.com/browse/UNDERTOW-2483)