### PR TITLE
[UNDERTOW-2759] Enabling testing on JDK25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         module: [core, servlet, websockets-jsr]
-        jdk: [17, 21]
+        jdk: [17, 21, 25]
         openjdk_impl: [ temurin ]
         openssl: [false, true]
     steps:
@@ -123,7 +123,7 @@ jobs:
         os: [ubuntu-latest]
         module: [core, servlet, websockets-jsr]
         proxy: ['-Pproxy', '']
-        jdk: [17]
+        jdk: [17, 21, 25]
     steps:
     - name: Update hosts - linux
       if: matrix.os == 'ubuntu-latest'

--- a/core/src/test/java/io/undertow/server/DirectByteBufferDeallocatorTestCase.java
+++ b/core/src/test/java/io/undertow/server/DirectByteBufferDeallocatorTestCase.java
@@ -18,6 +18,7 @@
 package io.undertow.server;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.security.Permission;
@@ -34,6 +35,7 @@ public class DirectByteBufferDeallocatorTestCase {
     @Test
     @SuppressWarnings({"removal"})
     public void directByteBufferDeallocatorInstantiationTest() {
+        Assume.assumeTrue("Skipping on JDK " + Runtime.version().feature(), Runtime.version().feature() < 25);
         Exception exception = null;
         java.security.Policy.setPolicy(new java.security.Policy() {
             @Override

--- a/pom.xml
+++ b/pom.xml
@@ -727,24 +727,44 @@
         <profile>
             <id>jdk18</id>
             <activation>
-                <jdk>[18,)</jdk>
+                <jdk>[17,24)</jdk>
             </activation>
             <properties>
                 <modular.jdk.props>-Djava.security.manager=allow</modular.jdk.props>
             </properties>
         </profile>
-		<profile>
-			<id>verbose</id>
-			<activation>
-				<property>
-					<name>findbugs</name>
-				</property>
-			</activation>
-			<properties>
-				<maven.javadoc.plugin.quiet>false</maven.javadoc.plugin.quiet>
-				<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
-				<maven.compiler.showWarnings>false</maven.compiler.showWarnings>
-			</properties>
-		</profile>
+
+        <profile>
+            <id>verbose</id>
+            <activation>
+                <property>
+                    <name>findbugs</name>
+                </property>
+            </activation>
+            <properties>
+                <maven.javadoc.plugin.quiet>false</maven.javadoc.plugin.quiet>
+                <maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
+                <maven.compiler.showWarnings>false</maven.compiler.showWarnings>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jdk23</id>
+            <activation>
+                <jdk>[23,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                                <!-- SE 23+ requires explicit config to turn on annotation processing -->
+                            <compilerArgument>-proc:full</compilerArgument>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/UNDERTOW-2759

 - Turning on compiler annotation processing on JDK23+
 - Disabling test using security manager framework on JDK25+
 - Adding JDK25 to CI pipeline