### PR TITLE
Revert "[UNDERTOW-2279] Re-enable LotsOfHeadersResponseTestCase in Wi…

### DIFF
--- a/core/src/test/java/io/undertow/server/handlers/LotsOfHeadersResponseTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/LotsOfHeadersResponseTestCase.java
@@ -67,6 +67,8 @@ public class LotsOfHeadersResponseTestCase {
 
     @Test
     public void testLotsOfHeadersInResponse() throws IOException {
+        // FIXME UNDERTOW-2279
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
         TestHttpClient client = new TestHttpClient();
         try {
             HttpGet get = new HttpGet(DefaultServer.getDefaultServerURL() + "/path");


### PR DESCRIPTION
…ndows"

The tests were disabled in CI by mistake and this prevented us seeing that those tests still need to be fixed so they can work in Windows

This reverts commit abc70e2601b69cc28d167d129bc71e29ec566cbe.

JIra: https://issues.redhat.com/browse/UNDERTOW-2279