### PR TITLE
[UNDERTOW-2539] Move Undertow to WebSocket API 2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <version.easymock>4.3</version.easymock>
         <version.jakarta.annotation.jakarta-annotation-api>2.1.1</version.jakarta.annotation.jakarta-annotation-api>
         <version.jakarta.servlet.jakarta-servlet-api>6.1.0</version.jakarta.servlet.jakarta-servlet-api>
-        <version.jakarta.websocket.jakarta-websocket-api>2.1.0</version.jakarta.websocket.jakarta-websocket-api>
+        <version.jakarta.websocket.jakarta-websocket-api>2.1.1</version.jakarta.websocket.jakarta-websocket-api>
         <version.junit>4.13.2</version.junit>
         <version.netty>4.1.82.Final</version.netty>
         <version.org.apache.directory.server>2.0.0.AM26</version.org.apache.directory.server>


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2539

Ported to 2.4.x by #1823 