### PR TITLE
[UNDERTOW-2693] Sync sameSite flag with cookie SameSite attribute in …

### DIFF
--- a/servlet/src/main/java/io/undertow/servlet/spec/ServletCookieAdaptor.java
+++ b/servlet/src/main/java/io/undertow/servlet/spec/ServletCookieAdaptor.java
@@ -42,6 +42,7 @@ public class ServletCookieAdaptor implements Cookie {
 
     public ServletCookieAdaptor(final jakarta.servlet.http.Cookie cookie) {
         this.cookie = cookie;
+        this.sameSite = cookie.getAttribute(SAME_SITE) != null;
     }
 
     @Override
@@ -194,6 +195,9 @@ public class ServletCookieAdaptor implements Cookie {
     @Override
     public Cookie setAttribute(final String name, final String value) {
         cookie.setAttribute(name, value);
+        if (SAME_SITE.equals(name)) {
+            this.sameSite = value != null;
+        }
         return this;
     }
 

--- a/servlet/src/test/java/io/undertow/servlet/test/spec/ServletCookieAdaptorTestCase.java
+++ b/servlet/src/test/java/io/undertow/servlet/test/spec/ServletCookieAdaptorTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.servlet.test.spec;
+
+import jakarta.servlet.http.Cookie;
+
+import io.undertow.servlet.spec.ServletCookieAdaptor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ServletCookieAdaptorTestCase {
+
+    @Test
+    public void testConstructorSyncsSameSiteFromWrappedCookie() {
+        Cookie cookie = new Cookie("test", "value");
+        cookie.setAttribute("SameSite", "Lax");
+
+        ServletCookieAdaptor adaptor = new ServletCookieAdaptor(cookie);
+
+        Assert.assertTrue(adaptor.isSameSite());
+        Assert.assertEquals("Lax", adaptor.getSameSiteMode());
+    }
+
+    @Test
+    public void testConstructorSameSiteFalseWhenNotSet() {
+        Cookie cookie = new Cookie("test", "value");
+
+        ServletCookieAdaptor adaptor = new ServletCookieAdaptor(cookie);
+
+        Assert.assertFalse(adaptor.isSameSite());
+    }
+
+    @Test
+    public void testSetAttributeSyncsSameSite() {
+        Cookie cookie = new Cookie("test", "value");
+        ServletCookieAdaptor adaptor = new ServletCookieAdaptor(cookie);
+
+        Assert.assertFalse(adaptor.isSameSite());
+
+        adaptor.setAttribute("SameSite", "Strict");
+
+        Assert.assertTrue(adaptor.isSameSite());
+        Assert.assertEquals("Strict", adaptor.getSameSiteMode());
+    }
+
+    @Test
+    public void testSetAttributeClearsSameSite() {
+        Cookie cookie = new Cookie("test", "value");
+        cookie.setAttribute("SameSite", "Lax");
+        ServletCookieAdaptor adaptor = new ServletCookieAdaptor(cookie);
+
+        Assert.assertTrue(adaptor.isSameSite());
+
+        adaptor.setAttribute("SameSite", null);
+
+        Assert.assertFalse(adaptor.isSameSite());
+    }
+}


### PR DESCRIPTION
…ServletCookieAdaptor

The `UNDERTOW-2693` fix re-introduced a sameSite boolean field in ServletCookieAdaptor but left two gaps where it gets out of sync with the wrapped cookie's SameSite attribute:

1. Constructor — when wrapping a jakarta.servlet.http.Cookie that already has setAttribute("SameSite", "Lax") set, the boolean stays false. Connectors gates Set-Cookie serialization on isSameSite(), so the attribute is silently dropped.
2. setAttribute() — calling setAttribute("SameSite", value) on the adaptor delegates to the wrapped cookie but doesn't sync the boolean, creating the same inconsistency.

This fix initializes sameSite from the wrapped cookie in the constructor and syncs it in setAttribute().

The issue was found while testing Apache Camel, in particular https://github.com/apache/camel-spring-boot/blob/main/components-starter/camel-platform-http-starter/src/test/java/org/apache/camel/component/platform/http/springboot/SpringBootPlatformHttpCookiesTest.java#L125 with undertow