### PR TITLE
[UNDERTOW-2569] At the parent pom, set the javadoc source version to …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
                             <head>Implementation Note:</head>
                         </tag>
                     </tags>
-                    <source>1.8</source> 
+                    <source>${maven.compiler.release}</source>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
…maven.compiler.release

Jira: https://issues.redhat.com/browse/UNDERTOW-2569