### PR TITLE
[UNDERTOW-2465] Fix javadoc and add default value for URL_CHARSET option

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -18,6 +18,8 @@
 
 package io.undertow;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import org.xnio.Option;
 import org.xnio.Options;
 import org.xnio.channels.ReadTimeoutException;
@@ -167,12 +169,15 @@ public class UndertowOptions {
      */
     public static final Option<Boolean> DECODE_URL = Option.simple(UndertowOptions.class, "DECODE_URL", Boolean.class);
 
+    /**
+     * Default value of {@link #URL_CHARSET} option.
+     */
+    public static final String DEFAULT_URL_CHARSET = UTF_8.name();
 
     /**
-     * If this is true then the parser will decode the URL and query parameters using the selected character encoding (UTF-8 by default). If this is false they will
-     * not be decoded. This will allow a later handler to decode them into whatever charset is desired.
+     * The character encoding to be used for the URL decoding of requests.
      * <p>
-     * Defaults to true.
+     * Defaults to {@link #DEFAULT_URL_CHARSET}.
      */
     public static final Option<String> URL_CHARSET = Option.simple(UndertowOptions.class, "URL_CHARSET", String.class);
 

--- a/core/src/main/java/io/undertow/server/Connectors.java
+++ b/core/src/main/java/io/undertow/server/Connectors.java
@@ -39,7 +39,6 @@ import org.xnio.channels.StreamSourceChannel;
 import org.xnio.conduits.ConduitStreamSinkChannel;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -490,7 +489,7 @@ public class Connectors {
         final OptionMap options = exchange.getConnection().getUndertowOptions();
         boolean slashDecodingFlag = URLUtils.getSlashDecodingFlag(options);
         setExchangeRequestPath(exchange, encodedPath,
-                options.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()),
+                options.get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET),
                 options.get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL),
                 slashDecodingFlag,
                 decodeBuffer,

--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
@@ -44,13 +44,13 @@ import org.xnio.StreamConnection;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static io.undertow.UndertowOptions.DECODE_URL;
 import static io.undertow.UndertowOptions.URL_CHARSET;
+import static io.undertow.UndertowOptions.DEFAULT_URL_CHARSET;
 
 /**
  * @author Stuart Douglas
@@ -100,7 +100,7 @@ public class AjpOpenListener implements OpenListener {
         PooledByteBuffer buf = pool.allocate();
         this.bufferSize = buf.getBuffer().remaining();
         buf.close();
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL), undertowOptions.get(UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN, DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, DEFAULT_URL_CHARSET), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL), undertowOptions.get(UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN, DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
         connectorStatistics = new ConnectorStatisticsImpl();
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
     }
@@ -180,7 +180,7 @@ public class AjpOpenListener implements OpenListener {
         }
         this.undertowOptions = undertowOptions;
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, StandardCharsets.UTF_8.name()), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL));
+        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, DEFAULT_URL_CHARSET), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL));
     }
 
     @Override

--- a/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpRequestParser.java
@@ -22,7 +22,6 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -214,7 +213,7 @@ public abstract class HttpRequestParser {
         maxHeaders = options.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS);
         slashDecodingFlag = URLUtils.getSlashDecodingFlag(options);
         decode = options.get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL);
-        charset = options.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
+        charset = options.get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET);
         maxCachedHeaderSize = options.get(UndertowOptions.MAX_CACHED_HEADER_SIZE, UndertowOptions.DEFAULT_MAX_CACHED_HEADER_SIZE);
         this.allowUnescapedCharactersInUrl = options.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL);
         if(options.contains(UndertowOptions.ALLOW_ID_LESS_MATRIX_PARAMETERS)) {

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ReceiveListener.java
@@ -54,7 +54,6 @@ import org.xnio.conduits.StreamSinkConduit;
 import javax.net.ssl.SSLSession;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Deque;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -99,7 +98,7 @@ public class Http2ReceiveListener implements ChannelListener<Http2Channel> {
         this.maxParameters = undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS);
         this.recordRequestStartTime = undertowOptions.get(UndertowOptions.RECORD_REQUEST_START_TIME, false);
         if (undertowOptions.get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL)) {
-            this.encoding = undertowOptions.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
+            this.encoding = undertowOptions.get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET);
         } else {
             this.encoding = null;
         }

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -21,7 +21,6 @@ package io.undertow.server.protocol.http2;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.net.ssl.SSLSession;
@@ -442,7 +441,7 @@ public class Http2ServerConnection extends ServerConnection {
             exchange.setProtocol(Protocols.HTTP_1_1);
             exchange.setRequestScheme(this.exchange.getRequestScheme());
             try {
-                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), URLUtils.getSlashDecodingFlag(getUndertowOptions()), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
+                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET), getUndertowOptions().get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), URLUtils.getSlashDecodingFlag(getUndertowOptions()), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
             } catch (ParameterLimitException | BadRequestException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.debug("Too many parameters in HTTP/2 request", e);
                 exchange.setStatusCode(StatusCodes.BAD_REQUEST);

--- a/core/src/main/java/io/undertow/util/QueryParameterUtils.java
+++ b/core/src/main/java/io/undertow/util/QueryParameterUtils.java
@@ -196,7 +196,7 @@ public class QueryParameterUtils {
         String encoding = null;
         OptionMap undertowOptions = exchange.getConnection().getUndertowOptions();
         if(undertowOptions.get(UndertowOptions.DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL)) {
-            encoding = undertowOptions.get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name());
+            encoding = undertowOptions.get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET);
         }
         return encoding;
     }

--- a/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
+++ b/servlet/src/main/java/io/undertow/servlet/compat/rewrite/RewriteHandler.java
@@ -27,8 +27,6 @@ import io.undertow.servlet.spec.HttpServletRequestImpl;
 import io.undertow.servlet.spec.HttpServletResponseImpl;
 import io.undertow.util.Headers;
 import io.undertow.util.QueryParameterUtils;
-
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import jakarta.servlet.http.Cookie;
@@ -236,7 +234,7 @@ public class RewriteHandler implements HttpHandler {
                 if (queryString != null) {
                     exchange.setQueryString(queryString);
                     exchange.getQueryParameters().clear();
-                    exchange.getQueryParameters().putAll(QueryParameterUtils.parseQueryString(queryString, exchange.getConnection().getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name())));
+                    exchange.getQueryParameters().putAll(QueryParameterUtils.parseQueryString(queryString, exchange.getConnection().getUndertowOptions().get(UndertowOptions.URL_CHARSET, UndertowOptions.DEFAULT_URL_CHARSET)));
                 }
                 // Set the new host if it changed
                 if (!host.equals(request.getServerName())) {


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2465

2.4.x PR: #1903 

Undertow EE PRs:
Main PR: https://github.com/undertow-io/undertow-ee/pull/60
1.0.x PR: https://github.com/undertow-io/undertow-ee/pull/61