### PR TITLE
[UNDERTOW-2481] At UndertowOptions, fix the order of the comments for…

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -301,12 +301,12 @@ public class UndertowOptions {
      */
     public static final Option<Integer> HTTP2_SETTINGS_INITIAL_WINDOW_SIZE = Option.simple(UndertowOptions.class, "HTTP2_SETTINGS_INITIAL_WINDOW_SIZE", Integer.class);
     /**
-     * Max frame size for HTTP2.
-     *  <br>UNIT: Bytes.
+     * Default value of {@link #HTTP2_SETTINGS_INITIAL_WINDOW_SIZE}. <br>UNIT: Bytes.
      */
     public static final int DEFAULT_HTTP2_SETTINGS_INITIAL_WINDOW_SIZE = 65535;
     /**
-     * Default value of {@link #HTTP2_SETTINGS_INITIAL_WINDOW_SIZE}. <br>UNIT: Bytes.
+     * Max frame size for HTTP2.
+     *  <br>UNIT: Bytes.
      */
     public static final Option<Integer> HTTP2_SETTINGS_MAX_FRAME_SIZE = Option.simple(UndertowOptions.class, "HTTP2_SETTINGS_MAX_FRAME_SIZE", Integer.class);
 


### PR DESCRIPTION
… DEFAULT_HTTP2_SETTINGS_INITIAL_WINDOW_SIZE and HTTP2_SETTINGS_MAX_FRAME_SIZE

Jira: https://issues.redhat.com/browse/UNDERTOW-2481