### PR TITLE
[UNDERTOW-2379] Replace hardcoded argument with default value for MAX_PARAMETERS option

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -84,17 +84,21 @@ public class UndertowOptions {
      */
     public static final Option<Integer> NO_REQUEST_TIMEOUT = Option.simple(UndertowOptions.class, "NO_REQUEST_TIMEOUT", Integer.class);
 
-    public static final int DEFAULT_MAX_PARAMETERS = 1000;
-
     /**
      * The maximum number of parameters that will be parsed. This is used to protect against hash vulnerabilities.
      * <p>
      * This applies to both query parameters, and to POST data, but is not cumulative (i.e. you can potentially have
      * max parameters * 2 total parameters).
      * <p>
-     * Defaults to 1000
+     * Defaults to {@link #DEFAULT_MAX_PARAMETERS}
      */
     public static final Option<Integer> MAX_PARAMETERS = Option.simple(UndertowOptions.class, "MAX_PARAMETERS", Integer.class);
+
+    /**
+     * Default value of {@link #MAX_PARAMETERS} option.
+     */
+    public static final int DEFAULT_MAX_PARAMETERS = 1000;
+
 
     public static final int DEFAULT_MAX_HEADERS = 200;
 

--- a/core/src/main/java/io/undertow/server/handlers/form/FormEncodedDataDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/FormEncodedDataDefinition.java
@@ -108,7 +108,7 @@ public class FormEncodedDataDefinition implements FormParserFactory.ParserDefini
         private FormEncodedDataParser(final String charset, final HttpServerExchange exchange) {
             this.exchange = exchange;
             this.charset = charset;
-            this.data = new FormData(exchange.getConnection().getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, 1000));
+            this.data = new FormData(exchange.getConnection().getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS));
         }
 
         @Override

--- a/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
+++ b/core/src/main/java/io/undertow/server/handlers/form/MultiPartParserDefinition.java
@@ -187,7 +187,7 @@ public class MultiPartParserDefinition implements FormParserFactory.ParserDefini
             this.defaultEncoding = defaultEncoding;
             this.fileSizeThreshold = fileSizeThreshold;
             this.fieldSizeThreshold = fieldSizeThreshold;
-            this.data = new FormData(exchange.getConnection().getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, 1000));
+            this.data = new FormData(exchange.getConnection().getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS,  UndertowOptions.DEFAULT_MAX_PARAMETERS));
             String charset = defaultEncoding;
             String contentType = exchange.getRequestHeaders().getFirst(Headers.CONTENT_TYPE);
             if (contentType != null) {

--- a/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
+++ b/core/src/main/java/io/undertow/server/protocol/http2/Http2ServerConnection.java
@@ -442,7 +442,7 @@ public class Http2ServerConnection extends ServerConnection {
             exchange.setProtocol(Protocols.HTTP_1_1);
             exchange.setRequestScheme(this.exchange.getRequestScheme());
             try {
-                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), URLUtils.getSlashDecodingFlag(getUndertowOptions()), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_HEADERS));
+                Connectors.setExchangeRequestPath(exchange, path, getUndertowOptions().get(UndertowOptions.URL_CHARSET, StandardCharsets.UTF_8.name()), getUndertowOptions().get(UndertowOptions.DECODE_URL, true), URLUtils.getSlashDecodingFlag(getUndertowOptions()), new StringBuilder(), getUndertowOptions().get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS));
             } catch (ParameterLimitException | BadRequestException e) {
                 UndertowLogger.REQUEST_IO_LOGGER.debug("Too many parameters in HTTP/2 request", e);
                 exchange.setStatusCode(StatusCodes.BAD_REQUEST);


### PR DESCRIPTION
https://issues.redhat.com/browse/UNDERTOW-2379. 

I also updated a call on Http2ServerConnection#pushResource that (most likely mistakenly) uses the default value of MAX_HEADERS instead of MAX_PARAMETERS