### PR TITLE
[UNDERTOW-2511] CVE-2024-4109 At HpackDecoder, make sure that stringBu…

### DIFF
--- a/core/src/main/java/io/undertow/protocols/http2/HpackDecoder.java
+++ b/core/src/main/java/io/undertow/protocols/http2/HpackDecoder.java
@@ -247,11 +247,15 @@ public class HpackDecoder {
         if (huffman) {
             return readHuffmanString(length, buffer);
         }
-        for (int i = 0; i < length; ++i) {
-            stringBuilder.append((char) (buffer.get() & 0xFF));
+        final String ret;
+        try {
+            for (int i = 0; i < length; ++i) {
+                stringBuilder.append((char) (buffer.get() & 0xFF));
+            }
+            ret = stringBuilder.toString();
+        } finally {
+            stringBuilder.setLength(0);
         }
-        String ret = stringBuilder.toString();
-        stringBuilder.setLength(0);
         if (ret.isEmpty()) {
             //return the interned empty string, rather than allocating a new one each time
             return "";
@@ -260,12 +264,17 @@ public class HpackDecoder {
     }
 
     private String readHuffmanString(int length, ByteBuffer buffer) throws HpackException {
-        HPackHuffman.decode(buffer, length, stringBuilder);
-        String ret = stringBuilder.toString();
+        final String ret;
+        try {
+            HPackHuffman.decode(buffer, length, stringBuilder);
+            ret = stringBuilder.toString();
+        } finally {
+            stringBuilder.setLength(0);
+        }
         if (ret.isEmpty()) {
             return "";
         }
-        stringBuilder.setLength(0);
+
         return ret;
     }
 


### PR DESCRIPTION
…ilder field does not carry over info from one decode operation to the next one.

Notice that given the nature of Undertow's architecture, we dont have multiple threads invoking the HpackDecoder at the same time

Jira: https://issues.redhat.com/browse/UNDERTOW-2511