### PR TITLE
[UNDERTOW-2553] Add reuseHostHeader to ModCluster

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/ModCluster.java
@@ -59,6 +59,7 @@ public class ModCluster {
     private final String rankedAffinityDelimiter;
 
     private final boolean reuseXForwarded;
+    private final boolean rewriteHostHeader;
 
     private final String serverID = UUID.randomUUID().toString(); // TODO
 
@@ -79,6 +80,7 @@ public class ModCluster {
         this.useAlias = builder.useAlias;
         this.maxRetries = builder.maxRetries;
         this.reuseXForwarded = builder.reuseXForwarded;
+        this.rewriteHostHeader = builder.rewriteHostHeader;
         this.container = new ModClusterContainer(this, builder.xnioSsl, builder.client, builder.clientOptions);
     }
 
@@ -162,6 +164,7 @@ public class ModCluster {
                 .setMaxRequestTime(maxRequestTime)
                 .setMaxConnectionRetries(maxRetries)
                 .setReuseXForwarded(reuseXForwarded)
+                .setRewriteHostHeader(rewriteHostHeader)
                 .build();
     }
 
@@ -177,6 +180,7 @@ public class ModCluster {
                 .setMaxRequestTime(maxRequestTime)
                 .setMaxConnectionRetries(maxRetries)
                 .setReuseXForwarded(reuseXForwarded)
+                .setRewriteHostHeader(rewriteHostHeader)
                 .build();
     }
     /**
@@ -244,6 +248,7 @@ public class ModCluster {
         private String rankedAffinityDelimiter = ".";
 
         private boolean reuseXForwarded;
+        private boolean rewriteHostHeader;
 
         private Builder(XnioWorker xnioWorker, UndertowClient client, XnioSsl xnioSsl) {
             this.xnioSsl = xnioSsl;
@@ -346,6 +351,11 @@ public class ModCluster {
 
         public Builder setReuseXForwarded(boolean reuseXForwarded) {
             this.reuseXForwarded = reuseXForwarded;
+            return this;
+        }
+
+        public Builder setRewriteHostHeader(boolean rewriteHostHeader) {
+            this.rewriteHostHeader = rewriteHostHeader;
             return this;
         }
     }


### PR DESCRIPTION
Issues: https://issues.redhat.com/browse/UNDERTOW-2553
main: #1728 (and #1899; this one was created by mistake and merged by mistake, it was supposed to have gone into 2.4.x)
2.4.x: #1902 