### PR TITLE
[UNDERTOW-2538] The ServletRelativePathAttribute.Builder should have a priority of 1

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/attribute/ServletRelativePathAttribute.java
+++ b/servlet/src/main/java/io/undertow/servlet/attribute/ServletRelativePathAttribute.java
@@ -88,7 +88,7 @@ public class ServletRelativePathAttribute implements ExchangeAttribute {
 
         @Override
         public int priority() {
-            return 0;
+            return 1;
         }
     }
 }


### PR DESCRIPTION
…a priority of 1 as there is a matching ExchangeAttribute in the core module.

https://issues.redhat.com/browse/UNDERTOW-2538