### PR TITLE
[UNDERTOW-2740] Second part of the fix: untie the parsing of quotes i…

### DIFF
--- a/core/src/main/java/io/undertow/util/Cookies.java
+++ b/core/src/main/java/io/undertow/util/Cookies.java
@@ -230,6 +230,7 @@ public class Cookies {
     static Map<String, Cookie> parseRequestCookies(int maxCookies, boolean allowEqualInValue, List<String> cookies, boolean commaIsSeperator) {
         return parseRequestCookies(maxCookies, allowEqualInValue, cookies, commaIsSeperator, LegacyCookieSupport.ALLOW_HTTP_SEPARATORS_IN_V0, false);
     }
+
     @Deprecated(since="2.4.0", forRemoval=true)
     static Map<String, Cookie> parseRequestCookies(int maxCookies, boolean allowEqualInValue, List<String> cookies, boolean commaIsSeperator, boolean allowHttpSeparatorsV0) {
         return parseRequestCookies(maxCookies, allowEqualInValue, cookies, commaIsSeperator, allowHttpSeparatorsV0, false);
@@ -338,7 +339,7 @@ public class Cookies {
                 case 3: {
                     //extract quoted value
                     if (c == '"') {
-                        if (rfc6265CookieValidationEnabled && cookieJar.inQuotes) {
+                        if (cookieJar.inQuotes) {
                             cookieJar.start = cookieJar.start - 1;
                             //i++;
                             createCookie(cookieJar.containsEscapedQuotes ? unescapeDoubleQuotes(cookie.substring(cookieJar.start, i + 1)) : cookie.substring(cookieJar.start, i + 1), cookieJar);

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -235,7 +235,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertNotNull(cookie);
-        Assert.assertEquals("WILE_E_COYOTE=THE_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE=THE_COYOTE\"", cookie.getValue());
         cookie = cookies.get("SHIPPING");
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
@@ -250,7 +250,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertNotNull(cookie);
-        Assert.assertEquals("WILE_E_COYOTE=THE_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE=THE_COYOTE\"", cookie.getValue());
         cookie = cookies.get("SHIPPING");
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
@@ -265,7 +265,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertNotNull(cookie);
-        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE\"", cookie.getValue());
         cookie = cookies.get("SHIPPING");
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
@@ -275,7 +275,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         cookie = cookies.get("CUSTOMER");
         Assert.assertNotNull(cookie);
-        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE\"", cookie.getValue());
         cookie = cookies.get("SHIPPING");
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
@@ -285,7 +285,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         cookie = cookies.get("CUSTOMER");
         Assert.assertNotNull(cookie);
-        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE\"", cookie.getValue());
         cookie = cookies.get("SHIPPING");
         Assert.assertNotNull(cookie);
         Assert.assertEquals("FEDEX", cookie.getValue());
@@ -438,13 +438,13 @@ public class CookiesTestCase {
 
         cookie = cookies.get("SHIPPING");
         Assert.assertEquals("SHIPPING", cookie.getName());
-        Assert.assertEquals("FEDEX\\\\", cookie.getValue()); // backslash escapled backslash in the value
+        Assert.assertEquals("\"FEDEX\\\\\"", cookie.getValue()); // backslash escapled backslash in the value
         Assert.assertEquals("/acme", cookie.getPath());
         Assert.assertEquals(1, cookie.getVersion());
 
         cookie = cookies.get("foo");
         Assert.assertEquals("foo", cookie.getName());
-        Assert.assertEquals("\\", cookie.getValue()); // unescaped backslash exists at the last of the value
+        Assert.assertEquals("\"\\\"", cookie.getValue()); // unescaped backslash exists at the last of the value
     }
 
     @Test
@@ -564,7 +564,7 @@ public class CookiesTestCase {
         Assert.assertEquals(2, cookies.size());
         Cookie cookie = cookies.get("CUSTOMER");
         Assert.assertEquals("CUSTOMER", cookie.getName());
-        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        Assert.assertEquals("\"WILE_E_COYOTE\"", cookie.getValue());
         cookie = cookies.get("BAD");
         Assert.assertNull(cookie);
         cookie = cookies.get("SHIPPING");


### PR DESCRIPTION
…n the cookie value from the ENABLE_RFC6265_COOKIE_VALIDATION UndertowOption config

Jira: https://redhat.atlassian.net/browse/UNDERTOW-2740

Follows up on #1938 