### PR TITLE
[UNDERTOW-2588] avoid buffer clear that breaks NewSessionTicket writes

### DIFF
--- a/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
+++ b/core/src/main/java/io/undertow/server/protocol/http/HttpResponseConduit.java
@@ -158,6 +158,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
                         res = next.write(data, 0, length + 1);
                     }
                     if (res == 0) {
+                        // UNDERTOW-2588 - skip bufferDone() for a STATE_BUF_FLUSH return
                         buffDone = false;
                         return STATE_BUF_FLUSH;
                     }
@@ -293,6 +294,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
                     res = next.write(data, 0, index + length);
                 }
                 if (res == 0) {
+                    // UNDERTOW-2588 - skip bufferDone() for a STATE_BUF_FLUSH return
                     buffDone = false;
                     return STATE_BUF_FLUSH;
                 }
@@ -300,6 +302,7 @@ final class HttpResponseConduit extends AbstractStreamSinkConduit<StreamSinkCond
             return STATE_BODY;
         } finally {
             if (buffer != null && buffDone) {
+                // UNDERTOW-2588 - skip this for a STATE_BUF_FLUSH return
                 bufferDone();
                 this.state &= ~POOLED_BUFFER_IN_USE;
             }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/UNDERTOW-2588

main: https://github.com/undertow-io/undertow/pull/1771
2.4.x: https://github.com/undertow-io/undertow/pull/1990
2.3.x: https://github.com/undertow-io/undertow/pull/1991