### PR TITLE
[UNDERTOW-2573] At MultiPartParserDefinition.create, only set the exch…

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -106,7 +106,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
                 }
             });
             Long sizeLimit = exchange.getConnection().getUndertowOptions().get(UndertowOptions.MULTIPART_MAX_ENTITY_SIZE);
-            if(sizeLimit != null) {
+            if(sizeLimit != null && sizeLimit > 0) { // do not overwrite the entity size with sizeLimit that is <= 0
                 exchange.setMaxEntitySize(sizeLimit);
             }
             UndertowLogger.REQUEST_LOGGER.tracef("Created multipart parser for %s", exchange);


### PR DESCRIPTION
…ange max entity size if it is > 0

Jira: https://issues.redhat.com/browse/UNDERTOW-2573

Note: this PR contains no testcases because tests already contained in another bug fix uncover this bug. I'll add more info on this note as soon as the PR for such fix is submitted.