### PR TITLE
[UNDERTOW-2604]: fix request decompression when multiple buffers must be allocated

### DIFF
--- a/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
@@ -211,10 +211,14 @@ public class InflatingStreamSourceConduit extends AbstractStreamSourceConduit<St
     }
 
     protected void initializeInflater(ByteBuffer buf) throws IOException {
-        if(isZlibHeaderPresent(buf)) {
-            this.activePooledObject = this.objectPoolWrapping.allocate();
-        } else {
-            this.activePooledObject = this.objectPoolNonWrapping.allocate();
+        // ensure the activePooledObject is set only once until done() is called
+        // we don't want to reset the inflater state mid-stream
+        if (activePooledObject == null) {
+            if (isZlibHeaderPresent(buf)) {
+                this.activePooledObject = this.objectPoolWrapping.allocate();
+            } else {
+                this.activePooledObject = this.objectPoolNonWrapping.allocate();
+            }
         }
         this.inflater = this.activePooledObject.getObject();
     }

--- a/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
+++ b/core/src/main/java/io/undertow/conduits/InflatingStreamSourceConduit.java
@@ -73,10 +73,7 @@ public class InflatingStreamSourceConduit extends AbstractStreamSourceConduit<St
             HttpServerExchange exchange,
             StreamSourceConduit next,
             ObjectPool<Inflater> inflaterPool) {
-        super(next);
-        this.exchange = exchange;
-        this.objectPoolNonWrapping = inflaterPool;
-        this.objectPoolWrapping = null;
+        this(exchange, next, inflaterPool, newInstanceWrappingInflaterPool());
     }
 
     public InflatingStreamSourceConduit(

--- a/core/src/test/java/io/undertow/server/handlers/encoding/RequestContentEncodingTestCase.java
+++ b/core/src/test/java/io/undertow/server/handlers/encoding/RequestContentEncodingTestCase.java
@@ -18,16 +18,13 @@
 
 package io.undertow.server.handlers.encoding;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Random;
 import java.util.zip.Deflater;
-import java.util.zip.GZIPOutputStream;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;


### PR DESCRIPTION
I believe this fixes [UNDERTOW-2604](https://issues.redhat.com/browse/UNDERTOW-2604), and that problem was actually an issue with `InflatingStreamSourceConduit` and not a specific issue with `HttpURLConnection` as reported in the Jira issue.

This problem seems to have been introduced in https://github.com/undertow-io/undertow/pull/1578 which attempted to fix [UNDERTOW-2361](https://issues.redhat.com/browse/UNDERTOW-2361).

fix request decompression when multiple buffers must be allocated

The inflater object used to decompress a stream was possibly being reset each time a new ByteBuffer needed to be allocated, which may happen several times depending upon the request size. This causes decompression to fail for sufficiently large request body sizes.

Instead, only initialize the inflater state once per stream (until done() is called and we can safely request a new inflater from the object pool).

2.3.x PR: #1802 
2.2.x PR: #1805 