### PR TITLE
[UNDERTOW-2787] Cookie-resolving with same named cookies preferes the last one, instead of the significant first one

### DIFF
--- a/core/src/main/java/io/undertow/server/CookieStore.java
+++ b/core/src/main/java/io/undertow/server/CookieStore.java
@@ -114,8 +114,9 @@ public class CookieStore implements Iterable<Cookie> {
      * </p>
      *
      * <p>
-     * For cookies with the same name but different path/domain combinations, only one arbitrary cookie with that name
-     * is returned. To access all cookies with the same name, use {@link #get(String)} instead.
+     * For cookies with the same name but different path/domain combinations, only the first cookie with that name
+     * is returned. Per RFC 6265, the user agent sorts cookies by path specificity (longest first), so the first
+     * cookie is the most specific. To access all cookies with the same name, use {@link #get(String)} instead.
      * </p>
      *
      * @return a map where each cookie name maps to a single Cookie instance
@@ -230,7 +231,7 @@ public class CookieStore implements Iterable<Cookie> {
             }
             for (var entry : cookieStore.entrySet()) {
                 final Deque<Cookie> queue = entry.getValue();
-                if (value.equals(queue.peekLast())) {
+                if (value.equals(queue.peekFirst())) {
                     return true;
                 }
             }
@@ -240,13 +241,13 @@ public class CookieStore implements Iterable<Cookie> {
         @Override
         public Cookie get(final Object key) {
             final Deque<Cookie> queue = cookieStore.cookies.get(key);
-            return queue == null ? null : queue.peekLast();
+            return queue == null ? null : queue.peekFirst();
         }
 
         @Override
         public Cookie put(final String key, final Cookie value) {
             final Deque<Cookie> cookies = cookieStore.getOrCreate(key);
-            final Cookie result = cookies.peekLast();
+            final Cookie result = cookies.peekFirst();
             cookies.clear();
             cookies.add(value);
             return result;
@@ -255,7 +256,7 @@ public class CookieStore implements Iterable<Cookie> {
         @Override
         public Cookie remove(final Object key) {
             final Deque<Cookie> queue = cookieStore.cookies.remove(key);
-            return queue == null ? null : queue.peekLast();
+            return queue == null ? null : queue.peekFirst();
         }
 
         @Override
@@ -276,14 +277,14 @@ public class CookieStore implements Iterable<Cookie> {
         @Override
         public Collection<Cookie> values() {
             return cookieStore.cookies.values().stream()
-                    .map(Deque::getLast)
+                    .map(Deque::getFirst)
                     .collect(Collectors.toUnmodifiableList());
         }
 
         @Override
         public Set<Entry<String, Cookie>> entrySet() {
             return cookieStore.cookies.entrySet().stream()
-                    .map(e -> Map.entry(e.getKey(), e.getValue().getLast()))
+                    .map(e -> Map.entry(e.getKey(), e.getValue().getFirst()))
                     .collect(Collectors.toUnmodifiableSet());
         }
     }

--- a/core/src/test/java/io/undertow/server/CookieStoreLegacyMapTestCase.java
+++ b/core/src/test/java/io/undertow/server/CookieStoreLegacyMapTestCase.java
@@ -79,7 +79,8 @@ public class CookieStoreLegacyMapTestCase {
 
     /**
      * Tests that the legacy map will return the first cookie on a duplicate cookie name, but different paths. This
-     * is for RFC-2109.
+     * is for RFC-2109. Per RFC 6265, the user agent sends cookies sorted by path specificity (longest first), so
+     * the first cookie should be preferred.
      */
     @Test
     public void multipleRFC2109Cookies() {
@@ -98,9 +99,9 @@ public class CookieStoreLegacyMapTestCase {
 
         final Cookie result = legacyMap.get("CUSTOMER");
         Assert.assertNotNull("Should find CUSTOMER cookie", result);
-        // Should return the last one added
-        Assert.assertEquals("Should return last cookie", "MONICA", result.getValue());
-        Assert.assertEquals("Should have correct path", "/", result.getPath());
+        // Should return the first one added (most specific path per RFC 6265)
+        Assert.assertEquals("Should return first cookie", "JOE", result.getValue());
+        Assert.assertEquals("Should have correct path", "/acme", result.getPath());
         Assert.assertEquals("Values should have 2 entries", 2, legacyMap.values().size());
         Assert.assertEquals("EntrySet should have 2 entries", 2, legacyMap.entrySet().size());
     }
@@ -140,7 +141,7 @@ public class CookieStoreLegacyMapTestCase {
         final Cookie old = legacyMap.put("FOO", newCookie);
 
         Assert.assertNotNull("put() should return old value", old);
-        Assert.assertEquals("Should return last old cookie", "another", old.getValue());
+        Assert.assertEquals("Should return first old cookie", "original", old.getValue());
 
         // After put, only the new cookie should exist
         final Cookie result = legacyMap.get("FOO");


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/UNDERTOW-2787