### PR TITLE
Revert "[UNDERTOW-2344] Take into account that close could run concur…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletInputStreamImpl.java
@@ -194,9 +194,10 @@ public class ServletInputStreamImpl extends ServletInputStream {
         return copied;
     }
 
-    private PooledByteBuffer readIntoBuffer() throws IOException {
+    private void readIntoBuffer() throws IOException {
         if (pooled == null && !anyAreSet(state, FLAG_FINISHED)) {
-            final PooledByteBuffer buffer = pooled = bufferPool.allocate();
+            pooled = bufferPool.allocate();
+
             int res = Channels.readBlocking(channel, pooled.getBuffer());
             pooled.getBuffer().flip();
             if (res == -1) {
@@ -204,9 +205,7 @@ public class ServletInputStreamImpl extends ServletInputStream {
                 pooled.close();
                 pooled = null;
             }
-            return buffer;
         }
-        return null;
     }
 
     private void readIntoBufferNonBlocking() throws IOException {
@@ -264,12 +263,7 @@ public class ServletInputStreamImpl extends ServletInputStream {
         setFlags(FLAG_CLOSED);
         try {
             while (allAreClear(state, FLAG_FINISHED)) {
-                // read is always supposed to run from the same thread, but
-                // close is a different story... specially in tests
-                PooledByteBuffer buffer = readIntoBuffer();
-                if (buffer != null) {
-                    buffer.close();
-                }
+                readIntoBuffer();
                 if (pooled != null) {
                     pooled.close();
                     pooled = null;


### PR DESCRIPTION
…rently with a read operation"

This reverts commit 050f2eceff1659026f84e2d2b57ac3ed317e31ae.

I am not convinced if this is the right/proper fix. I ran some tests just now, and I see that I'll need to run some more before I'm 100% certain.

Jira: https://issues.redhat.com/browse/UNDERTOW-2344