### PR TITLE
[UNDERTOW-2780] Fix defaults in websocket container + tests

### DIFF
--- a/core/src/main/java/io/undertow/UndertowOptions.java
+++ b/core/src/main/java/io/undertow/UndertowOptions.java
@@ -20,6 +20,8 @@ package io.undertow;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import java.time.Duration;
+
 import org.xnio.Option;
 import org.xnio.Options;
 import org.xnio.channels.ReadTimeoutException;
@@ -578,6 +580,13 @@ public class UndertowOptions {
     @Deprecated
     public static final boolean DEFAULT_ALLOW_ID_LESS_MATRIX_PARAMETERS = false;
 
+    public static final long WEB_SOCKET_DEFAULT_ASYNC_SEND_TIMEOUT = Duration.ofSeconds(30).toMillis();
+
+    public static final long WEB_SOCKET_DEFAULT_MAX_SESSION_IDLE = Duration.ofMinutes(30).toSeconds();
+
+    public static final int WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_BINARY =  128 * 1024; // 128 KB; //int is derived from websocket API.
+
+    public static final int WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_TEXT =  128 * 1024; // 128 KB;
 
     private UndertowOptions() {
 

--- a/core/src/main/java/io/undertow/websockets/core/BufferedTextMessage.java
+++ b/core/src/main/java/io/undertow/websockets/core/BufferedTextMessage.java
@@ -156,6 +156,7 @@ public class BufferedTextMessage {
                                             }
                                         }
                                     } catch (IOException e) {
+                                        channel.suspendReads();
                                         callback.onError(channel.getWebSocketChannel(), BufferedTextMessage.this, e);
                                     }
                                 } finally {

--- a/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
+++ b/servlet/src/main/java/io/undertow/servlet/api/DeploymentInfo.java
@@ -21,6 +21,7 @@ package io.undertow.servlet.api;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -86,7 +87,7 @@ public class DeploymentInfo implements Cloneable {
     private ConfidentialPortManager confidentialPortManager;
     private boolean allowNonStandardWrappers = false;
     private int defaultSessionTimeout = 60 * 30;
-    private long defaultAsyncContextTimeout = 30000;
+    private long defaultAsyncContextTimeout = Duration.ofSeconds(30).toMillis();
     private ConcurrentMap<String, Object> servletContextAttributeBackingMap;
     private ServletSessionConfig servletSessionConfig;
     private String hostName = "localhost";

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/Bootstrap.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/Bootstrap.java
@@ -43,6 +43,7 @@ import static java.lang.System.getProperty;
 
 import java.net.InetSocketAddress;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -87,8 +88,14 @@ public class Bootstrap implements ServletExtension {
             extensions.add(new ExtensionImpl(e.getName(), Collections.emptyList()));
         }
         ServerWebSocketContainer container = new ServerWebSocketContainer(deploymentInfo.getClassIntrospecter(), servletContext.getClassLoader(), worker, buffers, setup, info.isDispatchToWorkerThread(), bind, info.getReconnectHandler(), extensions);
-        container.setDefaultMaxTextMessageBufferSize(this.getMaxTextBufferSize());
-        container.setDefaultMaxBinaryMessageBufferSize(this.getMaxBinaryBufferSize());
+
+        container.setAsyncSendTimeout(info.getDefaultAsyncSendTimeout());
+        container.setDefaultMaxSessionIdleTimeout(Duration.ofSeconds(info.getDefaultMaxSessionIdleTimeout()).toMillis());//NOTE: conversion
+        int bufferSize = this.getMaxBinaryBufferSize();
+        container.setDefaultMaxBinaryMessageBufferSize(bufferSize == -1 ? info.getDefaultMaxBinaryMessageBufferSize() : bufferSize);
+        bufferSize = this.getMaxTextBufferSize();
+        container.setDefaultMaxTextMessageBufferSize(bufferSize == -1 ? info.getDefaultMaxTextMessageBufferSize() : bufferSize);
+
         try {
             for (Class<?> annotation : info.getAnnotatedEndpoints()) {
                 container.addEndpoint(annotation);

--- a/websockets-jsr/src/main/java/io/undertow/websockets/jsr/WebSocketDeploymentInfo.java
+++ b/websockets-jsr/src/main/java/io/undertow/websockets/jsr/WebSocketDeploymentInfo.java
@@ -18,18 +18,20 @@
 
 package io.undertow.websockets.jsr;
 
-import io.undertow.server.XnioByteBufferPool;
-import io.undertow.websockets.extensions.ExtensionHandshake;
-import io.undertow.connector.ByteBufferPool;
-import org.xnio.Pool;
-import org.xnio.XnioWorker;
-
-import jakarta.websocket.server.ServerEndpointConfig;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Supplier;
+
+import org.xnio.Pool;
+import org.xnio.XnioWorker;
+
+import io.undertow.UndertowOptions;
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.XnioByteBufferPool;
+import io.undertow.websockets.extensions.ExtensionHandshake;
+import jakarta.websocket.server.ServerEndpointConfig;
 
 /**
  * Web socket deployment information
@@ -60,7 +62,10 @@ public class WebSocketDeploymentInfo implements Cloneable {
     private final List<ExtensionHandshake> extensions = new ArrayList<>();
     private String clientBindAddress = null;
     private WebSocketReconnectHandler reconnectHandler;
-
+    private long defaultAsyncSendTimeout = UndertowOptions.WEB_SOCKET_DEFAULT_ASYNC_SEND_TIMEOUT;
+    private long defaultMaxSessionIdleTimeout = UndertowOptions.WEB_SOCKET_DEFAULT_MAX_SESSION_IDLE; //WARNING: container has API contract in millis, but from user POV, seconds are something more tangible?
+    private int defaultMaxBinaryMessageBufferSize = UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_BINARY;
+    private int defaultMaxTextMessageBufferSize = UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_TEXT;
     public Supplier<XnioWorker> getWorker() {
         return worker;
     }
@@ -198,6 +203,79 @@ public class WebSocketDeploymentInfo implements Cloneable {
         return this;
     }
 
+
+    /**
+     * Get default web-socket async send timeout in milliseconds. Defaults to: 30000
+     * @return
+     */
+    public long getDefaultAsyncSendTimeout() {
+        return defaultAsyncSendTimeout;
+    }
+
+    /**
+     *
+     * @param defaultAsyncSendTimeout - defualt web-socket async send in milliseconds.
+     * @return
+     */
+    public WebSocketDeploymentInfo setDefaultAsyncSendTimeout(long defaultAsyncSendTimeout) {
+        this.defaultAsyncSendTimeout = defaultAsyncSendTimeout;
+        return this;
+    }
+
+    /**
+     * default web-socket idling timeout for session in seconds, defaults to 30 minutes.
+     * @return
+     */
+    public long getDefaultMaxSessionIdleTimeout() {
+        return defaultMaxSessionIdleTimeout;
+    }
+
+    /**
+     * Set default web-socket idling timeout in seconds.
+     * @param defaultMaxSessionIdleTimeout
+     * @return
+     */
+    public WebSocketDeploymentInfo setDefaultMaxSessionIdleTimeout(long defaultMaxSessionIdleTimeout) {
+        this.defaultMaxSessionIdleTimeout = defaultMaxSessionIdleTimeout;
+        return this;
+    }
+
+    /**
+     * Get default binary messages size in Byte, defaults to 128KB
+     * @return
+     */
+    public int getDefaultMaxBinaryMessageBufferSize() {
+        return defaultMaxBinaryMessageBufferSize;
+    }
+
+    /**
+     * Set default max binary size in Bytes.
+     * @param defaultMaxBinaryMessageBufferSize
+     * @return
+     */
+    public WebSocketDeploymentInfo setDefaultMaxBinaryMessageBufferSize(int defaultMaxBinaryMessageBufferSize) {
+        this.defaultMaxBinaryMessageBufferSize = defaultMaxBinaryMessageBufferSize;
+        return this;
+    }
+
+    /**
+     * Get default text messages size in Byte, defaults to 128KB
+     * @return
+     */
+    public int getDefaultMaxTextMessageBufferSize() {
+        return defaultMaxTextMessageBufferSize;
+    }
+
+    /**
+     * Set default max text size in Bytes.
+     * @param defaultMaxTextMessageBufferSize
+     * @return
+     */
+    public WebSocketDeploymentInfo setDefaultMaxTextMessageBufferSize(int defaultMaxTextMessageBufferSize) {
+        this.defaultMaxTextMessageBufferSize = defaultMaxTextMessageBufferSize;
+        return this;
+    }
+
     @Override
     public WebSocketDeploymentInfo clone() {
         return new WebSocketDeploymentInfo()
@@ -210,6 +288,10 @@ public class WebSocketDeploymentInfo implements Cloneable {
                 .addExtensions(this.extensions)
                 .setClientBindAddress(this.clientBindAddress)
                 .setReconnectHandler(this.reconnectHandler)
+                .setDefaultAsyncSendTimeout(this.defaultAsyncSendTimeout)
+                .setDefaultMaxSessionIdleTimeout(this.defaultMaxSessionIdleTimeout)
+                .setDefaultMaxBinaryMessageBufferSize(this.defaultMaxBinaryMessageBufferSize)
+                .setDefaultMaxTextMessageBufferSize(this.defaultMaxTextMessageBufferSize)
         ;
     }
 

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointTest.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryEndpointTest.java
@@ -67,19 +67,19 @@ public class BinaryEndpointTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-
         bytes = new byte[256 * 1024];
         new Random().nextBytes(bytes);
 
         final ServletContainer container = ServletContainer.Factory.newInstance();
-
+        final WebSocketDeploymentInfo webSocketInfo = new WebSocketDeploymentInfo();
+        webSocketInfo.setDefaultMaxBinaryMessageBufferSize(bytes.length+1);
         DeploymentInfo builder = new DeploymentInfo()
                 .setClassLoader(BinaryEndpointTest.class.getClassLoader())
                 .setContextPath("/")
                 .setClassIntrospecter(TestClassIntrospector.INSTANCE)
                 .addServlet(Servlets.servlet("bin", BinaryEndpointServlet.class).setLoadOnStartup(100))
                 .addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME,
-                        new WebSocketDeploymentInfo()
+                        webSocketInfo
                                 .setBuffers(DefaultServer.getBufferPool())
                                 .setWorker(DefaultServer.getWorkerSupplier())
                                 .addListener(serverContainer -> deployment = serverContainer)

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryPartialEndpoint.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/BinaryPartialEndpoint.java
@@ -39,6 +39,12 @@ public final class BinaryPartialEndpoint extends Endpoint {
 
     }
 
+    @Override
+    public void onError(Session session, Throwable thr) {
+        // TODO Auto-generated method stub
+        super.onError(session, thr);
+    }
+
     private static class BinaryPartialMessageHandler implements MessageHandler.Partial<byte[]> {
 
         private final Session session;

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryDefaultLimitOverFlow.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryDefaultLimitOverFlow.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import io.undertow.UndertowOptions;
+import io.undertow.websockets.core.WebSocketMessages;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.server.ServerEndpoint;
+import jakarta.websocket.RemoteEndpoint;
+
+public class TestBinaryDefaultLimitOverFlow extends TestMessageLimitBase {
+
+    private static final byte[] MESSAGE;
+    static {
+        MESSAGE = new byte[UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_BINARY+1];
+        new Random().nextBytes(MESSAGE);
+    }
+    @Override
+    protected List<Event> getExpectedEvents() {
+        final Event me = new Event(new IOException(WebSocketMessages.MESSAGES.messageToBig(UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_BINARY)), 0);
+        final CloseReason reason = new CloseReason(CloseCodes.TOO_BIG, WebSocketMessages.MESSAGES.messageToBig(UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_BINARY));
+        final Event overflow = new Event(reason,1);
+        ArrayList<Event> lst = new ArrayList<TestMessageLimitBase.Event>(2);
+        lst.add(me);
+        lst.add(overflow);
+        return lst;
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        //NOP
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a,b)->{
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendBinary(ByteBuffer.wrap(MESSAGE));
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSocketBinaryDefaultLimitOverFlow";
+    }
+
+    @ServerEndpoint("/webSocketBinaryDefaultLimitOverFlow")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryNewLimitOverFlow.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryNewLimitOverFlow.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import io.undertow.websockets.core.WebSocketMessages;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
+
+public class TestBinaryNewLimitOverFlow extends TestMessageLimitBase {
+
+    private static final byte[] MESSAGE;
+    static {
+        MESSAGE = new byte[1024 + 1];
+        new Random().nextBytes(MESSAGE);
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        final Event[] events = new Event[2];
+
+        final Event first = new Event(new IOException(WebSocketMessages.MESSAGES.messageToBig(1024)), 0);
+        final CloseReason reason = new CloseReason(CloseCodes.TOO_BIG, WebSocketMessages.MESSAGES.messageToBig(1024));
+        final Event overflow = new Event(reason,1);
+        events[0] = first;
+        events[1] = overflow;
+
+        return Arrays.asList(events);
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        // NOP
+        info.setDefaultMaxBinaryMessageBufferSize(1024); // 1KB
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a, b) -> {
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendBinary(ByteBuffer.wrap(MESSAGE));
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSocketBinaryNewLimitOverFlow";
+    }
+
+    @ServerEndpoint("/webSocketBinaryNewLimitOverFlow")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryNewLimitRespected.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestBinaryNewLimitRespected.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
+
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
+
+public class TestBinaryNewLimitRespected extends TestMessageLimitBase {
+
+    private static final byte[] MESSAGE;
+    static {
+        MESSAGE = new byte[1024];
+        primeMessage(MESSAGE);
+    }
+
+    private static void primeMessage(byte[] data) {
+        for(int i = 0; i< 1024;i++) {
+            data[i]=(byte)i;
+        }
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        //some class loading shenanigans cause it to randomize ?
+        primeMessage(MESSAGE);
+        final Event me = new Event(TestBinaryNewLimitRespected.MESSAGE, 0);
+        return Collections.singletonList(me);
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        // NOP
+        info.setDefaultMaxBinaryMessageBufferSize(1024); // 1KB
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a, b) -> {
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendBinary(ByteBuffer.wrap(MESSAGE));
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSockeBinaryNewLimitRespected";
+    }
+
+    @ServerEndpoint("/webSockeBinaryNewLimitRespected")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestMessageLimitBase.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestMessageLimitBase.java
@@ -1,0 +1,309 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.undertow.websockets.jsr.test.limit;
+
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.undertow.Handlers;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.DeploymentManager;
+import io.undertow.servlet.api.ServletContainer;
+import io.undertow.servlet.test.util.TestClassIntrospector;
+import io.undertow.servlet.test.util.TestResourceLoader;
+import io.undertow.testutils.DefaultServer;
+import io.undertow.testutils.HttpOneOnly;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.servlet.ServletException;
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+
+@RunWith(DefaultServer.class)
+@HttpOneOnly
+public abstract class TestMessageLimitBase {
+
+    private static DeploymentManager deploymentManager;
+
+    @Before
+    public void setup() throws ServletException {
+        WebSocketBaseClass.events.clear();
+        WebSocketBaseClass.finished = false;
+        final ServletContainer container = ServletContainer.Factory.newInstance();
+
+        final WebSocketDeploymentInfo websocketDeploymentInfo = new WebSocketDeploymentInfo();
+        configure(websocketDeploymentInfo);
+        DeploymentInfo builder = new DeploymentInfo().setClassLoader(TestMessageLimitBase.class.getClassLoader())
+                .setContextPath("/").setResourceManager(new TestResourceLoader(TestMessageLimitBase.class))
+                .setClassIntrospecter(TestClassIntrospector.INSTANCE)
+                .addServletContextAttribute(WebSocketDeploymentInfo.ATTRIBUTE_NAME,
+                        websocketDeploymentInfo.setBuffers(DefaultServer.getBufferPool())
+                                .setWorker(DefaultServer.getWorkerSupplier()).addEndpoint(getEndpoint()))
+                .setDeploymentName("servletContext.war");
+
+        deploymentManager = container.addDeployment(builder);
+        deploymentManager.deploy();
+
+        DefaultServer.setRootHandler(Handlers.path().addPrefixPath("/", deploymentManager.start()));
+    }
+
+    @After
+    public void cleanup() throws ServletException {
+        WebSocketBaseClass.events.clear();
+        if (deploymentManager != null) {
+            deploymentManager.stop();
+            deploymentManager.undeploy();
+        }
+    }
+
+    @Test
+    public void testLimit() throws Exception {
+
+        List<TestMessageLimitBase.Event> events = WebSocketBaseClass.events;
+        final ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create().build();
+        ContainerProvider.getWebSocketContainer().connectToServer(new LimitsEndpoint(getSender()),
+                clientEndpointConfig, new URI(DefaultServer.getDefaultServerURL() + getEndpointURLPart()));
+
+        Thread.currentThread().sleep(2000);
+        //this is hack to overcome GOING_AWAY randomness. This is triggered on DefaultServer going down.
+        WebSocketBaseClass.finished = true;
+        List<TestMessageLimitBase.Event> expectedEvents = getExpectedEvents();
+        Assert.assertEquals(printEvents(expectedEvents, events), expectedEvents.size(), events.size());
+        final int numberOfEvents = expectedEvents.size();
+        for(int i = 0; i< numberOfEvents; i++) {
+            Assert.assertEquals(expectedEvents.get(i), events.get(i));
+        }
+
+    }
+
+    protected String printEvents(List<Event> expectedEvents, List<Event> receivedEvents) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        final int maxIndex = Math.max(expectedEvents.size(), receivedEvents.size());
+        for(int i = 0; i< maxIndex; i++) {
+            Event expected = fetchEvent(expectedEvents,i);
+            Event received = fetchEvent(receivedEvents, i);
+            stringBuilder.append("\n=============[").append(i).append("]=============\n");
+            stringBuilder.append(printEvent("Expected", expected));
+            stringBuilder.append(printEvent("Received", received));
+        }
+        return stringBuilder.toString();
+    }
+
+    protected String printEvent(final String type, final Event event) {
+        final StringBuilder stringBuilder = new StringBuilder();
+        if (event != null) {
+            stringBuilder.append(type).append(": \n")
+            .append("Index: ").append(event.getIndex()).append("\n")
+            .append("Message: ").append(formatMessage(event)).append("\n")
+            .append("Binary: ").append(event.isBinary()).append("\n");
+
+            if (event.getError() != null) {
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                final PrintStream ps = new PrintStream(baos);
+                event.getError().printStackTrace(ps);
+                ps.flush();
+                stringBuilder.append("Error: ").append(new String(baos.toByteArray())).append("\n\n");
+            } else {
+                stringBuilder.append("Error: ").append(event.getError()).append("\n\n");
+            }
+
+        } else {
+            stringBuilder.append(type).append(": \n")
+            .append("Index: ").append("N/A").append("\n")
+            .append("Message: ").append("N/A").append("\n")
+            .append("Binary: ").append("N/A").append("\n")
+            .append("Error: ").append("N/A").append("\n\n");
+        }
+
+        return stringBuilder.toString();
+    }
+
+    protected Event fetchEvent(final List<Event> list, final int index) {
+        if (index < list.size()) {
+            return list.get(index);
+        } else {
+            return null;
+        }
+    }
+
+    protected static String formatMessage(final Event event) {
+        if (event.getMessage() == null) {
+            return "N/A";
+        } else {
+            final Object msg = event.getMessage();
+            if (msg instanceof String) {
+                final String data = (String) msg;
+                return data.substring(0, 20 < data.length() ? 20 : data.length()) + "(" + data.length() + ")";
+            } else if (msg instanceof byte[]) {
+                byte[] data = (byte[]) msg;
+                return Arrays.toString(data).substring(0, 20 < data.length ? 20 : data.length) + "(" + data.length + ")";
+            } else if (event.getMessage() instanceof CloseReason) {
+                CloseReason cr = (CloseReason) event.getMessage();
+                return cr.getCloseCode() + "-" + cr.getReasonPhrase();
+            } else {
+                final String data = (String) msg.toString();
+                return data.substring(0, 20 < data.length() ? 20 : data.length()) + "(" + data.length() + ")";
+            }
+        }
+    }
+
+    protected abstract List<Event> getExpectedEvents();
+
+    protected abstract void configure(WebSocketDeploymentInfo info);
+
+    protected abstract Sender getSender();
+
+    protected abstract Class<?> getEndpoint();
+
+    protected abstract String getEndpointURLPart();
+
+    public static class Event {
+
+        private int index;
+        private Object message;
+        private boolean binary;
+        private Throwable error;
+
+        public Event(Throwable error, int index) {
+            super();
+            this.index = index;
+            this.error = error;
+        }
+
+        public Event(Object message, int index) {
+            this.message = message;
+            this.index = index;
+        }
+
+        public int getIndex() {
+            return index;
+        }
+
+        public Object getMessage() {
+            return message;
+        }
+
+        public boolean isBinary() {
+            return binary;
+        }
+
+        public Throwable getError() {
+            return error;
+        }
+
+        @Override
+        public String toString() {
+            return "Event [index=" + index + ", message=" + formatMessage(this) + ", binary=" + binary + ", error=" + error + "]";
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(error, index, message, binary);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Event other = (Event) obj;
+            return Objects.equals(error == null ? "N/A" : error.getMessage(), other.error == null ? "N/A" : other.error.getMessage()) && index == other.index && Objects.deepEquals(formatMessage(this), formatMessage(other));
+        }
+
+    }
+
+    @ServerEndpoint("/webSocket")
+    public static class WebSocketBaseClass {
+
+        protected int index = 0;
+        protected static List<TestMessageLimitBase.Event> events = new ArrayList<TestMessageLimitBase.Event>(5);
+        protected static boolean finished = true;
+        @OnMessage
+        public synchronized void onMessage(ByteBuffer dataBuffer, Session session) throws IOException {
+            byte[] hd = new byte[dataBuffer.remaining()];
+            dataBuffer.get(hd);
+            events.add(new Event(hd, index++));
+        }
+
+        @OnMessage
+        public synchronized void onMessage(String dataBuffer, Session session) throws IOException {
+            events.add(new Event(dataBuffer, index++));
+        }
+
+        @OnError
+        public synchronized void onError(Throwable t, Session s) {
+            events.add(new Event(t, index++));
+        }
+
+        @OnClose
+        public synchronized void onClose(final Session session, CloseReason closeReason) {
+            if(finished) {
+                return;
+            }
+            events.add(new Event(closeReason, index++));
+        }
+    }
+
+    protected interface Sender{
+        void sendMessages(Session session, EndpointConfig endpointConfig) throws Exception;
+    }
+
+    protected static class LimitsEndpoint extends Endpoint {
+        private final Sender sender;
+        LimitsEndpoint(final Sender sender) {
+            this.sender = sender;
+        }
+
+        @Override
+        public void onOpen(final Session session, final EndpointConfig endpointConfig) {
+
+            try {
+                this.sender.sendMessages(session, endpointConfig);
+            } catch (Throwable t) {
+                t.printStackTrace();
+                fail();
+            }
+        }
+    }
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestSessionTimeout.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestSessionTimeout.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.undertow.testutils.DefaultServer;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import io.undertow.websockets.jsr.test.limit.TestMessageLimitBase.WebSocketBaseClass;
+import jakarta.servlet.ServletException;
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+
+public class TestSessionTimeout extends TestMessageLimitBase {
+
+    private static final String MESSAGE = "It's not about the money, it's about the message!!!";
+    private static final int SESSION_TIMEOUT = 5000;
+    private static CountDownLatch LATCH = new CountDownLatch(1); // thats iffy....
+
+    @Override
+    public void setup() throws ServletException {
+        LATCH = new CountDownLatch(1);
+        super.setup();
+    }
+
+    @Override
+    @Test
+    public void testLimit() throws Exception {
+
+        List<TestMessageLimitBase.Event> events = WebSocketBaseClass.events;
+        final ClientEndpointConfig clientEndpointConfig = ClientEndpointConfig.Builder.create().build();
+        final Session s = ContainerProvider.getWebSocketContainer().connectToServer(new LimitsEndpoint(getSender()),
+                clientEndpointConfig, new URI(DefaultServer.getDefaultServerURL() + getEndpointURLPart()));
+        LATCH.await(1000, TimeUnit.MILLISECONDS);
+        Thread.currentThread().sleep(SESSION_TIMEOUT + 1000);
+        try {
+            s.getBasicRemote().sendText("In the end it doesnt even matter!!!!");
+            fail();
+        } catch (java.io.IOException e) {
+        }
+        Thread.currentThread().sleep(2000); // just in case
+        WebSocketBaseClass.finished = true;
+        List<TestMessageLimitBase.Event> expectedEvents = getExpectedEvents();
+        Assert.assertEquals(printEvents(expectedEvents, events), expectedEvents.size(), events.size());
+        final int numberOfEvents = expectedEvents.size();
+        for (int i = 0; i < numberOfEvents; i++) {
+            Assert.assertEquals(expectedEvents.get(i), events.get(i));
+        }
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        final Event me = new Event(MESSAGE, 0);
+        final CloseReason reason = new CloseReason(CloseCodes.CLOSED_ABNORMALLY, null);
+        final Event timeout = new Event(reason, 1);
+        ArrayList<Event> lst = new ArrayList<TestMessageLimitBase.Event>(2);
+        lst.add(me);
+        lst.add(timeout);
+        return lst;
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        // NOP
+        info.setDefaultMaxSessionIdleTimeout(SESSION_TIMEOUT / 1000); // 5s
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a, b) -> {
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendText(MESSAGE);
+        };
+    }
+
+    protected Class<?> getEndpoint() {
+        return SessionTimeouTendpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSockeSessionTimeout";
+    }
+
+    @ServerEndpoint("/webSockeSessionTimeout") // This is not inheritable ?
+    protected static class SessionTimeouTendpoint extends TestMessageLimitBase.WebSocketBaseClass {
+
+        @Override
+        public void onMessage(ByteBuffer dataBuffer, Session session) throws IOException {
+            super.onMessage(dataBuffer, session);
+            LATCH.countDown();
+        }
+
+        @Override
+        public void onMessage(String dataBuffer, Session session) throws IOException {
+            super.onMessage(dataBuffer, session);
+            LATCH.countDown();
+        }
+
+        @Override
+        public void onError(Throwable t, Session s) {
+            super.onError(t, s);
+            LATCH.countDown();
+        }
+
+        @Override
+        public void onClose(Session session, CloseReason closeReason) {
+            super.onClose(session, closeReason);
+            LATCH.countDown();
+        }
+
+    }
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextDefaultLimitOverFlow.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextDefaultLimitOverFlow.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import io.undertow.UndertowOptions;
+import io.undertow.websockets.core.WebSocketMessages;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
+
+public class TestTextDefaultLimitOverFlow extends TestMessageLimitBase{
+
+    private static final String MESSAGE;
+    static {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for(int i = 0; i< UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_TEXT+1; i++) {
+            stringBuilder.append(i%2);
+        }
+
+        MESSAGE = stringBuilder.toString();
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        final Event[] events = new Event[2];
+
+        final Event second = new Event(new IOException(WebSocketMessages.MESSAGES.messageToBig(UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_TEXT)), 0);
+        final CloseReason reason = new CloseReason(CloseCodes.TOO_BIG, WebSocketMessages.MESSAGES.messageToBig(UndertowOptions.WEB_SOCKET_DEFAULT_MAX_MESSAGE_SIZE_TEXT));
+        final Event overflow = new Event(reason,1);
+        events[0] = second;
+        events[1] = overflow;
+        return Arrays.asList(events);
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        //NOP
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a,b)->{
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendText(MESSAGE);
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSockeTextDefaultLimitOverFlow";
+    }
+
+    @ServerEndpoint("/webSockeTextDefaultLimitOverFlow")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextNewLimitOverFlow.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextNewLimitOverFlow.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import io.undertow.websockets.core.WebSocketMessages;
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.CloseReason.CloseCodes;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
+
+//There is race condition sometimes spawning Event[0] or skewing index numbers in events if event is not recorded
+public class TestTextNewLimitOverFlow extends TestMessageLimitBase {
+
+    private static final String MESSAGE;
+    static {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for(int i = 0; i< 1024 + 1; i++) {
+            stringBuilder.append(i%2);
+        }
+
+        MESSAGE = stringBuilder.toString();
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        final Event[] events = new Event[2];
+
+        final Event first = new Event(new IOException(WebSocketMessages.MESSAGES.messageToBig(1024)), 0);
+        final CloseReason reason = new CloseReason(CloseCodes.TOO_BIG, WebSocketMessages.MESSAGES.messageToBig(1024));
+        final Event overflow = new Event(reason,1);
+        events[0] = first;
+        events[1] = overflow;
+
+        return Arrays.asList(events);
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        // NOP
+        info.setDefaultMaxTextMessageBufferSize(1024); // 1KB
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a,b)->{
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendText(MESSAGE);
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSockeTextNewLimitOverFlow";
+    }
+
+    @ServerEndpoint("/webSockeTextNewLimitOverFlow")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}

--- a/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextNewLimitRespected.java
+++ b/websockets-jsr/src/test/java/io/undertow/websockets/jsr/test/limit/TestTextNewLimitRespected.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2026 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.undertow.websockets.jsr.test.limit;
+
+import java.util.Collections;
+import java.util.List;
+
+import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.server.ServerEndpoint;
+
+public class TestTextNewLimitRespected extends TestMessageLimitBase {
+
+    private static final String MESSAGE;
+    static {
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for(int i = 0; i< 1024; i++) {
+            stringBuilder.append(i%2);
+        }
+
+        MESSAGE = stringBuilder.toString();
+    }
+
+    private static void primeMessage(byte[] data) {
+        for(int i = 0; i< 1024;i++) {
+            data[i]=(byte)i;
+        }
+    }
+
+    @Override
+    protected List<Event> getExpectedEvents() {
+        //some class loading shenanigans cause it to randomize ?
+        final Event me = new Event(MESSAGE, 0);
+        return Collections.singletonList(me);
+    }
+
+    @Override
+    protected void configure(WebSocketDeploymentInfo info) {
+        // NOP
+        info.setDefaultMaxTextMessageBufferSize(1024); // 1KB
+    }
+
+    @Override
+    protected Sender getSender() {
+        return (a,b)->{
+            RemoteEndpoint.Basic rem = a.getBasicRemote();
+            rem.sendText(MESSAGE);
+        };
+    }
+
+    @Override
+    protected Class<?> getEndpoint() {
+        return MyEndpoint.class;
+    }
+
+    @Override
+    protected String getEndpointURLPart() {
+        return "/webSockeTextNewLimitRespected";
+    }
+
+    @ServerEndpoint("/webSockeTextNewLimitRespected")
+    protected static class MyEndpoint extends TestMessageLimitBase.WebSocketBaseClass{};
+}


### PR DESCRIPTION
Im no longer able to add comment in line. NOTE: WebSocketContainer API has session timeout defined in milis, but ATM its defined in seconds: https://github.com/undertow-io/undertow/compare/main...baranowb:undertow:UNDERTOW-2780_master?expand=1#diff-7fee4cdb9ce708cc07169729c60f2dd22524acaa35e13df05c8071126a99f9b0R66

From user POV seconds are good enough resolution, but might be confusing ?


Issue: https://redhat.atlassian.net/browse/UNDERTOW-2780