### PR TITLE
[UNDERTOW-2590] Support 'rspauth' in Digest auth header

### DIFF
--- a/core/src/main/java/io/undertow/security/impl/DigestAuthorizationToken.java
+++ b/core/src/main/java/io/undertow/security/impl/DigestAuthorizationToken.java
@@ -43,7 +43,8 @@ public enum DigestAuthorizationToken implements HeaderToken {
     OPAQUE(Headers.OPAQUE, true),
     MESSAGE_QOP(Headers.QOP, true),
     NONCE_COUNT(Headers.NONCE_COUNT, false),
-    AUTH_PARAM(Headers.AUTH_PARAM, false);
+    AUTH_PARAM(Headers.AUTH_PARAM, false),
+    RESPONSE_AUTH(Headers.RESPONSE_AUTH, true);
 
     private static final HeaderTokenParser<DigestAuthorizationToken> TOKEN_PARSER;
 

--- a/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
+++ b/core/src/test/java/io/undertow/server/security/ParseDigestAuthorizationTokenTestCase.java
@@ -125,4 +125,23 @@ public class ParseDigestAuthorizationTokenTestCase {
         doTest(header, expected);
     }
 
+    @Test
+    public void testHttpClient_55() {
+        final String header = "username=\"userTwo\", realm=\"Digest_Realm\", nonce=\"Yxmkh5liIOYNMTM1MTUyNjQzMTE4NJziT7YLEOEJ4QEN1py4Yog=\", uri=\"/\", response=\"5b26e00233607e8a714cd1d910692e08\", qop=auth, nc=00000001, cnonce=\"8c008c8ce43dc0a7\", rspauth=\"3b3473383bf0d182a6c6653e88ecc2e7\", algorithm=MD5, opaque=\"00000000000000000000000000000000\"";
+
+        Map<DigestAuthorizationToken, String> expected = new EnumMap<>(DigestAuthorizationToken.class);
+        expected.put(DigestAuthorizationToken.USERNAME, "userTwo");
+        expected.put(DigestAuthorizationToken.REALM, "Digest_Realm");
+        expected.put(DigestAuthorizationToken.NONCE, "Yxmkh5liIOYNMTM1MTUyNjQzMTE4NJziT7YLEOEJ4QEN1py4Yog=");
+        expected.put(DigestAuthorizationToken.DIGEST_URI, "/");
+        expected.put(DigestAuthorizationToken.ALGORITHM, DigestAlgorithm.MD5.getToken());
+        expected.put(DigestAuthorizationToken.RESPONSE, "5b26e00233607e8a714cd1d910692e08");
+        expected.put(DigestAuthorizationToken.OPAQUE, "00000000000000000000000000000000");
+        expected.put(DigestAuthorizationToken.MESSAGE_QOP, DigestQop.AUTH.getToken());
+        expected.put(DigestAuthorizationToken.NONCE_COUNT, "00000001");
+        expected.put(DigestAuthorizationToken.CNONCE, "8c008c8ce43dc0a7");
+        expected.put(DigestAuthorizationToken.RESPONSE_AUTH, "3b3473383bf0d182a6c6653e88ecc2e7");
+
+        doTest(header, expected);
+    }
 }


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/UNDERTOW-2590
Adds support of 'rspauth' in Digest auth header