### PR TITLE
[UNDERTOW-2448] At ServletPrintWriter.write(CharBuffer) do not mark e…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriter.java
@@ -180,8 +180,10 @@ public class ServletPrintWriter {
                 remainingContentLength -= writtenLength;
                 outputStream.updateWritten(writtenLength);
                 if (result.isOverflow() || !buffer.hasRemaining()) {
+                    final int remainingBytesBeforeFlush = buffer.remaining();
                     outputStream.flushInternal();
-                    if (buffer.remaining() == remaining) {
+                    if (buffer.remaining() == remainingBytesBeforeFlush) {
+                        // no progress has been made, set error to true
                         error = true;
                         return;
                     }


### PR DESCRIPTION
…rror if buffer.remaining() == remaining after flush. We need to update remaining to do a proper check here.

The aforementioned == check can return true after a successfull flush, because "remaining" value is set to be the size of the bytes remaining in the buffer before encoding. If, at that stage, the buffer is empty, "remaining" value is set to buffer.capacity(). When encoding many bytes, we will end up with a full buffer. As a result, we will try to flush, and it is often the case that the buffer will be entirely cleared after flushing. This results in buffer.remaining() being the overall buffer size, i.e., buffer.capacity(). As a result, buffer.remaining() == remaining check returns true, and write is aborted, causing the broken responses we are seeing.

Jira: https://issues.redhat.com/browse/UNDERTOW-2448