### PR TITLE
[UNDERTOW-2709] UndertowOptions.ALLOWED_REQUEST_ATTRIBUTES_PATTERN is ignored in AjpOpenListener.setUndertowOptions

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
+++ b/core/src/main/java/io/undertow/server/protocol/ajp/AjpOpenListener.java
@@ -100,7 +100,7 @@ public class AjpOpenListener implements OpenListener {
         PooledByteBuffer buf = pool.allocate();
         this.bufferSize = buf.getBuffer().remaining();
         buf.close();
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, DEFAULT_URL_CHARSET), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL), undertowOptions.get(UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN, DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN));
+        parser = createAjpRequestParser(undertowOptions);
         connectorStatistics = new ConnectorStatisticsImpl();
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
     }
@@ -180,7 +180,30 @@ public class AjpOpenListener implements OpenListener {
         }
         this.undertowOptions = undertowOptions;
         statisticsEnabled = undertowOptions.get(UndertowOptions.ENABLE_CONNECTOR_STATISTICS, false);
-        parser = new AjpRequestParser(undertowOptions.get(URL_CHARSET, DEFAULT_URL_CHARSET), undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL), undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS), undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS), URLUtils.getSlashDecodingFlag(undertowOptions), undertowOptions.get(UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL, UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL));
+        parser = createAjpRequestParser(undertowOptions);
+    }
+
+    /**
+     * Create and return a new AjpRequestParser instance, based on some undertowOptions.
+     * @param undertowOptions The options to use when creating the AjpRequestParser
+     * @return A new AjpRequestParser instance
+     */
+    private AjpRequestParser createAjpRequestParser(final OptionMap undertowOptions) {
+        return new AjpRequestParser(
+            undertowOptions.get(URL_CHARSET, DEFAULT_URL_CHARSET),
+            undertowOptions.get(DECODE_URL, UndertowOptions.DEFAULT_DECODE_URL),
+            undertowOptions.get(UndertowOptions.MAX_PARAMETERS, UndertowOptions.DEFAULT_MAX_PARAMETERS),
+            undertowOptions.get(UndertowOptions.MAX_HEADERS, UndertowOptions.DEFAULT_MAX_HEADERS),
+            URLUtils.getSlashDecodingFlag(undertowOptions),
+            undertowOptions.get(
+                UndertowOptions.ALLOW_UNESCAPED_CHARACTERS_IN_URL,
+                UndertowOptions.DEFAULT_ALLOW_UNESCAPED_CHARACTERS_IN_URL
+            ),
+            undertowOptions.get(
+                UndertowOptions.AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN,
+                DEFAULT_AJP_ALLOWED_REQUEST_ATTRIBUTES_PATTERN
+            )
+        );
     }
 
     @Override


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/UNDERTOW-2709