### PR TITLE
[UNDERTOW-2608] Go back to an anonymous inner class for SM-enabled ca…

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletPrintWriterDelegate.java
@@ -249,7 +249,12 @@ public final class ServletPrintWriterDelegate extends PrintWriter {
     @SuppressWarnings("removal")
     private static Unsafe getUnsafe() {
         if (System.getSecurityManager() != null) {
-            return java.security.AccessController.doPrivileged((PrivilegedAction<Unsafe>) ServletPrintWriterDelegate::getUnsafe0);
+            //noinspection Convert2Lambda
+            return java.security.AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
+                public Unsafe run() {
+                    return getUnsafe0();
+                }
+            });
         }
         return getUnsafe0();
     }


### PR DESCRIPTION
…lls to ServletPrintWriterDelegate.getUnsafe0

https://issues.redhat.com/browse/UNDERTOW-2608

Upstream: #1794 
2.2.x: #1805 
I haven't run the full WF testsuite with this to confirm that all errors seen in https://ci.wildfly.org/viewLog.html?buildId=518390&buildTypeId=WF_PullRequest_LinuxSmJdk17&fromSakuraUI=true are resolved, but I do see the many, many failures in testsuite/integration/basic are gone.

It's possible that CI job had failures due to some other cause, but this fixes the UNDERTOW-2608 problem.