### PR TITLE
[UNDERTOW-2719] fix: replace printStackTrace() with proper logging

### DIFF
--- a/core/src/main/java/io/undertow/Version.java
+++ b/core/src/main/java/io/undertow/Version.java
@@ -18,6 +18,7 @@
 
 package io.undertow;
 
+import io.undertow.UndertowLogger;
 import java.io.InputStream;
 import java.util.Properties;
 
@@ -36,7 +37,7 @@ public class Version {
             props.load(versionPropsStream);
             version = props.getProperty("undertow.version");
         } catch (Exception e) {
-            e.printStackTrace();
+            UndertowLogger.ROOT_LOGGER.error("Failed to load version properties", e);
         }
         versionString = version;
         fullVersionString = SERVER_NAME + " - "+ versionString;

--- a/core/src/main/java/io/undertow/io/AsyncReceiverImpl.java
+++ b/core/src/main/java/io/undertow/io/AsyncReceiverImpl.java
@@ -47,7 +47,6 @@ public class AsyncReceiverImpl implements Receiver {
     private static final ErrorCallback END_EXCHANGE = new ErrorCallback() {
         @Override
         public void error(HttpServerExchange exchange, IOException e) {
-            e.printStackTrace();
             exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
             UndertowLogger.REQUEST_IO_LOGGER.ioException(e);
             exchange.endExchange();

--- a/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
+++ b/core/src/main/java/io/undertow/server/DefaultByteBufferPool.java
@@ -18,6 +18,7 @@
 
 package io.undertow.server;
 
+import io.undertow.UndertowLogger;
 import io.undertow.UndertowMessages;
 import io.undertow.connector.ByteBufferPool;
 import io.undertow.connector.PooledByteBuffer;
@@ -331,7 +332,7 @@ public class DefaultByteBufferPool implements ByteBufferPool {
         protected void finalize() throws Throwable {
             try {
                 if(!closed) {
-                    allocationPoint.printStackTrace();
+                    UndertowLogger.ROOT_LOGGER.debug("Buffer pool closed without proper cleanup");
                 }
             } finally {
                 super.finalize();

--- a/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
+++ b/core/src/main/java/io/undertow/server/handlers/proxy/mod_cluster/MCMPHandler.java
@@ -539,7 +539,7 @@ class MCMPHandler implements HttpHandler {
                     try {
                         sendResponse(exchange, OK);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        UndertowLogger.PROXY_LOGGER.debug("Error sending ping response", e);
                     }
                 }
 
@@ -549,7 +549,7 @@ class MCMPHandler implements HttpHandler {
                         nodeConfig.markInError();
                         sendResponse(exchange, NOTOK);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        UndertowLogger.PROXY_LOGGER.debug("Error sending failed ping response", e);
                     }
                 }
             };

--- a/core/src/main/java/io/undertow/websockets/core/WebSocketChannel.java
+++ b/core/src/main/java/io/undertow/websockets/core/WebSocketChannel.java
@@ -184,7 +184,7 @@ public abstract class WebSocketChannel extends AbstractFramedChannel<WebSocketCh
                 try {
                     abstractReceiveListener.onCloseMessage(CLOSE_MSG, this);
                 } catch(Exception e) {
-                    e.printStackTrace();
+                    UndertowLogger.WEB_SOCKET_LOGGER.debug("Error processing close message", e);
                 }
             }
         }


### PR DESCRIPTION
Replace printStackTrace() calls with proper logging using UndertowLogger in 5 files.

Jira: https://issues.redhat.com/browse/UNDERTOW-2719