### PR TITLE
Avoid websocket ByteBuffer copy for single buffer

### DIFF
--- a/core/src/main/java/io/undertow/websockets/core/WebSockets.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSockets.java
@@ -1018,6 +1018,9 @@ public class WebSockets {
         if (size == 0) {
             return Buffers.EMPTY_BYTE_BUFFER;
         }
+        if (payload.length == 1) {
+            return payload[0].duplicate();
+        }
         ByteBuffer buffer = ByteBuffer.allocate(size);
         for (ByteBuffer buf : payload) {
             buffer.put(buf);


### PR DESCRIPTION
When a websocket message is fully contained in a single `ByteBuffer` we can avoid allocating a new `ByteBuffer` and copying the contents.