### PR TITLE
EAPSUP-1960: SSEHandler Header Connection is set to close.

### DIFF
--- a/core/src/main/java/io/undertow/server/handlers/sse/ServerSentEventHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/sse/ServerSentEventHandler.java
@@ -58,7 +58,7 @@ public class ServerSentEventHandler implements HttpHandler {
     @Override
     public void handleRequest(final HttpServerExchange exchange) throws Exception {
         exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/event-stream; charset=UTF-8");
-        exchange.setPersistent(false);
+        exchange.setPersistent(true);
         final StreamSinkChannel sink = exchange.getResponseChannel();
         if(!sink.flush()) {
             sink.getWriteSetter().set(ChannelListeners.flushingChannelListener(new ChannelListener<StreamSinkChannel>() {


### PR DESCRIPTION
Since the SSE connection is supposed to be long-lived and reused for sending events it should be persistent.

Issue: https://issues.redhat.com/browse/EAPSUP-1960