### PR TITLE
[UNDERTOW-2741] Cookies does not strip quotes from legacy attribute values

### DIFF
--- a/core/src/main/java/io/undertow/util/Cookies.java
+++ b/core/src/main/java/io/undertow/util/Cookies.java
@@ -458,12 +458,15 @@ public class Cookies {
         }
 
         if (!cookieJar.name.isEmpty() && cookieJar.name.charAt(0) == '$') {
+            // RFC 2109 allows quoted strings for $Version, $Domain and $Path attribute values.
+            // Strip surrounding quotes so callers always receive a clean value.
+            final String cleanValue = stripSurroundingQuotes(value);
             if(cookieJar.name.equals(VERSION)) {
-                cookieJar.version = Integer.parseInt(value);
+                cookieJar.version = Integer.parseInt(cleanValue);
                 //Theoretically this should happen only once at the start
-                applyAdditional(cookieJar, cookieJar.name, value);
+                applyAdditional(cookieJar, cookieJar.name, cleanValue);
             } else if(cookieJar.currentCookie != null) {
-                applyAdditional(cookieJar, cookieJar.name, value);
+                applyAdditional(cookieJar, cookieJar.name, cleanValue);
             }
             return;
         } else {
@@ -499,6 +502,14 @@ public class Cookies {
         return;
     }
 
+    private static String stripSurroundingQuotes(final String value) {
+        if (value != null && value.length() >= 2
+                && value.charAt(0) == '"'
+                && value.charAt(value.length() - 1) == '"') {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
 
     private static String unescapeDoubleQuotes(final String value) {
         if (value == null || value.isEmpty()) {

--- a/core/src/test/java/io/undertow/util/CookiesTestCase.java
+++ b/core/src/test/java/io/undertow/util/CookiesTestCase.java
@@ -129,6 +129,30 @@ public class CookiesTestCase {
     }
 
     @Test
+    public void testRequestCookieDomainPathVersionQuoted() {
+        // Quoted values for $Version, $Domain and $Path must have their surrounding quotes stripped.
+        Map<String, Cookie> cookies = Cookies.parseRequestCookies(4, false, Arrays.asList(
+                "$Version=\"1\"; CUSTOMER=WILE_E_COYOTE; $Domain=\"LOONEY_TUNES\"; $Path=\"/\""), LegacyCookieSupport.COMMA_IS_SEPARATOR, LegacyCookieSupport.ALLOW_HTTP_SEPARATORS_IN_V0, false);
+
+        // RFC 6265 treats the domain, path and version attributes of an RFC 2109 cookie as a separate cookies
+        Assert.assertTrue(cookies.containsKey("$Domain"));
+        Assert.assertTrue(cookies.containsKey("$Version"));
+        Assert.assertTrue(cookies.containsKey("$Path"));
+
+        // The separate RFC-6265 cookies must not carry surrounding quotes in their values.
+        Assert.assertEquals("1", cookies.get("$Version").getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookies.get("$Domain").getValue());
+        Assert.assertEquals("/", cookies.get("$Path").getValue());
+
+        Cookie cookie = cookies.get("CUSTOMER");
+        Assert.assertEquals("CUSTOMER", cookie.getName());
+        Assert.assertEquals("WILE_E_COYOTE", cookie.getValue());
+        Assert.assertEquals("LOONEY_TUNES", cookie.getDomain());
+        Assert.assertEquals(1, cookie.getVersion());
+        Assert.assertEquals("/", cookie.getPath());
+    }
+
+    @Test
     public void testMultipleRequestCookies() {
         Map<String, Cookie> cookies = Cookies.parseRequestCookies(5, false, Arrays.asList(
                 "CUSTOMER=WILE_E_COYOTE; $Version=1;SHIPPING=FEDEX; $Domain=LOONEY_TUNES; $Path=/"));


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/UNDERTOW-2741